### PR TITLE
feat(student): add PostgreSQL data layer and student session endpoints

### DIFF
--- a/ethicapp-student/backend/app.js
+++ b/ethicapp-student/backend/app.js
@@ -33,6 +33,7 @@ app.use(
 app.use(hydrateLegacySession);
 app.use(exposeLegacySession);
 
+app.use('/student', requireLegacyAuth, studentRoutes);
 app.use('/student/api', requireLegacyAuth, studentRoutes);
 
 app.get('/student/health', (req, res) => {

--- a/ethicapp-student/backend/config/database.js
+++ b/ethicapp-student/backend/config/database.js
@@ -1,0 +1,47 @@
+import { Pool } from 'pg';
+
+const useSsl = process.env.PGSSLMODE === 'require';
+
+const pool = new Pool({
+  host: process.env.PGHOST || 'localhost',
+  port: Number(process.env.PGPORT || 5432),
+  user: process.env.PGUSER,
+  password: process.env.PGPASSWORD,
+  database: process.env.PGDATABASE || process.env.POSTGRES_DB,
+  max: Number(process.env.PGPOOL_MAX || 10),
+  idleTimeoutMillis: Number(process.env.PG_IDLE_TIMEOUT || 30000),
+  connectionTimeoutMillis: Number(process.env.PG_CONN_TIMEOUT || 2000),
+  ssl: useSsl
+    ? {
+        rejectUnauthorized: false
+      }
+    : false
+});
+
+pool.on('error', (err) => {
+  console.error('Unexpected error on idle PostgreSQL client', err);
+});
+
+export async function query(text, params) {
+  const start = Date.now();
+
+  try {
+    const result = await pool.query(text, params);
+
+    if (process.env.DEBUG_SQL === 'true') {
+      const duration = Date.now() - start;
+      console.log('SQL:', { text, duration, rows: result.rowCount });
+    }
+
+    return result;
+  } catch (err) {
+    console.error('SQL ERROR:', {
+      text,
+      params,
+      message: err.message
+    });
+    throw err;
+  }
+}
+
+export { pool };

--- a/ethicapp-student/backend/package.json
+++ b/ethicapp-student/backend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "dotenv": "^17.4.1",
     "express": "^5.2.1",
-    "express-session": "^1.19.0"
+    "express-session": "^1.19.0",
+    "pg": "^8.16.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.14"

--- a/ethicapp-student/backend/routes/student.routes.js
+++ b/ethicapp-student/backend/routes/student.routes.js
@@ -1,6 +1,24 @@
 import { Router } from 'express';
+import { query } from '../config/database.js';
 
 const router = Router();
+
+function ensureStudentSession(req, res) {
+  const uid = Number(req.session?.uid);
+  const role = req.session?.role;
+
+  if (!Number.isInteger(uid) || uid <= 0) {
+    res.status(401).json({ error: 'Usuario no autenticado' });
+    return null;
+  }
+
+  if (role !== 'A') {
+    res.status(403).json({ error: 'Usuario sin permisos de estudiante' });
+    return null;
+  }
+
+  return uid;
+}
 
 router.get('/session', (req, res) => {
   res.json({
@@ -9,6 +27,118 @@ router.get('/session', (req, res) => {
     isAuthenticated: req.session?.uid != null,
     impersonating: !!req.session?.impersonating
   });
+});
+
+router.get('/sessions', async (req, res, next) => {
+  const uid = ensureStudentSession(req, res);
+
+  if (!uid) {
+    return;
+  }
+
+  try {
+    const result = await query(
+      `
+        SELECT *
+        FROM (
+            SELECT DISTINCT s.id,
+                s.name,
+                s.descr,
+                s.status,
+                s.type,
+                s.time,
+                s.code,
+                s.options,
+                s.archived,
+                s.current_stage,
+                s.additional_config,
+                (
+                    s.id in (SELECT sesid FROM teams)
+                ) AS grouped,
+                (
+                    SELECT count(*)
+                    FROM report_pair
+                    WHERE sesid = s.id
+                ) AS paired,
+                sr.stime
+            FROM sessions AS s
+            LEFT OUTER JOIN status_record AS sr
+              ON sr.sesid = s.id
+             AND s.status = sr.status,
+            sesusers AS su,
+            users AS u
+            WHERE su.uid = $1
+              AND (OPTIONS like 'X%') IS NOT TRUE
+              AND u.id = su.uid
+              AND su.sesid = s.id
+        ) AS v
+        ORDER BY v.time DESC
+      `,
+      [uid]
+    );
+
+    res.json(result.rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/sessions/join', async (req, res, next) => {
+  const uid = ensureStudentSession(req, res);
+
+  if (!uid) {
+    return;
+  }
+
+  const code = req.params?.code ?? req.body?.code;
+  const { device } = req.body;
+
+  if (!code) {
+    return res.status(400).json({ error: 'Código de sesión requerido' });
+  }
+
+  try {
+    const result = await query(
+      `
+        INSERT INTO sesusers(uid, sesid, device)
+        SELECT $1::int AS uid,
+               id,
+               $2 AS device
+        FROM sessions
+        WHERE code = $3
+          AND NOT EXISTS (
+              SELECT su.sesid
+              FROM sesusers AS su,
+                   sessions AS s
+              WHERE su.uid = $1
+                AND s.code = $3
+                AND su.sesid = s.id
+          )
+          AND NOT EXISTS (
+              SELECT st.id
+              FROM stages AS st,
+                   sessions AS ss
+              WHERE st.sesid = ss.id
+                AND ss.code = $3
+                AND st.type = 'team'
+          )
+        RETURNING sesid
+      `,
+      [uid, device ?? null, code]
+    );
+
+    if (result.rowCount === 0) {
+      return res.status(404).json({
+        error: 'No fue posible unirse a la sesión con el código entregado'
+      });
+    }
+
+    return res.status(201).json({
+      sesid: result.rows[0].sesid
+    });
+  } catch (error) {
+    return next(error);
+  }
 });
 
 export default router;


### PR DESCRIPTION
### Motivation
- Proveer una capa de acceso a PostgreSQL en el backend de `ethicapp-student` similar a la existente en `auth-backend` y configurable por variables de entorno (`PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`, `PGSSLMODE`).
- Exponer API para que estudiantes obtengan sus sesiones y puedan unirse a sesiones por código respetando la sesión de usuario (`req.session.uid`) y el rol (`req.session.role === 'A'`).
- Mantener compatibilidad con la estructura existente del proyecto y usar la misma lógica SQL proporcionada para listados y unión a sesiones.

### Description
- Se añadió `ethicapp-student/backend/config/database.js` que implementa un `pg` `Pool` configurable por variables de entorno y exporta `query(...)` y `pool` para uso desde rutas. 
- Se implementaron los endpoints en `ethicapp-student/backend/routes/student.routes.js`: `GET /student/sessions` para listar sesiones del usuario autenticado y `POST /student/sessions/join` para unirse a una sesión por `code` (se acepta `device` en el body). 
- Se agregó la función de validación `ensureStudentSession(...)` que responde `401` si no hay sesión válida y `403` si el rol no es `A`, y los endpoints usan esta validación antes de consultar la DB. 
- Se montaron las rutas bajo `'/student'` (además de `'/student/api'` por compatibilidad) y se añadió la dependencia `pg` en `ethicapp-student/backend/package.json`.

### Testing
- Ejecuté `node --check ethicapp-student/backend/config/database.js` y la comprobación de sintaxis pasó correctamente. 
- Ejecuté `node --check ethicapp-student/backend/routes/student.routes.js` y la comprobación de sintaxis pasó correctamente. 
- Ejecuté `node --check ethicapp-student/backend/app.js` y la comprobación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f0bf83c0832ba26ffbb10e69ec16)