### PR TITLE
[ethicapp-v2] Solución a #299 ruta y permisos de volumen de PostgreSQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     #* Do not modify this volume declaration, as the automated initialization of the volume mount
     #* will break if not updated as well
     volumes:
-      - "${HOST_DB_VOLUME_PATH}:/var/lib/postgresql/${POSTGRES_VERSION}/main:rw"
+      - "${HOST_DB_VOLUME_PATH}:/var/lib/postgresql/data:rw"
 
   # ---------------------- PGAdmin ---------------------- #
   pgadmin:


### PR DESCRIPTION
Se propone solución al problema que consiste en cambiar la ruta de /var/lib/postgres/10/main a /var/lib/postgres/data, con permisos de lectura y escritura.
