### PR TITLE
Add ethicapp-student app (Node/Express backend + React19 frontend) and route /student in dev nginx

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,6 +23,29 @@ services:
       - "8502"
       - "5173"
 
+  ethicapp-student:
+    env_file:
+      - ./.env.shared
+      - ./ethicapp-student/backend/.env
+    environment:
+      - NODE_ENV=development
+      - ETHICAPP_STUDENT_NODE_PORT=8503
+    volumes:
+      - ./ethicapp-student:/app
+      - ethicapp_student_backend_node_modules:/app/backend/node_modules
+      - ethicapp_student_frontend_node_modules:/app/frontend/node_modules
+    command: >
+      sh -c "
+        cd backend && npm install &&
+        cd ../frontend && npm install &&
+        cd /app &&
+        npx nodemon backend/server.js &
+        cd frontend && npx vite --host 0.0.0.0 --port 5174
+      "
+    expose:
+      - "8503"
+      - "5174"
+
   nginx:
     volumes:
       - ./nginx/conf.d/dev.conf:/etc/nginx/nginx.conf:ro
@@ -30,3 +53,5 @@ services:
 volumes:
   auth_backend_node_modules:
   auth_frontend_node_modules:
+  ethicapp_student_backend_node_modules:
+  ethicapp_student_frontend_node_modules:

--- a/ethicapp-student/.dockerignore
+++ b/ethicapp-student/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+backend/node_modules
+frontend/node_modules
+frontend/dist
+.git

--- a/ethicapp-student/Dockerfile
+++ b/ethicapp-student/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS frontend-builder
+
+WORKDIR /app/frontend
+COPY frontend/package*.json ./
+RUN npm ci
+COPY frontend ./
+RUN npm run build
+
+FROM node:22-alpine AS backend-builder
+
+WORKDIR /app
+COPY backend/package*.json ./
+RUN npm ci --omit=dev
+COPY backend ./backend
+COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+
+FROM node:22-alpine
+
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=backend-builder /app /app
+EXPOSE 8503
+CMD ["node", "backend/server.js"]

--- a/ethicapp-student/README.md
+++ b/ethicapp-student/README.md
@@ -1,0 +1,23 @@
+# ethicapp-student
+
+Aplicación nueva para estudiantes con:
+
+- Backend Node + Express (`backend/`)
+- Frontend React 19 + Bootstrap 5 (`frontend/`)
+- Integración con sesión autenticada desde `auth-backend` vía headers `X-User-Id` y `X-User-Role`
+
+## Desarrollo
+
+```bash
+cd ethicapp-student/backend && npm install
+cd ../frontend && npm install
+cd ..
+npm install
+npm run dev
+```
+
+## Producción
+
+```bash
+docker build -t ethicapp-student ./ethicapp-student
+```

--- a/ethicapp-student/backend/app.js
+++ b/ethicapp-student/backend/app.js
@@ -1,0 +1,59 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import express from 'express';
+import session from 'express-session';
+
+import studentRoutes from './routes/student.routes.js';
+import { exposeLegacySession, hydrateLegacySession, requireLegacyAuth } from './middleware/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+
+app.set('trust proxy', 1);
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+app.use(
+  session({
+    name: process.env.ETHICAPP_STUDENT_SESSION_COOKIE_NAME || 'ethicapp.student.sid',
+    secret: process.env.ETHICAPP_STUDENT_SESSION_SECRET || process.env.SESSION_SECRET || 'development-secret',
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 1000 * 60 * 60 * 8
+    }
+  })
+);
+
+app.use(hydrateLegacySession);
+app.use(exposeLegacySession);
+
+app.use('/student/api', requireLegacyAuth, studentRoutes);
+
+app.get('/student/health', (req, res) => {
+  res.status(200).json({ ok: true });
+});
+
+app.use('/student/assets', express.static(path.join(__dirname, '../frontend/dist/assets')));
+app.use('/student', express.static(path.join(__dirname, '../frontend/dist')));
+
+app.get('/student/*splat', requireLegacyAuth, (req, res) => {
+  res.sendFile(path.join(__dirname, '../frontend/dist/index.html'));
+});
+
+app.use((err, req, res, next) => {
+  console.error(err);
+
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  return res.status(500).json({ error: 'Internal server error' });
+});
+
+export default app;

--- a/ethicapp-student/backend/middleware/exposeLegacySession.js
+++ b/ethicapp-student/backend/middleware/exposeLegacySession.js
@@ -1,0 +1,13 @@
+export default function exposeLegacySession(req, res, next) {
+  const currentSession = req.session || {};
+
+  res.locals.uid = currentSession.uid ?? null;
+  res.locals.role = currentSession.role ?? null;
+  res.locals.sesid = currentSession.sesid ?? null;
+  res.locals.isAuthenticated = currentSession.uid != null;
+  res.locals.impersonating = !!currentSession.impersonating;
+  res.locals.authUid = currentSession.authUid ?? null;
+  res.locals.authRole = currentSession.authRole ?? null;
+
+  next();
+}

--- a/ethicapp-student/backend/middleware/hydrateLegacySession.js
+++ b/ethicapp-student/backend/middleware/hydrateLegacySession.js
@@ -1,0 +1,58 @@
+export default function hydrateLegacySession(req, res, next) {
+  try {
+    const headerUserId = req.get('X-User-Id');
+    const headerUserRole = req.get('X-User-Role');
+
+    if (!headerUserId || !req.session) {
+      return next();
+    }
+
+    const incomingUid = Number(headerUserId);
+
+    if (!Number.isInteger(incomingUid) || incomingUid <= 0) {
+      return next();
+    }
+
+    const incomingRole = headerUserRole || null;
+
+    if (!req.session.uid) {
+      req.session.uid = incomingUid;
+      req.session.role = incomingRole;
+      req.session.authUid = incomingUid;
+      req.session.authRole = incomingRole;
+      req.session.impersonating = false;
+      return next();
+    }
+
+    if (req.session.impersonating) {
+      req.session.authUid = incomingUid;
+      req.session.authRole = incomingRole;
+      return next();
+    }
+
+    if (req.session.uid === incomingUid) {
+      if (!req.session.role && incomingRole) {
+        req.session.role = incomingRole;
+      }
+      req.session.authUid = incomingUid;
+      req.session.authRole = incomingRole;
+      return next();
+    }
+
+    req.session.regenerate((err) => {
+      if (err) {
+        return next(err);
+      }
+
+      req.session.uid = incomingUid;
+      req.session.role = incomingRole;
+      req.session.authUid = incomingUid;
+      req.session.authRole = incomingRole;
+      req.session.impersonating = false;
+
+      return next();
+    });
+  } catch (error) {
+    return next(error);
+  }
+}

--- a/ethicapp-student/backend/middleware/index.js
+++ b/ethicapp-student/backend/middleware/index.js
@@ -1,0 +1,3 @@
+export { default as hydrateLegacySession } from './hydrateLegacySession.js';
+export { default as exposeLegacySession } from './exposeLegacySession.js';
+export { default as requireLegacyAuth } from './requireLegacyAuth.js';

--- a/ethicapp-student/backend/middleware/requireLegacyAuth.js
+++ b/ethicapp-student/backend/middleware/requireLegacyAuth.js
@@ -1,0 +1,7 @@
+export default function requireLegacyAuth(req, res, next) {
+  if (req.session?.uid != null) {
+    return next();
+  }
+
+  return res.redirect('/auth/login');
+}

--- a/ethicapp-student/backend/package.json
+++ b/ethicapp-student/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ethicapp-student-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "dev": "nodemon server.js",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "dotenv": "^17.4.1",
+    "express": "^5.2.1",
+    "express-session": "^1.19.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.14"
+  }
+}

--- a/ethicapp-student/backend/routes/student.routes.js
+++ b/ethicapp-student/backend/routes/student.routes.js
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/session', (req, res) => {
+  res.json({
+    uid: req.session?.uid ?? null,
+    role: req.session?.role ?? null,
+    isAuthenticated: req.session?.uid != null,
+    impersonating: !!req.session?.impersonating
+  });
+});
+
+export default router;

--- a/ethicapp-student/backend/server.js
+++ b/ethicapp-student/backend/server.js
@@ -1,0 +1,8 @@
+import 'dotenv/config';
+import app from './app.js';
+
+const port = process.env.ETHICAPP_STUDENT_NODE_PORT || 8503;
+
+app.listen(port, () => {
+  console.log(`Ethicapp Student backend listening on port ${port}`);
+});

--- a/ethicapp-student/frontend/index.html
+++ b/ethicapp-student/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EthicApp Student</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/ethicapp-student/frontend/package.json
+++ b/ethicapp-student/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ethicapp-student-frontend",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 5174",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4174"
+  },
+  "dependencies": {
+    "bootstrap": "^5.3.8",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "@popperjs/core": "^2.11.8"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^6.0.1",
+    "vite": "^8.0.4"
+  }
+}

--- a/ethicapp-student/frontend/src/App.jsx
+++ b/ethicapp-student/frontend/src/App.jsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export default function App() {
+  const [session, setSession] = useState({ isAuthenticated: false, uid: null, role: null });
+
+  useEffect(() => {
+    fetch('/student/api/session', { credentials: 'include' })
+      .then((response) => response.json())
+      .then((data) => setSession(data))
+      .catch(() => {
+        setSession({ isAuthenticated: false, uid: null, role: null });
+      });
+  }, []);
+
+  return (
+    <main className="container py-5">
+      <h1 className="mb-3">EthicApp Student</h1>
+      <p className="text-muted">Aplicación base para rutas bajo <code>/student</code>.</p>
+      <div className="card p-3">
+        <h2 className="h5">Sesión actual</h2>
+        <ul className="mb-0">
+          <li>Autenticado: {session.isAuthenticated ? 'Sí' : 'No'}</li>
+          <li>UID: {session.uid ?? '-'}</li>
+          <li>Rol: {session.role ?? '-'}</li>
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/ethicapp-student/frontend/src/main.jsx
+++ b/ethicapp-student/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import App from './App.jsx';
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ethicapp-student/frontend/vite.config.js
+++ b/ethicapp-student/frontend/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/student/',
+  server: {
+    host: '0.0.0.0',
+    port: 5174,
+    strictPort: true
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
+  }
+});

--- a/ethicapp-student/package.json
+++ b/ethicapp-student/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ethicapp-student",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "concurrently \"npm --prefix backend run dev\" \"npm --prefix frontend run dev\"",
+    "build": "npm --prefix frontend run build"
+  },
+  "dependencies": {
+    "concurrently": "^9.2.1"
+  }
+}

--- a/nginx/conf.d/dev.conf
+++ b/nginx/conf.d/dev.conf
@@ -28,6 +28,14 @@ http {
     server ethicapp:8501;
   }
 
+  upstream ethicapp_student_api {
+    server ethicapp-student:8503;
+  }
+
+  upstream ethicapp_student_frontend {
+    server ethicapp-student:5174;
+  }
+
   server {
     listen 80;
     server_name _;
@@ -104,6 +112,40 @@ http {
     # ======================================
     # ETHICAPP LEGACY (protected)
     # ======================================
+
+    location /student/api/ {
+      auth_request /_auth_check;
+      error_page 401 = @auth_redirect;
+
+      proxy_pass http://ethicapp_student_api;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      proxy_set_header X-User-Id $auth_user_id;
+      proxy_set_header X-User-Role $auth_user_role;
+    }
+
+    location /student/ {
+      auth_request /_auth_check;
+      error_page 401 = @auth_redirect;
+
+      proxy_pass http://ethicapp_student_frontend;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      proxy_set_header X-User-Id $auth_user_id;
+      proxy_set_header X-User-Role $auth_user_role;
+    }
 
     location /socket.io/ {
       auth_request /_auth_check;


### PR DESCRIPTION
### Motivation
- Provision a new student-facing application that reuses authentication from `auth-backend` via propagated identity headers and serves all student UI under the `/student` prefix.
- Keep the new app architecturally aligned with existing services (`auth-backend` / `ethicapp`) so session hydration and routing are consistent in development and production.

### Description
- Added a new `ethicapp-student/` project containing a Node + Express `backend/` and a React 19 + Bootstrap 5 `frontend/` with Vite configuration and a production `Dockerfile`.
- Implemented legacy session middleware (`hydrateLegacySession`, `exposeLegacySession`, `requireLegacyAuth`) in `ethicapp-student/backend/middleware` copied from the existing `ethicapp` implementation so the service can hydrate session identity from `X-User-Id` and `X-User-Role`.
- Exposed a protected API `GET /student/api/session` and basic frontend bootstrap pages; configured `vite` base to `'/student/'` so built assets are available under `/student/assets/...` and static routes in the backend serve `/student` content.
- Updated dev infra: added `ethicapp-student` service to `docker-compose.dev.yml` (dev backend + frontend processes) and extended `nginx/conf.d/dev.conf` with new upstreams and locations routing `/student/api/` to the backend and `/student/` to the frontend dev server, both using the existing `auth_request` hook.

### Testing
- Ran `node --check` against new backend source files (`ethicapp-student/backend/*.js`) and the check completed successfully.
- Attempted `docker compose -f docker-compose.dev.yml config` but it could not be executed in this environment because Docker is not available.
- Attempted `nginx -t -c $(pwd)/nginx/conf.d/dev.conf` but it could not be executed in this environment because the `nginx` binary is not available.
- Attempted `npm --prefix ethicapp-student/frontend install` in this environment and it failed due to registry access policy (`403 Forbidden`), so frontend package installation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e41da5ac832b87741d3f86c80499)