### PR TITLE
[api/v2] Implementación de endpoint para recuperación de estado de ac…

### DIFF
--- a/ethicapp/backend/api/v2/activities.js
+++ b/ethicapp/backend/api/v2/activities.js
@@ -19,6 +19,38 @@ router.get('/activity', async (req, res) => {
     }
 });
 
+// GET /activities/:activity_id
+router.get('/activities/:activity_id', async (req, res) => {
+    const { activity_id } = req.params;
+ 
+ 
+    try {
+        const activity = await Activity.findByPk(activity_id, {
+            include: {
+                model: Phase,
+                as: 'Phases',
+                attributes: ['id', 'number', 'status'] 
+            }
+        });
+        if (!activity) {
+            return res.status(404).json({ status: 'error', message: 'Activity not found' });
+        }
+ 
+ 
+        res.status(200).json({
+            status: 'success',
+            data: {
+                activity_id: activity.id,
+                name: activity.name,
+                phases: activity.Phases
+            }
+        });
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ status: 'error', message: 'Internal server error' });
+    }
+ });
+ 
 // Create
 router.post('/activity', auth, checkAbility('create', 'Activity'), async (req, res) => {
     const { design, session } = req.body;

--- a/ethicapp/backend/api/v2/migrations/20241024141909-add-status-to-phases.js
+++ b/ethicapp/backend/api/v2/migrations/20241024141909-add-status-to-phases.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('phases', 'status', {
+      type:  Sequelize.ENUM('inprogress', 'done'),
+      allowNull: false,
+      defaultValue: 'inprogress'
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('phases', 'status');
+  }
+};
+

--- a/ethicapp/backend/api/v2/models/activity.js
+++ b/ethicapp/backend/api/v2/models/activity.js
@@ -12,6 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       // define association here
       //Activity.belongsTo(models.Session, { foreignKey: 'session_id' });
+      Activity.hasMany(models.Phase, { foreignKey: 'activity_id', as: 'Phases' });
     }
   }
   Activity.init({

--- a/ethicapp/backend/api/v2/test/integration/activityAndPhases.test.js
+++ b/ethicapp/backend/api/v2/test/integration/activityAndPhases.test.js
@@ -130,4 +130,24 @@ describe('Activities and Phases API', () => {
         expect(res.body.status).toBe('success');
         expect(res.body.data.anon).toBe(true);
     });
+
+    it('should return the phases with their state', async () => {
+        const res = await request(app)
+          .get(`${API_VERSION_PATH_PREFIX}/activities/${activityId}`)
+          .set('Authorization', `Bearer ${token}`)
+          .expect(200);
+      
+        expect(res.body.status).toBe('success');
+        expect(Array.isArray(res.body.data.phases)).toBe(true);
+        expect(res.body.data.phases.length).toBeGreaterThan(0);
+        res.body.data.phases.forEach(phase => {
+            expect(phase).toHaveProperty('id');
+            expect(phase).toHaveProperty('number');
+            expect(phase).toHaveProperty('status');
+            expect(typeof phase.number).toBe('number'); 
+            expect(['inprogress', 'done']).toContain(phase.status);
+        });
+        
+      });
+      
 });

--- a/ethicapp/backend/api/v2/test/unit/activity.test.js
+++ b/ethicapp/backend/api/v2/test/unit/activity.test.js
@@ -1,4 +1,4 @@
-const { Activity, Design } = require('../../models');
+const { Activity, Design, Phase } = require('../../models');
 const designs = require('../fixtures/designs.json')
 
 describe('Activity Model', () => {
@@ -19,4 +19,7 @@ describe('Activity Model', () => {
             .rejects
             .toThrow();
     });
+
+    
+    
 });

--- a/ethicapp/backend/api/v2/test/unit/phase.test.js
+++ b/ethicapp/backend/api/v2/test/unit/phase.test.js
@@ -119,6 +119,22 @@ describe('Phase Model', () => {
     //console.log("resPhaseDesign", resPhaseDesign.body)
     expect(resPhaseDesign.status).toBe(201)
     expect(resPhaseDesign.body).toHaveProperty('status', 'success')
-  })
+  });
+  it('should get the activity with its phases via API', async () => {
+    const res = await request(app)
+      .get(`${API_VERSION_PATH_PREFIX}/activities/${activityId.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
 
+    expect(res.body.status).toBe('success');
+    expect(Array.isArray(res.body.data.phases)).toBe(true);
+    expect(res.body.data.phases.length).toBeGreaterThan(0);
+
+    res.body.data.phases.forEach(phase => {
+      expect(phase).toHaveProperty('id');
+      expect(phase).toHaveProperty('number');
+      expect(phase).toHaveProperty('status');
+      expect(['inprogress', 'done']).toContain(phase.status);//aqui dejar solo inprogress y done
+    });
+  });
 });


### PR DESCRIPTION
-Se agrego un endpoint '''GET /activities/:activity_id''' en el archivo '''activities.js''' para obtener los detalles de una actividad, incluyendo las fases asociadas.
-Se creo una nueva migración para agregar una nueva columna '''status''' al modelo '''Phase''', el cual permite los valores '''inprogress''' y '''done'''
-Se estableció la asociación entre los modelos '''Activity''' y '''Phase'''
-Se crearon tests de integración y tests unitarios para validar la relación entre los modelos y para verificar el funcionamiento del endpoint.