### PR TITLE
feat(student): pestañas en Home y paginación para sesiones anteriores

### DIFF
--- a/ethicapp-student/frontend/src/components/SessionList.jsx
+++ b/ethicapp-student/frontend/src/components/SessionList.jsx
@@ -1,10 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { formatSessionDate, sessionStatusLabel } from '../utils/sessionFormat.js';
 
-export default function SessionList({ isAuthenticated, refreshKey, onSessionSelect }) {
+export default function SessionList({
+  isAuthenticated,
+  refreshKey,
+  onSessionSelect,
+  title = 'Mis sesiones',
+  limit,
+  enablePagination = false,
+  pageSize = 10
+}) {
   const [joinedSessions, setJoinedSessions] = useState([]);
   const [loadingSessions, setLoadingSessions] = useState(true);
   const [sessionsError, setSessionsError] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -37,10 +46,43 @@ export default function SessionList({ isAuthenticated, refreshKey, onSessionSele
       });
   }, [isAuthenticated, refreshKey]);
 
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [refreshKey, isAuthenticated, limit, enablePagination, pageSize]);
+
+  const sortedSessions = useMemo(() => {
+    return [...joinedSessions].sort((a, b) => {
+      const aTime = new Date(a?.time ?? 0).getTime();
+      const bTime = new Date(b?.time ?? 0).getTime();
+
+      if (aTime !== bTime) {
+        return bTime - aTime;
+      }
+
+      return (b?.id ?? 0) - (a?.id ?? 0);
+    });
+  }, [joinedSessions]);
+
+  const totalPages = enablePagination ? Math.max(1, Math.ceil(sortedSessions.length / pageSize)) : 1;
+  const safePage = Math.min(currentPage, totalPages);
+
+  const visibleSessions = useMemo(() => {
+    if (enablePagination) {
+      const start = (safePage - 1) * pageSize;
+      return sortedSessions.slice(start, start + pageSize);
+    }
+
+    if (Number.isInteger(limit) && limit > 0) {
+      return sortedSessions.slice(0, limit);
+    }
+
+    return sortedSessions;
+  }, [enablePagination, safePage, pageSize, sortedSessions, limit]);
+
   return (
     <div className="card h-100 shadow-sm">
       <div className="card-body">
-        <h2 className="h5 mb-3">Mis sesiones</h2>
+        <h2 className="h5 mb-3">{title}</h2>
 
         {!isAuthenticated && <p className="text-muted mb-0">Inicia sesión para ver tus sesiones previas.</p>}
 
@@ -53,9 +95,9 @@ export default function SessionList({ isAuthenticated, refreshKey, onSessionSele
         ) : null}
 
         {!loadingSessions && isAuthenticated && !sessionsError ? (
-          joinedSessions.length > 0 ? (
+          visibleSessions.length > 0 ? (
             <div className="d-flex flex-column gap-3">
-              {joinedSessions.map((joinedSession) => (
+              {visibleSessions.map((joinedSession) => (
                 <article key={joinedSession.id} className="card nested-card shadow-sm border-1">
                   <button
                     type="button"
@@ -63,13 +105,9 @@ export default function SessionList({ isAuthenticated, refreshKey, onSessionSele
                     onClick={() => onSessionSelect?.(joinedSession.id)}
                   >
                     <div className="card-body">
-                      <h3 className="h6 mb-1">
-                        {joinedSession.name ?? `Sesión #${joinedSession.id}`}
-                      </h3>
+                      <h3 className="h6 mb-1">{joinedSession.name ?? `Sesión #${joinedSession.id}`}</h3>
 
-                      <p className="mb-2 small text-secondary">
-                        {joinedSession.descr || 'Sin descripción'}
-                      </p>
+                      <p className="mb-2 small text-secondary">{joinedSession.descr || 'Sin descripción'}</p>
 
                       <div className="small text-muted d-flex flex-wrap gap-2">
                         <span>Estado: {sessionStatusLabel(joinedSession.status)}</span>
@@ -84,6 +122,46 @@ export default function SessionList({ isAuthenticated, refreshKey, onSessionSele
           ) : (
             <p className="text-muted mb-0">Aún no te has unido a ninguna sesión.</p>
           )
+        ) : null}
+
+        {!loadingSessions && isAuthenticated && !sessionsError && enablePagination && totalPages > 1 ? (
+          <nav aria-label="Paginación de sesiones" className="mt-4 d-flex justify-content-end">
+            <ul className="pagination pagination-sm mb-0">
+              <li className={`page-item ${safePage === 1 ? 'disabled' : ''}`}>
+                <button
+                  type="button"
+                  className="page-link"
+                  onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                  aria-label="Página anterior"
+                >
+                  Anterior
+                </button>
+              </li>
+
+              {Array.from({ length: totalPages }, (_, index) => {
+                const pageNumber = index + 1;
+
+                return (
+                  <li key={pageNumber} className={`page-item ${safePage === pageNumber ? 'active' : ''}`}>
+                    <button type="button" className="page-link" onClick={() => setCurrentPage(pageNumber)}>
+                      {pageNumber}
+                    </button>
+                  </li>
+                );
+              })}
+
+              <li className={`page-item ${safePage === totalPages ? 'disabled' : ''}`}>
+                <button
+                  type="button"
+                  className="page-link"
+                  onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                  aria-label="Página siguiente"
+                >
+                  Siguiente
+                </button>
+              </li>
+            </ul>
+          </nav>
         ) : null}
       </div>
     </div>

--- a/ethicapp-student/frontend/src/pages/HomePage.jsx
+++ b/ethicapp-student/frontend/src/pages/HomePage.jsx
@@ -1,28 +1,75 @@
+import { useState } from 'react';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import JoinSessionCard from '../components/JoinSessionCard.jsx';
 import SessionList from '../components/SessionList.jsx';
 
+const TABS = {
+  JOIN: 'join-session',
+  PREVIOUS: 'previous-sessions'
+};
+
 export default function HomePage() {
   const navigate = useNavigate();
   const { loadingSession, session, sessionRefreshKey, onSessionJoined } = useOutletContext();
+  const [activeTab, setActiveTab] = useState(TABS.JOIN);
 
   const handleSessionSelect = (sessionId) => {
     navigate(`/sessions/${sessionId}`);
   };
 
   return (
-    <div className="row g-4">
-      <section className="col-12 col-xl-5">
-        <JoinSessionCard disabled={loadingSession} onJoined={onSessionJoined} />
-      </section>
+    <div className="d-flex flex-column gap-4">
+      <nav>
+        <div className="nav nav-tabs" role="tablist" aria-label="Navegación de sesiones">
+          <button
+            type="button"
+            className={`nav-link ${activeTab === TABS.JOIN ? 'active' : ''}`}
+            role="tab"
+            aria-selected={activeTab === TABS.JOIN}
+            onClick={() => setActiveTab(TABS.JOIN)}
+          >
+            Ingresar a Sesión
+          </button>
+          <button
+            type="button"
+            className={`nav-link ${activeTab === TABS.PREVIOUS ? 'active' : ''}`}
+            role="tab"
+            aria-selected={activeTab === TABS.PREVIOUS}
+            onClick={() => setActiveTab(TABS.PREVIOUS)}
+          >
+            Sesiones Anteriores
+          </button>
+        </div>
+      </nav>
 
-      <section className="col-12 col-xl-7">
-        <SessionList
-          isAuthenticated={session.isAuthenticated}
-          refreshKey={sessionRefreshKey}
-          onSessionSelect={handleSessionSelect}
-        />
-      </section>
+      {activeTab === TABS.JOIN ? (
+        <div className="row g-4">
+          <section className="col-12">
+            <JoinSessionCard disabled={loadingSession} onJoined={onSessionJoined} />
+          </section>
+
+          <section className="col-12">
+            <SessionList
+              title="Sesiones recientes"
+              isAuthenticated={session.isAuthenticated}
+              refreshKey={sessionRefreshKey}
+              onSessionSelect={handleSessionSelect}
+              limit={2}
+            />
+          </section>
+        </div>
+      ) : (
+        <section>
+          <SessionList
+            title="Sesiones anteriores"
+            isAuthenticated={session.isAuthenticated}
+            refreshKey={sessionRefreshKey}
+            onSessionSelect={handleSessionSelect}
+            enablePagination
+            pageSize={10}
+          />
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia en la página principal del estudiante permitiendo alternar entre la acción de unirse a una sesión y la exploración de sesiones previas.
- Mostrar el formulario de ingreso (`JoinSessionCard`) y solo las dos sesiones más recientes en la vista de ingreso para reducir ruido visual.
- Permitir ver las sesiones anteriores ordenadas de más reciente a menos reciente y navegarlas con paginación de 10 por página.

### Description
- Se añadió navegación por pestañas en `src/pages/HomePage.jsx` con dos pestañas: `Ingresar a Sesión` y `Sesiones Anteriores`, controladas por estado local y con títulos apropiados.
- `SessionList` (`src/components/SessionList.jsx`) se generalizó con props: `title`, `limit`, `enablePagination` y `pageSize` para soportar lista limitada y paginada.
- `SessionList` ahora ordena las sesiones por `time` descendente (con desempate por `id` descendente), calcula páginas y muestra controles de paginación (Anterior / Siguiente y selector de página).
- Se reinicia la página activa cuando cambia la autenticación, `refreshKey` o la configuración de paginación/limit para mantener consistencia.

### Testing
- Ejecuté `cd ethicapp-student/frontend && npm run build` y la compilación de producción de Vite completó correctamente sin errores.
- No se ejecutaron pruebas unitarias automatizadas adicionales en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5c81814c832b893785b23139d248)