### PR TITLE
feat(student): implementar routing SPA con páginas home y detalle de sesión

### DIFF
--- a/ethicapp-student/frontend/src/App.jsx
+++ b/ethicapp-student/frontend/src/App.jsx
@@ -1,63 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
-import JoinSessionCard from './components/JoinSessionCard.jsx';
-import SessionList from './components/SessionList.jsx';
-import StudentTopbar from './components/StudentTopbar.jsx';
-
-const SESSION_PLACEHOLDER = {
-  isAuthenticated: false,
-  uid: null,
-  role: null
-};
+import { RouterProvider } from 'react-router-dom';
+import router from './router';
 
 export default function App() {
-  const [session, setSession] = useState(SESSION_PLACEHOLDER);
-  const [loadingSession, setLoadingSession] = useState(true);
-  const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
-
-  const userDisplayName = useMemo(() => {
-    if (!session.isAuthenticated) {
-      return 'Estudiante';
-    }
-
-    return `Usuario #${session.uid}`;
-  }, [session]);
-
-  useEffect(() => {
-    fetch('/student/api/session', { credentials: 'include' })
-      .then((response) => response.json())
-      .then((data) => {
-        setSession(data);
-        setLoadingSession(false);
-      })
-      .catch(() => {
-        setSession(SESSION_PLACEHOLDER);
-        setLoadingSession(false);
-      });
-  }, []);
-
-  const handleLogout = () => {
-    window.location.assign('/logout');
-  };
-
-  const handleSessionJoined = () => {
-    setSessionRefreshKey((currentKey) => currentKey + 1);
-  };
-
-  return (
-    <div className="d-flex flex-column min-vh-100 bg-body-tertiary">
-      <StudentTopbar loadingSession={loadingSession} userDisplayName={userDisplayName} onLogout={handleLogout} />
-
-      <main className="container py-4 py-md-5 flex-grow-1">
-        <div className="row g-4">
-          <section className="col-12 col-xl-5">
-            <JoinSessionCard disabled={loadingSession} onJoined={handleSessionJoined} />
-          </section>
-
-          <section className="col-12 col-xl-7">
-            <SessionList isAuthenticated={session.isAuthenticated} refreshKey={sessionRefreshKey} />
-          </section>
-        </div>
-      </main>
-    </div>
-  );
+  return <RouterProvider router={router} />;
 }

--- a/ethicapp-student/frontend/src/components/SessionList.jsx
+++ b/ethicapp-student/frontend/src/components/SessionList.jsx
@@ -1,34 +1,7 @@
 import { useEffect, useState } from 'react';
+import { formatSessionDate, sessionStatusLabel } from '../utils/sessionFormat.js';
 
-function formatSessionDate(value) {
-  if (!value) {
-    return 'Sin fecha';
-  }
-
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return 'Sin fecha';
-  }
-
-  return new Intl.DateTimeFormat('es-CL', {
-    dateStyle: 'medium',
-    timeStyle: 'short'
-  }).format(date);
-}
-
-function sessionStatusLabel(status) {
-  const labels = {
-    setup: 'Configuración',
-    active: 'Activa',
-    closed: 'Cerrada',
-    archived: 'Archivada'
-  };
-
-  return labels[status] ?? status ?? 'Sin estado';
-}
-
-export default function SessionList({ isAuthenticated, refreshKey }) {
+export default function SessionList({ isAuthenticated, refreshKey, onSessionSelect }) {
   const [joinedSessions, setJoinedSessions] = useState([]);
   const [loadingSessions, setLoadingSessions] = useState(true);
   const [sessionsError, setSessionsError] = useState('');
@@ -84,17 +57,23 @@ export default function SessionList({ isAuthenticated, refreshKey }) {
             <div className="list-group list-group-flush">
               {joinedSessions.map((joinedSession) => (
                 <article key={joinedSession.id} className="list-group-item px-0">
-                  <div className="d-flex flex-column flex-sm-row justify-content-between gap-2">
-                    <div>
-                      <h3 className="h6 mb-1">{joinedSession.name ?? `Sesión #${joinedSession.id}`}</h3>
-                      <p className="mb-1 small text-secondary">{joinedSession.descr || 'Sin descripción'}</p>
-                      <div className="small text-muted d-flex flex-wrap gap-2">
-                        <span>Estado: {sessionStatusLabel(joinedSession.status)}</span>
-                        <span>Fecha: {formatSessionDate(joinedSession.time)}</span>
-                        <span>Código: {joinedSession.code}</span>
+                  <button
+                    type="button"
+                    className="btn btn-link p-0 text-start text-decoration-none w-100"
+                    onClick={() => onSessionSelect?.(joinedSession.id)}
+                  >
+                    <div className="d-flex flex-column flex-sm-row justify-content-between gap-2">
+                      <div>
+                        <h3 className="h6 mb-1">{joinedSession.name ?? `Sesión #${joinedSession.id}`}</h3>
+                        <p className="mb-1 small text-secondary">{joinedSession.descr || 'Sin descripción'}</p>
+                        <div className="small text-muted d-flex flex-wrap gap-2">
+                          <span>Estado: {sessionStatusLabel(joinedSession.status)}</span>
+                          <span>Fecha: {formatSessionDate(joinedSession.time)}</span>
+                          <span>Código: {joinedSession.code}</span>
+                        </div>
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </article>
               ))}
             </div>

--- a/ethicapp-student/frontend/src/layouts/StudentLayout.jsx
+++ b/ethicapp-student/frontend/src/layouts/StudentLayout.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Outlet } from 'react-router-dom';
+import StudentTopbar from '../components/StudentTopbar.jsx';
+
+const SESSION_PLACEHOLDER = {
+  isAuthenticated: false,
+  uid: null,
+  role: null
+};
+
+export default function StudentLayout() {
+  const [session, setSession] = useState(SESSION_PLACEHOLDER);
+  const [loadingSession, setLoadingSession] = useState(true);
+  const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
+
+  const userDisplayName = useMemo(() => {
+    if (!session.isAuthenticated) {
+      return 'Estudiante';
+    }
+
+    return `Usuario #${session.uid}`;
+  }, [session]);
+
+  useEffect(() => {
+    fetch('/student/api/session', { credentials: 'include' })
+      .then((response) => response.json())
+      .then((data) => {
+        setSession(data);
+        setLoadingSession(false);
+      })
+      .catch(() => {
+        setSession(SESSION_PLACEHOLDER);
+        setLoadingSession(false);
+      });
+  }, []);
+
+  const handleLogout = () => {
+    window.location.assign('/logout');
+  };
+
+  const handleSessionJoined = () => {
+    setSessionRefreshKey((currentKey) => currentKey + 1);
+  };
+
+  return (
+    <div className="d-flex flex-column min-vh-100 bg-body-tertiary">
+      <StudentTopbar loadingSession={loadingSession} userDisplayName={userDisplayName} onLogout={handleLogout} />
+
+      <main className="container py-4 py-md-5 flex-grow-1">
+        <Outlet
+          context={{
+            loadingSession,
+            session,
+            sessionRefreshKey,
+            onSessionJoined: handleSessionJoined
+          }}
+        />
+      </main>
+    </div>
+  );
+}

--- a/ethicapp-student/frontend/src/pages/HomePage.jsx
+++ b/ethicapp-student/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,28 @@
+import { useNavigate, useOutletContext } from 'react-router-dom';
+import JoinSessionCard from '../components/JoinSessionCard.jsx';
+import SessionList from '../components/SessionList.jsx';
+
+export default function HomePage() {
+  const navigate = useNavigate();
+  const { loadingSession, session, sessionRefreshKey, onSessionJoined } = useOutletContext();
+
+  const handleSessionSelect = (sessionId) => {
+    navigate(`/sessions/${sessionId}`);
+  };
+
+  return (
+    <div className="row g-4">
+      <section className="col-12 col-xl-5">
+        <JoinSessionCard disabled={loadingSession} onJoined={onSessionJoined} />
+      </section>
+
+      <section className="col-12 col-xl-7">
+        <SessionList
+          isAuthenticated={session.isAuthenticated}
+          refreshKey={sessionRefreshKey}
+          onSessionSelect={handleSessionSelect}
+        />
+      </section>
+    </div>
+  );
+}

--- a/ethicapp-student/frontend/src/pages/NotFoundPage.jsx
+++ b/ethicapp-student/frontend/src/pages/NotFoundPage.jsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router-dom';
+
+export default function NotFoundPage() {
+  return (
+    <section className="text-center py-5">
+      <h1 className="h4">Página no encontrada</h1>
+      <p className="text-muted">La ruta que intentaste abrir no existe en el módulo de estudiante.</p>
+      <Link to="/" className="btn btn-primary btn-sm">
+        Ir al home
+      </Link>
+    </section>
+  );
+}

--- a/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
+++ b/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useOutletContext, useParams } from 'react-router-dom';
+import { formatSessionDate, sessionStatusLabel } from '../utils/sessionFormat.js';
+
+export default function SessionDetailPage() {
+  const { session, sessionRefreshKey } = useOutletContext();
+  const { sessionId } = useParams();
+  const [joinedSessions, setJoinedSessions] = useState([]);
+  const [loadingSessions, setLoadingSessions] = useState(true);
+  const [sessionsError, setSessionsError] = useState('');
+
+  useEffect(() => {
+    if (!session.isAuthenticated) {
+      setJoinedSessions([]);
+      setLoadingSessions(false);
+      setSessionsError('');
+      return;
+    }
+
+    setLoadingSessions(true);
+    setSessionsError('');
+
+    fetch('/student/api/sessions', { credentials: 'include' })
+      .then(async (response) => {
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}));
+          throw new Error(payload?.error ?? 'No se pudieron cargar los datos de la sesión');
+        }
+
+        return response.json();
+      })
+      .then((rows) => {
+        setJoinedSessions(Array.isArray(rows) ? rows : []);
+        setLoadingSessions(false);
+      })
+      .catch((error) => {
+        setSessionsError(error.message);
+        setJoinedSessions([]);
+        setLoadingSessions(false);
+      });
+  }, [session.isAuthenticated, sessionRefreshKey]);
+
+  const selectedSession = useMemo(() => {
+    const parsedSessionId = Number(sessionId);
+    return joinedSessions.find((joinedSession) => joinedSession.id === parsedSessionId) ?? null;
+  }, [joinedSessions, sessionId]);
+
+  return (
+    <section className="mx-auto" style={{ maxWidth: '860px' }}>
+      <div className="d-flex align-items-center justify-content-between mb-3">
+        <h1 className="h4 mb-0">Detalle de sesión</h1>
+        <Link to="/" className="btn btn-outline-secondary btn-sm">
+          Volver al home
+        </Link>
+      </div>
+
+      {!session.isAuthenticated ? <p className="text-muted">Inicia sesión para revisar la sesión seleccionada.</p> : null}
+
+      {loadingSessions ? <p className="text-muted">Cargando detalle...</p> : null}
+
+      {sessionsError ? (
+        <div className="alert alert-danger" role="alert">
+          {sessionsError}
+        </div>
+      ) : null}
+
+      {!loadingSessions && !sessionsError && session.isAuthenticated ? (
+        selectedSession ? (
+          <article className="card shadow-sm">
+            <div className="card-body">
+              <h2 className="h5 mb-2">{selectedSession.name ?? `Sesión #${selectedSession.id}`}</h2>
+              <p className="text-secondary mb-3">{selectedSession.descr || 'Sin descripción'}</p>
+
+              <dl className="row mb-0">
+                <dt className="col-sm-3">Estado</dt>
+                <dd className="col-sm-9">{sessionStatusLabel(selectedSession.status)}</dd>
+
+                <dt className="col-sm-3">Fecha</dt>
+                <dd className="col-sm-9">{formatSessionDate(selectedSession.time)}</dd>
+
+                <dt className="col-sm-3">Código</dt>
+                <dd className="col-sm-9">{selectedSession.code ?? 'No disponible'}</dd>
+
+                <dt className="col-sm-3">Tipo</dt>
+                <dd className="col-sm-9">{selectedSession.type ?? 'Sin tipo'}</dd>
+              </dl>
+            </div>
+          </article>
+        ) : (
+          <div className="alert alert-warning mb-0" role="alert">
+            No encontramos la sesión solicitada dentro de tus sesiones disponibles.
+          </div>
+        )
+      ) : null}
+    </section>
+  );
+}

--- a/ethicapp-student/frontend/src/router/index.jsx
+++ b/ethicapp-student/frontend/src/router/index.jsx
@@ -1,0 +1,33 @@
+import { createBrowserRouter } from 'react-router-dom';
+import StudentLayout from '../layouts/StudentLayout.jsx';
+import HomePage from '../pages/HomePage.jsx';
+import SessionDetailPage from '../pages/SessionDetailPage.jsx';
+import NotFoundPage from '../pages/NotFoundPage.jsx';
+
+const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <StudentLayout />,
+      children: [
+        {
+          index: true,
+          element: <HomePage />
+        },
+        {
+          path: 'sessions/:sessionId',
+          element: <SessionDetailPage />
+        },
+        {
+          path: '*',
+          element: <NotFoundPage />
+        }
+      ]
+    }
+  ],
+  {
+    basename: '/student'
+  }
+);
+
+export default router;

--- a/ethicapp-student/frontend/src/utils/sessionFormat.js
+++ b/ethicapp-student/frontend/src/utils/sessionFormat.js
@@ -1,0 +1,27 @@
+export function formatSessionDate(value) {
+  if (!value) {
+    return 'Sin fecha';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return 'Sin fecha';
+  }
+
+  return new Intl.DateTimeFormat('es-CL', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+export function sessionStatusLabel(status) {
+  const labels = {
+    setup: 'Configuración',
+    active: 'Activa',
+    closed: 'Cerrada',
+    archived: 'Archivada'
+  };
+
+  return labels[status] ?? status ?? 'Sin estado';
+}


### PR DESCRIPTION
### Motivation
- Alinear el frontend de `ethicapp-student` con el patrón de `auth-backend` usando un enrutador SPA basado en `createBrowserRouter` y `RouterProvider` para soportar navegación interna.
- Separar la UI en `layouts`, `pages` y `components` para mantener un `layout` persistente (topbar) y compartir estado de sesión entre páginas.
- Permitir que el estudiante abra el "home" como ruta inicial y navegue a una vista de detalle de sesión sin recargar la aplicación.

### Description
- Se añadió un enrutador SPA en `src/router/index.jsx` usando `createBrowserRouter` con `basename: '/student'` y rutas para `/`, `/sessions/:sessionId` y `*` (NotFound).
- Se creó `src/layouts/StudentLayout.jsx` que centraliza la carga de la sesión, mantiene la `StudentTopbar` y expone contexto a las páginas hijas mediante `Outlet`.
- Se añadieron páginas `src/pages/HomePage.jsx`, `src/pages/SessionDetailPage.jsx` y `src/pages/NotFoundPage.jsx`, y `src/App.jsx` ahora monta el `RouterProvider` con el nuevo `router`.
- Se refactorizó `SessionList` para aceptar `onSessionSelect` y activar la navegación a detalle, y se extrajeron utilidades de formateo a `src/utils/sessionFormat.js` para reutilización entre listado y detalle.

### Testing
- Ejecutado `cd ethicapp-student/frontend && npm run build` y la compilación de Vite terminó correctamente sin errores (build exitoso).
- Se verificó que la aplicación arranca el enrutador mediante inspección de los archivos generados y la estructura de rutas introducida (revisión automática de artefactos de build completada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9384db7f8832bb5183f4423d86c56)