### PR TITLE
Add student session UI: SessionList, JoinSessionCard, and StudentTopbar; refactor App session handling

### DIFF
--- a/ethicapp-student/frontend/src/App.jsx
+++ b/ethicapp-student/frontend/src/App.jsx
@@ -1,29 +1,63 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import JoinSessionCard from './components/JoinSessionCard.jsx';
+import SessionList from './components/SessionList.jsx';
+import StudentTopbar from './components/StudentTopbar.jsx';
+
+const SESSION_PLACEHOLDER = {
+  isAuthenticated: false,
+  uid: null,
+  role: null
+};
 
 export default function App() {
-  const [session, setSession] = useState({ isAuthenticated: false, uid: null, role: null });
+  const [session, setSession] = useState(SESSION_PLACEHOLDER);
+  const [loadingSession, setLoadingSession] = useState(true);
+  const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
+
+  const userDisplayName = useMemo(() => {
+    if (!session.isAuthenticated) {
+      return 'Estudiante';
+    }
+
+    return `Usuario #${session.uid}`;
+  }, [session]);
 
   useEffect(() => {
     fetch('/student/api/session', { credentials: 'include' })
       .then((response) => response.json())
-      .then((data) => setSession(data))
+      .then((data) => {
+        setSession(data);
+        setLoadingSession(false);
+      })
       .catch(() => {
-        setSession({ isAuthenticated: false, uid: null, role: null });
+        setSession(SESSION_PLACEHOLDER);
+        setLoadingSession(false);
       });
   }, []);
 
+  const handleLogout = () => {
+    window.location.assign('/logout');
+  };
+
+  const handleSessionJoined = () => {
+    setSessionRefreshKey((currentKey) => currentKey + 1);
+  };
+
   return (
-    <main className="container py-5">
-      <h1 className="mb-3">EthicApp Student</h1>
-      <p className="text-muted">Aplicación base para rutas bajo <code>/student</code>.</p>
-      <div className="card p-3">
-        <h2 className="h5">Sesión actual</h2>
-        <ul className="mb-0">
-          <li>Autenticado: {session.isAuthenticated ? 'Sí' : 'No'}</li>
-          <li>UID: {session.uid ?? '-'}</li>
-          <li>Rol: {session.role ?? '-'}</li>
-        </ul>
-      </div>
-    </main>
+    <div className="d-flex flex-column min-vh-100 bg-body-tertiary">
+      <StudentTopbar loadingSession={loadingSession} userDisplayName={userDisplayName} onLogout={handleLogout} />
+
+      <main className="container py-4 py-md-5 flex-grow-1">
+        <div className="row g-4">
+          <section className="col-12 col-xl-7">
+            <SessionList isAuthenticated={session.isAuthenticated} refreshKey={sessionRefreshKey} />
+          </section>
+
+          <section className="col-12 col-xl-5">
+            <JoinSessionCard disabled={loadingSession} onJoined={handleSessionJoined} />
+          </section>
+        </div>
+      </main>
+    </div>
   );
 }

--- a/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
+++ b/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+
+export default function JoinSessionCard({ disabled, onJoined }) {
+  const [joinCode, setJoinCode] = useState('');
+  const [joinBusy, setJoinBusy] = useState(false);
+  const [joinFeedback, setJoinFeedback] = useState(null);
+
+  const handleJoinSession = async (event) => {
+    event.preventDefault();
+
+    const normalizedCode = joinCode.trim();
+    if (!normalizedCode) {
+      setJoinFeedback({ type: 'danger', message: 'Ingresa un código de sesión válido.' });
+      return;
+    }
+
+    setJoinBusy(true);
+    setJoinFeedback(null);
+
+    try {
+      const response = await fetch('/student/api/sessions/join', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          code: normalizedCode,
+          device: 'web'
+        })
+      });
+
+      const payload = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        throw new Error(payload?.error ?? 'No fue posible unirse a la sesión');
+      }
+
+      setJoinFeedback({ type: 'success', message: 'Te uniste a la sesión correctamente.' });
+      setJoinCode('');
+      onJoined();
+    } catch (error) {
+      setJoinFeedback({ type: 'danger', message: error.message });
+    } finally {
+      setJoinBusy(false);
+    }
+  };
+
+  return (
+    <div className="card shadow-sm h-100">
+      <div className="card-body d-flex flex-column">
+        <h2 className="h5 mb-2">Unirse a una sesión</h2>
+        <p className="text-muted small mb-3">
+          Ingresa el código compartido por tu profesor. El formulario es compatible con móvil y escritorio.
+        </p>
+
+        <form className="mt-auto" onSubmit={handleJoinSession}>
+          <div className="input-group input-group-lg">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="Ej: ABC123"
+              aria-label="Código de sesión"
+              value={joinCode}
+              onChange={(event) => setJoinCode(event.target.value.toUpperCase())}
+            />
+            <button className="btn btn-primary" type="submit" disabled={joinBusy || disabled}>
+              {joinBusy ? 'Uniendo...' : 'Unirse'}
+            </button>
+          </div>
+        </form>
+
+        {joinFeedback ? (
+          <div className={`alert alert-${joinFeedback.type} py-2 mt-3 mb-0`} role="alert">
+            {joinFeedback.message}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/ethicapp-student/frontend/src/components/SessionList.jsx
+++ b/ethicapp-student/frontend/src/components/SessionList.jsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+
+function formatSessionDate(value) {
+  if (!value) {
+    return 'Sin fecha';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return 'Sin fecha';
+  }
+
+  return new Intl.DateTimeFormat('es-CL', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+function sessionStatusLabel(status) {
+  const labels = {
+    setup: 'Configuración',
+    active: 'Activa',
+    closed: 'Cerrada',
+    archived: 'Archivada'
+  };
+
+  return labels[status] ?? status ?? 'Sin estado';
+}
+
+export default function SessionList({ isAuthenticated, refreshKey }) {
+  const [joinedSessions, setJoinedSessions] = useState([]);
+  const [loadingSessions, setLoadingSessions] = useState(true);
+  const [sessionsError, setSessionsError] = useState('');
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setJoinedSessions([]);
+      setLoadingSessions(false);
+      setSessionsError('');
+      return;
+    }
+
+    setLoadingSessions(true);
+    setSessionsError('');
+
+    fetch('/student/api/sessions', { credentials: 'include' })
+      .then(async (response) => {
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}));
+          throw new Error(payload?.error ?? 'No se pudieron cargar las sesiones');
+        }
+
+        return response.json();
+      })
+      .then((rows) => {
+        setJoinedSessions(Array.isArray(rows) ? rows : []);
+        setLoadingSessions(false);
+      })
+      .catch((error) => {
+        setSessionsError(error.message);
+        setJoinedSessions([]);
+        setLoadingSessions(false);
+      });
+  }, [isAuthenticated, refreshKey]);
+
+  return (
+    <div className="card h-100 shadow-sm">
+      <div className="card-body">
+        <h2 className="h5 mb-3">Mis sesiones</h2>
+
+        {!isAuthenticated && <p className="text-muted mb-0">Inicia sesión para ver tus sesiones previas.</p>}
+
+        {isAuthenticated && loadingSessions ? <p className="text-muted mb-0">Cargando sesiones...</p> : null}
+
+        {sessionsError ? (
+          <div className="alert alert-danger py-2 mb-0" role="alert">
+            {sessionsError}
+          </div>
+        ) : null}
+
+        {!loadingSessions && isAuthenticated && !sessionsError ? (
+          joinedSessions.length > 0 ? (
+            <div className="list-group list-group-flush">
+              {joinedSessions.map((joinedSession) => (
+                <article key={joinedSession.id} className="list-group-item px-0">
+                  <div className="d-flex flex-column flex-sm-row justify-content-between gap-2">
+                    <div>
+                      <h3 className="h6 mb-1">{joinedSession.name ?? `Sesión #${joinedSession.id}`}</h3>
+                      <p className="mb-1 small text-secondary">{joinedSession.descr || 'Sin descripción'}</p>
+                      <div className="small text-muted d-flex flex-wrap gap-2">
+                        <span>Estado: {sessionStatusLabel(joinedSession.status)}</span>
+                        <span>Fecha: {formatSessionDate(joinedSession.time)}</span>
+                        <span>Código: {joinedSession.code}</span>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="text-muted mb-0">Aún no te has unido a ninguna sesión.</p>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/ethicapp-student/frontend/src/components/StudentTopbar.jsx
+++ b/ethicapp-student/frontend/src/components/StudentTopbar.jsx
@@ -1,0 +1,17 @@
+export default function StudentTopbar({ loadingSession, userDisplayName, onLogout }) {
+  return (
+    <header className="navbar navbar-expand-lg bg-white border-bottom sticky-top shadow-sm">
+      <div className="container-fluid container-lg py-1">
+        <span className="navbar-brand mb-0 h1 fw-semibold">EthicApp Student</span>
+        <div className="d-flex align-items-center gap-2 ms-auto">
+          <span className="small text-secondary text-truncate" style={{ maxWidth: '180px' }}>
+            {loadingSession ? 'Cargando usuario...' : userDisplayName}
+          </span>
+          <button type="button" className="btn btn-outline-danger btn-sm" onClick={onLogout}>
+            Logout
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a richer student interface to view joined sessions and join new sessions from the `/student` area. 
- Move session loading and display into a small set of reusable components to improve layout and maintainability. 
- Add a mechanism to refresh the sessions list when a student successfully joins a session.

### Description
- Refactor `App.jsx` to use `SESSION_PLACEHOLDER`, add `loadingSession` and `sessionRefreshKey` state, compute `userDisplayName` with `useMemo`, fetch the session on mount and wire `handleLogout` and `handleSessionJoined` to the UI. 
- Add `StudentTopbar.jsx` which shows the app brand, the current user display name or loading text, and a logout button that calls `onLogout`. 
- Add `SessionList.jsx` which fetches `/student/api/sessions`, displays joined sessions (with formatted date and status labels), handles loading and error states, and listens to `refreshKey` to re-fetch. 
- Add `JoinSessionCard.jsx` which provides a form to post to `/student/api/sessions/join`, normalizes and validates codes, shows feedback messages, and calls `onJoined` on success.

### Testing
- No automated tests were executed for these frontend changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e905368a24832bba7e64a8ac952a62)