### PR TITLE
Dos respuestas para un mismo request causa caída "/send-diff-selection" #362

### DIFF
--- a/ethicapp/backend/controllers/visor.js
+++ b/ethicapp/backend/controllers/visor.js
@@ -5,7 +5,7 @@ let router = express.Router();
 let rpg = require("../db/rest-pg");
 let pass = require("../config/keys-n-secrets");
 let socket = require("../config/socket.config");
-const {initializeContentAnalysis} = require("../services/content-analysis");
+const {initializeContentAnalysis, isContentAnalysisAvailable} = require("../services/content-analysis");
 
 let sesStatusCache = {};
 
@@ -339,7 +339,9 @@ router.post("/get-answers", rpg.multiSQL({
 
 router.post("/send-diff-selection", (req, res, next) => {
     
-    initializeContentAnalysis(req, res);
+    if (isContentAnalysisAvailable()){
+        initializeContentAnalysis(req, res);
+    }    
 
     return rpg.execSQL({
         dbcon: pass.dbcon,

--- a/ethicapp/backend/services/content-analysis.js
+++ b/ethicapp/backend/services/content-analysis.js
@@ -201,7 +201,7 @@ async function contentAnalysis(req, res) {
             console.error("Error processing content analysis:", error);
         }
     } else {
-        res.status(400).send('No comment provided');
+        console.warn('No comment provided for content analysis');
     }
 }
 
@@ -218,14 +218,9 @@ function isContentAnalysisAvailable(){
 
 function initializeContentAnalysis(req, res) {
     try {
-        if (isContentAnalysisAvailable()) {
-            contentAnalysis(req, res);
-        } else {
-            res.status(503).send('Content analysis not available');
-        }
+        contentAnalysis(req, res);
     } catch (error) {
         console.error('Error running content analysis:', error);
-        res.status(500).send('Internal Server Error');
     }
 }
 


### PR DESCRIPTION
Se eliminaron el uso de respuestas en el servicio content-analysis.js, estas fueron remplazadas por warnings.