### PR TITLE
[ethicapp-v2] Issue #161: Arreglar error de creación de WebSockets

### DIFF
--- a/web-nginx/nginx.conf
+++ b/web-nginx/nginx.conf
@@ -42,6 +42,9 @@ http {
         }
 
         location @node {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_pass       http://ethicapp;


### PR DESCRIPTION
Arreglo simple hecho al [nginx.conf](https://github.com/EthicApp-Development/ethicapp-main/blob/issue-161-bug/web-nginx/nginx.conf) para habilitar el paso de websockets a través de el.