### PR TITLE
Sql linter applied

### DIFF
--- a/postgres-db/schema/create_01.sql
+++ b/postgres-db/schema/create_01.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS users (
     mail text NOT NULL,
     sex char(1),
     role char(1),
-    PRIMARY KEY(id)
+    PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS sessions (
@@ -19,14 +19,14 @@ CREATE TABLE IF NOT EXISTS sessions (
     code char(6),
     type char(1),
     PRIMARY KEY (id),
-    FOREIGN KEY(creator) REFERENCES users(id)
+    FOREIGN KEY (creator) REFERENCES users (id)
 );
 
 CREATE TABLE IF NOT EXISTS sesusers (
     sesid integer,
     uid integer,
-    FOREIGN KEY(sesid) REFERENCES sessions(id),
-    FOREIGN KEY(uid) REFERENCES users(id)
+    FOREIGN KEY (sesid) REFERENCES sessions (id),
+    FOREIGN KEY (uid) REFERENCES users (id)
 );
 
 CREATE TABLE IF NOT EXISTS documents (
@@ -35,9 +35,9 @@ CREATE TABLE IF NOT EXISTS documents (
     path text NOT NULL,
     sesid integer,
     uploader integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(sesid) REFERENCES sessions(id),
-    FOREIGN KEY(uploader) REFERENCES users(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (sesid) REFERENCES sessions (id),
+    FOREIGN KEY (uploader) REFERENCES users (id)
 );
 
 CREATE TABLE IF NOT EXISTS ideas (
@@ -48,9 +48,9 @@ CREATE TABLE IF NOT EXISTS ideas (
     iteration integer DEFAULT 1,
     uid integer,
     docid integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(uid) REFERENCES users(id),
-    FOREIGN KEY(docid) REFERENCES documents(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (uid) REFERENCES users (id),
+    FOREIGN KEY (docid) REFERENCES documents (id)
 );
 
 CREATE TABLE IF NOT EXISTS questions (
@@ -61,8 +61,8 @@ CREATE TABLE IF NOT EXISTS questions (
     comment text,
     other text,
     sesid integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(sesid) REFERENCES sessions(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (sesid) REFERENCES sessions (id)
 );
 
 CREATE TABLE IF NOT EXISTS selection (
@@ -71,21 +71,21 @@ CREATE TABLE IF NOT EXISTS selection (
     iteration integer DEFAULT 1,
     comment text,
     qid integer,
-    PRIMARY KEY(uid, qid),
-    FOREIGN KEY(uid) REFERENCES users(id),
-    FOREIGN KEY(qid) REFERENCES questions(id)
+    PRIMARY KEY (uid, qid),
+    FOREIGN KEY (uid) REFERENCES users (id),
+    FOREIGN KEY (qid) REFERENCES questions (id)
 );
 
 CREATE TABLE IF NOT EXISTS teams (
     id serial,
     sesid integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(sesid) REFERENCES sessions(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (sesid) REFERENCES sessions (id)
 );
 
 CREATE TABLE IF NOT EXISTS teamusers (
     tmid integer,
     uid integer,
-    FOREIGN KEY(tmid) REFERENCES teams(id),
-    FOREIGN KEY(uid) REFERENCES users(id)
+    FOREIGN KEY (tmid) REFERENCES teams (id),
+    FOREIGN KEY (uid) REFERENCES users (id)
 );

--- a/postgres-db/schema/create_02.sql
+++ b/postgres-db/schema/create_02.sql
@@ -1,8 +1,8 @@
 CREATE TABLE IF NOT EXISTS rubricas (
     id serial,
     sesid integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(sesid) REFERENCES sessions(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (sesid) REFERENCES sessions (id)
 );
 
 CREATE TABLE IF NOT EXISTS reports (
@@ -11,9 +11,9 @@ CREATE TABLE IF NOT EXISTS reports (
     example boolean DEFAULT false,
     rid integer,
     uid integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(rid) REFERENCES rubricas(id),
-    FOREIGN KEY(uid) REFERENCES users(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (rid) REFERENCES rubricas (id),
+    FOREIGN KEY (uid) REFERENCES users (id)
 );
 
 CREATE TABLE IF NOT EXISTS criteria (
@@ -25,8 +25,8 @@ CREATE TABLE IF NOT EXISTS criteria (
     competente text,
     avanzado text,
     rid integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(rid) REFERENCES rubricas(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (rid) REFERENCES rubricas (id)
 );
 
 CREATE TABLE IF NOT EXISTS criteria_selection (
@@ -35,10 +35,10 @@ CREATE TABLE IF NOT EXISTS criteria_selection (
     cid integer,
     uid integer,
     repid integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(cid) REFERENCES criteria(id),
-    FOREIGN KEY(uid) REFERENCES users(id),
-    FOREIGN KEY(repid) REFERENCES reports(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (cid) REFERENCES criteria (id),
+    FOREIGN KEY (uid) REFERENCES users (id),
+    FOREIGN KEY (repid) REFERENCES reports (id)
 );
 
 CREATE TABLE report_pair (
@@ -46,14 +46,14 @@ CREATE TABLE report_pair (
     uid integer,
     sesid integer,
     repid integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(uid) REFERENCES users(id),
-    FOREIGN KEY(sesid) REFERENCES sessions(id),
-    FOREIGN KEY(repid) REFERENCES reports(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (uid) REFERENCES users (id),
+    FOREIGN KEY (sesid) REFERENCES sessions (id),
+    FOREIGN KEY (repid) REFERENCES reports (id)
 );
 
-CREATE TYPE tipo_aprendizaje AS ENUM('Reflexivo', 'Activo', 'Teorico', 'Pragmatico');
+CREATE TYPE tipo_aprendizaje AS ENUM ('Reflexivo', 'Activo', 'Teorico', 'Pragmatico');
 ALTER TABLE users ADD COLUMN aprendizaje tipo_aprendizaje;
 
 ALTER TABLE teams ADD COLUMN leader integer;
-ALTER TABLE teams ADD CONSTRAINT fk_leader FOREIGN KEY(leader) REFERENCES users(id);
+ALTER TABLE teams ADD CONSTRAINT fk_leader FOREIGN KEY (leader) REFERENCES users (id);

--- a/postgres-db/schema/create_03.sql
+++ b/postgres-db/schema/create_03.sql
@@ -1,12 +1,12 @@
-CREATE TABLE status_record(
-    sesid integer REFERENCES sessions(id),
+CREATE TABLE status_record (
+    sesid integer REFERENCES sessions (id),
     status integer,
     stime timestamp
 );
 
-CREATE TABLE finish_session(
-    uid integer REFERENCES users(id),
-    sesid integer REFERENCES sessions(id),
+CREATE TABLE finish_session (
+    uid integer REFERENCES users (id),
+    sesid integer REFERENCES sessions (id),
     status integer,
     stime timestamp
 );

--- a/postgres-db/schema/create_04.sql
+++ b/postgres-db/schema/create_04.sql
@@ -1,6 +1,6 @@
-CREATE TABLE report_comment(
-    uid integer REFERENCES users(id),
-    repid integer REFERENCES reports(id),
+CREATE TABLE report_comment (
+    uid integer REFERENCES users (id),
+    repid integer REFERENCES reports (id),
     comment text
 );
 

--- a/postgres-db/schema/create_05.sql
+++ b/postgres-db/schema/create_05.sql
@@ -1,1 +1,1 @@
-ALTER TABLE teams ADD COLUMN original_leader integer REFERENCES users(id);
+ALTER TABLE teams ADD COLUMN original_leader integer REFERENCES users (id);

--- a/postgres-db/schema/create_07.sql
+++ b/postgres-db/schema/create_07.sql
@@ -1,4 +1,4 @@
-CREATE TABLE report_ideas(
-    rid integer REFERENCES reports(id),
-    idea_id integer REFERENCES ideas(id)
+CREATE TABLE report_ideas (
+    rid integer REFERENCES reports (id),
+    idea_id integer REFERENCES ideas (id)
 );

--- a/postgres-db/schema/create_08.sql
+++ b/postgres-db/schema/create_08.sql
@@ -1,6 +1,6 @@
-CREATE TABLE question_text(
+CREATE TABLE question_text (
     id serial,
-    sesid integer REFERENCES sessions(id),
+    sesid integer REFERENCES sessions (id),
     title text,
     content text
 );

--- a/postgres-db/schema/create_10.sql
+++ b/postgres-db/schema/create_10.sql
@@ -1,14 +1,14 @@
-CREATE TABLE semantic_document(
+CREATE TABLE semantic_document (
     id serial PRIMARY KEY,
     title text,
     content text,
-    sesid integer REFERENCES sessions(id)
+    sesid integer REFERENCES sessions (id)
 );
 
-CREATE TABLE semantic_unit(
+CREATE TABLE semantic_unit (
     id serial PRIMARY KEY,
-    sentences integer[],
+    sentences integer [],
     comment text,
-    uid integer REFERENCES users(id),
-    docid integer REFERENCES semantic_document(id)
+    uid integer REFERENCES users (id),
+    docid integer REFERENCES semantic_document (id)
 );

--- a/postgres-db/schema/create_14.sql
+++ b/postgres-db/schema/create_14.sql
@@ -1,5 +1,5 @@
-ALTER TABLE semantic_unit ADD COLUMN docs integer[];
+ALTER TABLE semantic_unit ADD COLUMN docs integer [];
 ALTER TABLE semantic_unit DROP COLUMN docid;
-ALTER TABLE semantic_unit ADD COLUMN sesid integer REFERENCES sessions(id);
+ALTER TABLE semantic_unit ADD COLUMN sesid integer REFERENCES sessions (id);
 
 ALTER TABLE semantic_document ADD COLUMN orden integer;

--- a/postgres-db/schema/create_15.sql
+++ b/postgres-db/schema/create_15.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS overlays (
     geom text NOT NULL,
     "name" varchar(255) NOT NULL,
     description text,
-    PRIMARY KEY(id),
-    FOREIGN KEY(uid) REFERENCES users(id),
-    FOREIGN KEY(qid) REFERENCES questions(id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (uid) REFERENCES users (id),
+    FOREIGN KEY (qid) REFERENCES questions (id)
 );

--- a/postgres-db/schema/create_18.sql
+++ b/postgres-db/schema/create_18.sql
@@ -1,1 +1,1 @@
-ALTER TABLE questions ADD COLUMN cpid integer REFERENCES questions(id);
+ALTER TABLE questions ADD COLUMN cpid integer REFERENCES questions (id);

--- a/postgres-db/schema/create_20.sql
+++ b/postgres-db/schema/create_20.sql
@@ -1,1 +1,1 @@
-ALTER TABLE sesusers ADD CONSTRAINT no_dup_users UNIQUE(uid, sesid);
+ALTER TABLE sesusers ADD CONSTRAINT no_dup_users UNIQUE (uid, sesid);

--- a/postgres-db/schema/create_21.sql
+++ b/postgres-db/schema/create_21.sql
@@ -1,28 +1,28 @@
-CREATE TABLE IF NOT EXISTS differential(
+CREATE TABLE IF NOT EXISTS differential (
     id serial,
     title text DEFAULT '',
     tleft text NOT NULL,
     tright text NOT NULL,
     orden integer NOT NULL,
-    creator integer REFERENCES users(id),
-    sesid integer REFERENCES sessions(id),
-    PRIMARY KEY(id)
+    creator integer REFERENCES users (id),
+    sesid integer REFERENCES sessions (id),
+    PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS differential_selection(
+CREATE TABLE IF NOT EXISTS differential_selection (
     id serial,
-    uid integer REFERENCES users(id),
-    did integer REFERENCES differential(id),
+    uid integer REFERENCES users (id),
+    did integer REFERENCES differential (id),
     sel integer NOT NULL,
     iteration integer,
     comment text,
     stime timestamp DEFAULT now()
 );
 
-CREATE TABLE IF NOT EXISTS differential_chat(
+CREATE TABLE IF NOT EXISTS differential_chat (
     id serial,
-    uid integer REFERENCES users(id),
-    did integer REFERENCES differential(id),
+    uid integer REFERENCES users (id),
+    did integer REFERENCES differential (id),
     content text,
     stime timestamp DEFAULT now()
 );

--- a/postgres-db/schema/create_22.sql
+++ b/postgres-db/schema/create_22.sql
@@ -1,2 +1,2 @@
-ALTER TABLE differential_chat ADD PRIMARY KEY(id);
-ALTER TABLE differential_chat ADD COLUMN parent_id integer REFERENCES differential_chat(id);
+ALTER TABLE differential_chat ADD PRIMARY KEY (id);
+ALTER TABLE differential_chat ADD COLUMN parent_id integer REFERENCES differential_chat (id);

--- a/postgres-db/schema/create_23.sql
+++ b/postgres-db/schema/create_23.sql
@@ -1,7 +1,7 @@
-CREATE TABLE pass_reset(
+CREATE TABLE pass_reset (
     id serial,
     mail varchar(32) NOT NULL,
     token varchar(64) NOT NULL,
     ctime timestamp,
-    PRIMARY KEY(id)
+    PRIMARY KEY (id)
 );

--- a/postgres-db/schema/create_25.sql
+++ b/postgres-db/schema/create_25.sql
@@ -1,28 +1,28 @@
-CREATE TABLE IF NOT EXISTS stages(
+CREATE TABLE IF NOT EXISTS stages (
     id serial,
     number integer NOT NULL,
     type varchar(15) NOT NULL,
     anon boolean DEFAULT false,
     chat boolean DEFAULT false,
     prev_ans varchar(255),
-    sesid integer REFERENCES sessions(id),
-    PRIMARY KEY(id)
+    sesid integer REFERENCES sessions (id),
+    PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS actors(
+CREATE TABLE IF NOT EXISTS actors (
     id serial,
     name varchar(255) NOT NULL,
     jorder boolean NOT NULL,
-    stageid integer REFERENCES stages(id),
-    PRIMARY KEY(id)
+    stageid integer REFERENCES stages (id),
+    PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS actor_selection(
+CREATE TABLE IF NOT EXISTS actor_selection (
     id serial,
     description text NOT NULL,
     orden integer,
-    actorid integer REFERENCES actors(id),
-    uid integer REFERENCES users(id),
-    stageid integer REFERENCES stages(id),
-    PRIMARY KEY(id)
+    actorid integer REFERENCES actors (id),
+    uid integer REFERENCES users (id),
+    stageid integer REFERENCES stages (id),
+    PRIMARY KEY (id)
 );

--- a/postgres-db/schema/create_26.sql
+++ b/postgres-db/schema/create_26.sql
@@ -1,1 +1,1 @@
-ALTER TABLE sessions ADD COLUMN current_stage integer REFERENCES stages(id);
+ALTER TABLE sessions ADD COLUMN current_stage integer REFERENCES stages (id);

--- a/postgres-db/schema/create_27.sql
+++ b/postgres-db/schema/create_27.sql
@@ -1,4 +1,4 @@
-ALTER TABLE teams ADD COLUMN stageid integer REFERENCES stages(id);
+ALTER TABLE teams ADD COLUMN stageid integer REFERENCES stages (id);
 ALTER TABLE actor_selection ADD COLUMN stime timestamp DEFAULT now();
 ALTER TABLE actors ADD COLUMN justified boolean DEFAULT true;
 ALTER TABLE stages ADD COLUMN question text;

--- a/postgres-db/schema/create_28.sql
+++ b/postgres-db/schema/create_28.sql
@@ -1,10 +1,10 @@
-CREATE TABLE IF NOT EXISTS chat(
+CREATE TABLE IF NOT EXISTS chat (
     id serial,
-    sesid integer REFERENCES sessions(id),
-    stageid integer REFERENCES stages(id),
-    uid integer REFERENCES users(id),
+    sesid integer REFERENCES sessions (id),
+    stageid integer REFERENCES stages (id),
+    uid integer REFERENCES users (id),
     content text,
     stime timestamp DEFAULT now(),
-    parent_id integer REFERENCES chat(id),
-    PRIMARY KEY(id)
+    parent_id integer REFERENCES chat (id),
+    PRIMARY KEY (id)
 );

--- a/postgres-db/schema/create_29.sql
+++ b/postgres-db/schema/create_29.sql
@@ -1,4 +1,4 @@
-ALTER TABLE differential ADD COLUMN stageid integer REFERENCES stages(id);
+ALTER TABLE differential ADD COLUMN stageid integer REFERENCES stages (id);
 ALTER TABLE differential ADD COLUMN justify boolean DEFAULT true;
 ALTER TABLE differential ADD COLUMN num integer DEFAULT 7;
 ALTER TABLE stages ADD COLUMN options text;

--- a/postgres-db/schema/create_32.sql
+++ b/postgres-db/schema/create_32.sql
@@ -1,13 +1,13 @@
-CREATE TABLE IF NOT EXISTS jigsaw_role(
+CREATE TABLE IF NOT EXISTS jigsaw_role (
     id serial,
     name varchar(255) NOT NULL,
     description text,
-    sesid integer REFERENCES sessions(id),
-    PRIMARY KEY(id)
+    sesid integer REFERENCES sessions (id),
+    PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS jigsaw_users(
-    stageid integer REFERENCES stages(id),
-    userid integer REFERENCES users(id),
-    roleid integer REFERENCES jigsaw_role(id)
+CREATE TABLE IF NOT EXISTS jigsaw_users (
+    stageid integer REFERENCES stages (id),
+    userid integer REFERENCES users (id),
+    roleid integer REFERENCES jigsaw_role (id)
 );

--- a/postgres-db/schema/create_33.sql
+++ b/postgres-db/schema/create_33.sql
@@ -1,7 +1,7 @@
 ALTER TABLE sesusers ADD COLUMN device varchar(255);
 
-CREATE TABLE IF NOT EXISTS drafts(
+CREATE TABLE IF NOT EXISTS drafts (
     id serial,
-    sesid integer REFERENCES sessions(id),
+    sesid integer REFERENCES sessions (id),
     data text
 );

--- a/postgres-db/schema/create_35.sql
+++ b/postgres-db/schema/create_35.sql
@@ -1,21 +1,21 @@
-CREATE TABLE IF NOT EXISTS institution(
+CREATE TABLE IF NOT EXISTS institution (
     id serial,
-    userid integer REFERENCES users(id),
+    userid integer REFERENCES users (id),
     institution_name text,
     num_students int,
     country text,
     position text,
-    PRIMARY KEY(id)
+    PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS mail_domain(
+CREATE TABLE IF NOT EXISTS mail_domain (
     id serial,
-    institutionid integer REFERENCES institution(id),
+    institutionid integer REFERENCES institution (id),
     domain_name text UNIQUE,
-    PRIMARY KEY(id)
+    PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS temporary_users(
+CREATE TABLE IF NOT EXISTS temporary_users (
     id serial,
     name text NOT NULL,
     rut text NULL,
@@ -23,19 +23,19 @@ CREATE TABLE IF NOT EXISTS temporary_users(
     mail text NOT NULL,
     sex char(1),
     role char(1),
-    PRIMARY KEY(id)
+    PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS temporary_institution(
+CREATE TABLE IF NOT EXISTS temporary_institution (
     id serial,
-    userid integer REFERENCES temporary_users(id),
+    userid integer REFERENCES temporary_users (id),
     institution_name text,
     num_students int,
     country text,
     mail_domains text,
     position text,
     acepted boolean NOT NULL,
-    PRIMARY KEY(id)
+    PRIMARY KEY (id)
 );
 
 ALTER TABLE temporary_users ADD COLUMN token text NULL;

--- a/postgres-db/schema/create_36.sql
+++ b/postgres-db/schema/create_36.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS designs (
     id serial,
     creator integer,
     design jsonb,
-    FOREIGN KEY(creator) REFERENCES users(id),
+    FOREIGN KEY (creator) REFERENCES users (id),
     public boolean DEFAULT false,
     locked boolean DEFAULT false
 );
@@ -16,9 +16,9 @@ CREATE TABLE IF NOT EXISTS designs_documents (
     path text NOT NULL,
     dsgnid integer,
     uploader integer,
-    PRIMARY KEY(id),
-    FOREIGN KEY(dsgnid) REFERENCES designs(id),
-    FOREIGN KEY(uploader) REFERENCES users(id),
+    PRIMARY KEY (id),
+    FOREIGN KEY (dsgnid) REFERENCES designs (id),
+    FOREIGN KEY (uploader) REFERENCES users (id),
     active boolean DEFAULT true
 );
 
@@ -33,6 +33,6 @@ CREATE TABLE IF NOT EXISTS activity (
     id serial,
     design integer,
     session integer,
-    FOREIGN KEY(design) REFERENCES designs(id),
-    FOREIGN KEY(session) REFERENCES sessions(id)
+    FOREIGN KEY (design) REFERENCES designs (id),
+    FOREIGN KEY (session) REFERENCES sessions (id)
 );

--- a/postgres-db/seeds/01_users.sql
+++ b/postgres-db/seeds/01_users.sql
@@ -1,4 +1,4 @@
-INSERT INTO users(name, rut, pass, mail, sex, role, aprendizaje)
+INSERT INTO users (name, rut, pass, mail, sex, role, aprendizaje)
 VALUES
 ('Admin', 'N/A', md5('admin'), 'admin@admin', NULL, 'S', NULL),
 ('profesor', '16308816-9', md5('profesor'), 'profesor@test', 'M', 'P', 'Reflexivo'),

--- a/postgres-db/seeds/02_institution.sql
+++ b/postgres-db/seeds/02_institution.sql
@@ -1,7 +1,7 @@
-INSERT INTO institution(userid, institution_name, num_students, country, "position")
+INSERT INTO institution (userid, institution_name, num_students, country, "position")
 VALUES
 (1, 'QWERTY-institution', 999, 'qwerty', 'qwerty');
 
-INSERT INTO mail_domain(institutionid, domain_name)
+INSERT INTO mail_domain (institutionid, domain_name)
 VALUES
 (1, 'qwertymail.com');

--- a/postgres-db/seeds/03_activity_design.sql
+++ b/postgres-db/seeds/03_activity_design.sql
@@ -1,4 +1,4 @@
-INSERT INTO designs(creator, public, locked, design)
+INSERT INTO designs (creator, public, locked, design)
 VALUES
 (2, false, false, '{
   "type": "semantic_differential",


### PR DESCRIPTION
Code refactored using the linter mentioned above according to the project specifications. Only ".sql" files were affected by this change.

Types of issues found:
- Missing whitespace between identifier/KEY 'keyword' and start bracket/square bracket.

Console output after the linter was applied:

![Screenshot (4)](https://user-images.githubusercontent.com/62113405/232343416-944e7d2f-ef4f-43e0-a2a3-f6807981ddc5.png)
