### PR TITLE
Add password reset email delivery via SMTP with EJS template

### DIFF
--- a/auth-backend/.env.example
+++ b/auth-backend/.env.example
@@ -1,14 +1,29 @@
-PORT=8502
+PORT=3000
+NODE_ENV=development
+DEBUG_SQL=false
+
 SESSION_SECRET=change_me
+SESSION_COOKIE_NAME=auth.sid
+BCRYPT_SALT_ROUNDS=10
+RESET_TOKEN_TTL_MINUTES=60
+
 PGHOST=postgresql
 PGPORT=5432
 PGUSER=postgres
 PGPASSWORD=postgres
 PGDATABASE=ethicapp
-
 PGPOOL_MAX=10
 PG_IDLE_TIMEOUT=30000
 PG_CONN_TIMEOUT=2000
 
-NODE_ENV=development
-DEBUG_SQL=false
+# URL pública usada para construir el link de recuperación de contraseña.
+# Ejemplo: https://auth.mi-dominio.com
+AUTH_PUBLIC_URL=http://localhost:3000
+
+# SMTP saliente
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=mailer@example.com
+SMTP_PASS=super_secret_password
+SMTP_FROM="EthicApp <no-reply@example.com>"

--- a/auth-backend/app.js
+++ b/auth-backend/app.js
@@ -17,6 +17,8 @@ const app = express();
 app.set('trust proxy', 1);
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
+app.set('email template engine', 'ejs');
+app.set('email templates path', path.join(__dirname, 'views', 'emails'));
 
 // --------------------------------------------------
 // Parsers

--- a/auth-backend/package-lock.json
+++ b/auth-backend/package-lock.json
@@ -16,7 +16,8 @@
         "express-session": "^1.19.0",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
-        "pg": "^8.20.0"
+        "pg": "^8.20.0",
+        "nodemailer": "^8.0.5"
       },
       "devDependencies": {
         "nodemon": "^3.1.14"
@@ -836,6 +837,14 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/auth-backend/package.json
+++ b/auth-backend/package.json
@@ -21,6 +21,7 @@
     "ejs": "^5.0.1",
     "express": "^5.2.1",
     "express-session": "^1.19.0",
+    "nodemailer": "^8.0.5",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "pg": "^8.20.0"

--- a/auth-backend/routes/auth.routes.js
+++ b/auth-backend/routes/auth.routes.js
@@ -3,6 +3,7 @@ const bcrypt = require('bcrypt');
 const crypto = require('crypto');
 
 const db = require('../config/database');
+const mailService = require('../services/mail.service');
 
 const router = express.Router();
 
@@ -267,8 +268,8 @@ router.post('/logout', (req, res) => {
  *   email
  * }
  *
- * This implementation stores a reset token digest and expiry in the users table.
- * Sending the email is intentionally left out here to keep the data layer simple.
+ * This implementation stores a reset token digest and expiry in the users table
+ * and then sends an email with the reset link.
  */
 router.post('/forgot', async (req, res) => {
   try {
@@ -313,16 +314,14 @@ router.post('/forgot', async (req, res) => {
       [tokenDigest, expiresAt, user.id]
     );
 
-    const response = {
+    await mailService.sendPasswordResetEmail({
+      to: user.mail,
+      rawToken
+    });
+
+    return res.json({
       message: 'Si el correo existe, recibirás instrucciones para restablecer la contraseña'
-    };
-
-    if (process.env.NODE_ENV !== 'production') {
-      response.reset_token = rawToken;
-      response.reset_url = `/newpassword?token=${rawToken}`;
-    }
-
-    return res.json(response);
+    });
   } catch (err) {
     console.error('FORGOT PASSWORD ERROR:', err);
     return res.status(500).json({

--- a/auth-backend/services/mail.service.js
+++ b/auth-backend/services/mail.service.js
@@ -1,0 +1,74 @@
+const path = require('path');
+const ejs = require('ejs');
+const nodemailer = require('nodemailer');
+
+const EMAIL_TEMPLATES_PATH = path.join(__dirname, '..', 'views', 'emails');
+const SMTP_HOST = process.env.SMTP_HOST;
+const SMTP_PORT = Number(process.env.SMTP_PORT || 587);
+const SMTP_USER = process.env.SMTP_USER;
+const SMTP_PASS = process.env.SMTP_PASS;
+const SMTP_SECURE = process.env.SMTP_SECURE === 'true';
+const SMTP_FROM = process.env.SMTP_FROM || SMTP_USER;
+const AUTH_PUBLIC_URL = process.env.AUTH_PUBLIC_URL || 'http://localhost:3000';
+
+function ensureSmtpConfig() {
+  if (!SMTP_HOST || !SMTP_PORT || !SMTP_USER || !SMTP_PASS || !SMTP_FROM) {
+    throw new Error(
+      'SMTP configuration is incomplete. Required: SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM'
+    );
+  }
+}
+
+function buildResetUrl(rawToken) {
+  const normalizedBaseUrl = AUTH_PUBLIC_URL.endsWith('/')
+    ? AUTH_PUBLIC_URL.slice(0, -1)
+    : AUTH_PUBLIC_URL;
+
+  return `${normalizedBaseUrl}/newpassword?token=${encodeURIComponent(rawToken)}`;
+}
+
+function createTransporter() {
+  ensureSmtpConfig();
+
+  return nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: SMTP_PORT,
+    secure: SMTP_SECURE,
+    auth: {
+      user: SMTP_USER,
+      pass: SMTP_PASS
+    }
+  });
+}
+
+async function renderForgotPasswordHtml(templateData) {
+  const templatePath = path.join(EMAIL_TEMPLATES_PATH, 'forgot-password.ejs');
+
+  return ejs.renderFile(templatePath, templateData);
+}
+
+async function sendPasswordResetEmail({ to, rawToken }) {
+  const resetUrl = buildResetUrl(rawToken);
+  const html = await renderForgotPasswordHtml({
+    resetUrl,
+    resetTokenTtlMinutes: Number(process.env.RESET_TOKEN_TTL_MINUTES || 60)
+  });
+
+  const transporter = createTransporter();
+
+  await transporter.sendMail({
+    from: SMTP_FROM,
+    to,
+    subject: 'Recuperación de contraseña',
+    html
+  });
+
+  return {
+    resetUrl
+  };
+}
+
+module.exports = {
+  sendPasswordResetEmail,
+  buildResetUrl
+};

--- a/auth-backend/views/emails/forgot-password.ejs
+++ b/auth-backend/views/emails/forgot-password.ejs
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Recuperación de contraseña</title>
+  </head>
+  <body style="font-family: Arial, sans-serif; line-height: 1.5; color: #222;">
+    <h2>Solicitud de recuperación de contraseña</h2>
+    <p>
+      Recibimos una solicitud para restablecer tu contraseña de EthicApp.
+      Puedes crear una nueva contraseña usando el siguiente enlace:
+    </p>
+
+    <p>
+      <a href="<%= resetUrl %>" target="_blank" rel="noopener noreferrer"><%= resetUrl %></a>
+    </p>
+
+    <p>
+      Este enlace expira en <strong><%= resetTokenTtlMinutes %> minutos</strong>.
+    </p>
+
+    <p>
+      Si no solicitaste este cambio, puedes ignorar este correo y tu contraseña seguirá siendo la misma.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Implement sending password reset emails so users receive a link to change their password instead of exposing the token in API responses.
- Provide a configurable SMTP-backed mailer and a reusable email template for localization and consistent formatting.

### Description
- Added a new `services/mail.service.js` that builds reset links, renders the `forgot-password.ejs` template, and sends emails using `nodemailer` and environment SMTP settings, exposed as `sendPasswordResetEmail`.
- Updated `routes/auth.routes.js` to call `mailService.sendPasswordResetEmail` in the `/forgot` flow and removed returning the raw token in responses for non-production environments.
- Added the email template `views/emails/forgot-password.ejs` and configured the app in `app.js` with `email template engine` and `email templates path` settings.
- Updated `package.json` and `package-lock.json` to include the `nodemailer` dependency and extended the `.env.example` with SMTP, public URL, session and reset-related configuration variables.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff869c2cc832ba30e9077be6b59a9)