### PR TITLE
[ethicapp-v2/api-v2] Se crea una rama para trabajo en API v2 en el backend (issue #292)

### DIFF
--- a/dev-ops/docker-init-db-volume-sequelize.sh
+++ b/dev-ops/docker-init-db-volume-sequelize.sh
@@ -1,0 +1,81 @@
+#!/bin/bash -e
+# --------------------------------------------------------------------------------------------------
+# Initializes the shared volume for the Postgres database in the host filesystem. The directory in
+# which the virtualized Postgres database will be mounted at is $HOST_DB_VOLUME_PATH, but can be
+# overridden if given as an argument (if so, make sure to include the `./` prefix if relative).
+# --------------------------------------------------------------------------------------------------
+
+source .env
+
+TargetVolumePath=${1:-$HOST_DB_VOLUME_PATH}
+
+set -u
+
+if test -d ${TargetVolumePath}; then
+    echo "[ERROR] Directory \"${TargetVolumePath}\" already exists. Have you already initialized \
+the DB shared volume?" >&2
+    exit 1
+fi;
+
+#* ---
+#* Step (1): start Postgres without shared volume mount (i.e. with proper schema and dev data).
+#* ---
+export HOST_DB_VOLUME_PATH=
+
+TempComposeFilePath=./.docker-compose.NO-DB-VOLUME.temp
+ComposeRewriteFlags="--file ${TempComposeFilePath}"
+
+# Manually rewriting compose file, as usual docker-compose overrides can't undo an existing
+# property, see https://github.com/docker/compose/issues/3729
+echo "# ----
+# GENERATED FILE FROM $0
+# ----" > ${TempComposeFilePath}
+sed 's^- "${HOST_DB_VOLUME_PATH}:/var/lib/postgresql/${POSTGRES_VERSION}/main:rw"^[]^g' \
+    ./docker-compose.yml >> ${TempComposeFilePath}
+
+docker-compose ${ComposeRewriteFlags} config 1> /dev/null
+
+# Here, we also start PgAdmin service, as a trick for ensuring the `up` command does not return
+# until the Postgres service isn't healthy (as it depends on healthiness of Postgres)
+docker-compose ${ComposeRewriteFlags} down --remove-orphans
+docker-compose ${ComposeRewriteFlags} build postgres
+docker-compose ${ComposeRewriteFlags} up --detach postgres pgadmin
+
+# Checking target Postgres role and database exist
+docker exec ethicapp-postgres /bin/bash -c \
+    "psql postgresql://$DB_USER_NAME:$DB_USER_PASSWORD@localhost:5432/$DB_NAME -c '\conninfo'"
+
+#* ---
+#* Step (2): export database files directly into host.
+#* ---
+mkdir -p ${TargetVolumePath}
+docker cp ethicapp-postgres:/var/lib/postgresql/${POSTGRES_VERSION}/main/ ${TargetVolumePath}
+mv ${TargetVolumePath}/main/* ${TargetVolumePath}
+rm -R -v ${TargetVolumePath}/main/
+
+#* ---
+#* Step (3): restart Postgres with mounted volume into previously exported database.
+#* ---
+export HOST_DB_VOLUME_PATH=${TargetVolumePath}
+
+docker-compose down --remove-orphans
+
+# Setting mounted volume path defined in this bash script
+docker-compose build postgres
+docker-compose up --detach postgres
+
+# Initialise Sequelize
+echo "Inicializando Sequelize..."
+npx sequelize-cli init
+
+# Execute migrations
+echo "Ejecutando migraciones de Sequelize..."
+npx sequelize-cli db:migrate
+
+# Insert initial data
+echo "Insertando datos iniciales..."
+# Puedes escribir un script de inserción de datos en SQL o usar herramientas de Sequelize para insertar datos programáticamente.
+
+
+rm ${TempComposeFilePath}
+echo "[OK] Postgres service up and running with development data volume at ${HOST_DB_VOLUME_PATH}"

--- a/ethicapp/package.json
+++ b/ethicapp/package.json
@@ -31,7 +31,7 @@
     "passport": "^0.6.0",
     "passport-google-oauth2": "^0.2.0",
     "passport-local": "^1.0.0",
-    "pg": "^6.4.2",
+    "pg": "^8.11.3",
     "serve-favicon": "^2.5.0",
     "session-file-store": "^1.5.0",
     "simple-stats-server": "0.0.5",

--- a/ethicapp/package.json
+++ b/ethicapp/package.json
@@ -37,8 +37,7 @@
     "serve-favicon": "^2.5.0",
     "session-file-store": "^1.5.0",
     "simple-stats-server": "0.0.5",
-    "socket.io": "4.5.2",
-    "sqlite3": "^5.1.7"
+    "socket.io": "4.5.2"
   },
   "devDependencies": {
     "babel-minify": "0.5.0",

--- a/ethicapp/package.json
+++ b/ethicapp/package.json
@@ -33,6 +33,7 @@
     "passport-local": "^1.0.0",
     "pg": "^8.11.3",
     "sequelize": "^6.37.1",
+    "sequelize-cli": "^6.6.2",
     "serve-favicon": "^2.5.0",
     "session-file-store": "^1.5.0",
     "simple-stats-server": "0.0.5",

--- a/ethicapp/package.json
+++ b/ethicapp/package.json
@@ -32,10 +32,12 @@
     "passport-google-oauth2": "^0.2.0",
     "passport-local": "^1.0.0",
     "pg": "^8.11.3",
+    "sequelize": "^6.37.1",
     "serve-favicon": "^2.5.0",
     "session-file-store": "^1.5.0",
     "simple-stats-server": "0.0.5",
-    "socket.io": "4.5.2"
+    "socket.io": "4.5.2",
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "babel-minify": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "init-passwords-js": "./dev-ops/create-passwords-js.sh",
     "init-db": "./dev-ops/docker-init-db-volume.sh",
+    "init-db-sequelize": "",
     "build-and-push": "./dev-ops/build-and-push.sh",
     "lint-js": "npx eslint './ethicapp/**/*.js' ./ethicapp/backend/ethicapp",
     "lint-html": "npx htmlhint './ethicapp/frontend/static/**/*.html'",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "scripts": {
     "init-passwords-js": "./dev-ops/create-passwords-js.sh",
-    "init-db": "./dev-ops/docker-init-db-volume.sh",
-    "init-db-sequelize": "",
+    "init-db": "./dev-ops/docker-init-db-volume-sequelize.sh",
     "build-and-push": "./dev-ops/build-and-push.sh",
     "lint-js": "npx eslint './ethicapp/**/*.js' ./ethicapp/backend/ethicapp",
     "lint-html": "npx htmlhint './ethicapp/frontend/static/**/*.html'",


### PR DESCRIPTION
Conforme a issue #294:
- Se crea rama ethicapp-v2/api-v2 para dar inicio a un trabajo de reimplementación de la API en backend utilizando un stack renovado con sequelize y una versión actual del módulo pg.
- No se requiere mezclar esta rama con ethicapp-v2.