### PR TITLE
feat(student): migrate fetch to axios with configurable API base path

### DIFF
--- a/ethicapp-student/README.md
+++ b/ethicapp-student/README.md
@@ -16,6 +16,12 @@ npm install
 npm run dev
 ```
 
+## Configuración frontend
+
+- `VITE_STUDENT_API_BASE_PATH`: prefijo base para los requests del frontend al backend.
+  - Valor por defecto: `/student/api/`
+  - Se normaliza automáticamente para usar `/` inicial y final.
+
 ## Producción
 
 ```bash

--- a/ethicapp-student/frontend/package-lock.json
+++ b/ethicapp-student/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
+        "axios": "^1.15.2",
         "bootstrap": "^5.3.8",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -711,6 +712,23 @@
         }
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/bootstrap": {
       "version": "5.3.8",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
@@ -728,6 +746,19 @@
       "license": "MIT",
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/chokidar": {
@@ -754,6 +785,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -767,6 +810,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -775,6 +827,65 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/fdir": {
@@ -795,6 +906,42 @@
         }
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -810,6 +957,64 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -818,6 +1023,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/immutable": {
@@ -1113,6 +1357,36 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1187,6 +1461,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react": {

--- a/ethicapp-student/frontend/package.json
+++ b/ethicapp-student/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
+    "axios": "^1.15.2",
     "bootstrap": "^5.3.8",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/ethicapp-student/frontend/src/api/studentApi.js
+++ b/ethicapp-student/frontend/src/api/studentApi.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import { studentApiBasePath } from '../config/env.js';
+
+const studentApi = axios.create({
+  baseURL: studentApiBasePath,
+  withCredentials: true
+});
+
+export { studentApi };

--- a/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
+++ b/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
@@ -1,4 +1,6 @@
+import axios from 'axios';
 import { useState } from 'react';
+import { studentApi } from '../api/studentApi.js';
 
 export default function JoinSessionCard({ disabled, onJoined }) {
   const [joinCode, setJoinCode] = useState('');
@@ -18,29 +20,20 @@ export default function JoinSessionCard({ disabled, onJoined }) {
     setJoinFeedback(null);
 
     try {
-      const response = await fetch('/student/api/sessions/join', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          code: normalizedCode,
-          device: 'web'
-        })
+      await studentApi.post('sessions/join', {
+        code: normalizedCode,
+        device: 'web'
       });
-
-      const payload = await response.json().catch(() => ({}));
-
-      if (!response.ok) {
-        throw new Error(payload?.error ?? 'No fue posible unirse a la sesión');
-      }
 
       setJoinFeedback({ type: 'success', message: 'Te uniste a la sesión correctamente.' });
       setJoinCode('');
       onJoined();
     } catch (error) {
-      setJoinFeedback({ type: 'danger', message: error.message });
+      const message = axios.isAxiosError(error)
+        ? (error.response?.data?.error ?? 'No fue posible unirse a la sesión')
+        : 'No fue posible unirse a la sesión';
+
+      setJoinFeedback({ type: 'danger', message });
     } finally {
       setJoinBusy(false);
     }

--- a/ethicapp-student/frontend/src/components/SessionList.jsx
+++ b/ethicapp-student/frontend/src/components/SessionList.jsx
@@ -1,4 +1,6 @@
+import axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
+import { studentApi } from '../api/studentApi.js';
 import { formatSessionDate, sessionStatusLabel } from '../utils/sessionFormat.js';
 
 export default function SessionList({
@@ -26,21 +28,18 @@ export default function SessionList({
     setLoadingSessions(true);
     setSessionsError('');
 
-    fetch('/student/api/sessions', { credentials: 'include' })
-      .then(async (response) => {
-        if (!response.ok) {
-          const payload = await response.json().catch(() => ({}));
-          throw new Error(payload?.error ?? 'No se pudieron cargar las sesiones');
-        }
-
-        return response.json();
-      })
-      .then((rows) => {
-        setJoinedSessions(Array.isArray(rows) ? rows : []);
+    studentApi
+      .get('sessions')
+      .then(({ data }) => {
+        setJoinedSessions(Array.isArray(data) ? data : []);
         setLoadingSessions(false);
       })
       .catch((error) => {
-        setSessionsError(error.message);
+        const message = axios.isAxiosError(error)
+          ? (error.response?.data?.error ?? 'No se pudieron cargar las sesiones')
+          : 'No se pudieron cargar las sesiones';
+
+        setSessionsError(message);
         setJoinedSessions([]);
         setLoadingSessions(false);
       });

--- a/ethicapp-student/frontend/src/config/env.js
+++ b/ethicapp-student/frontend/src/config/env.js
@@ -1,0 +1,15 @@
+function ensureLeadingSlash(value) {
+  return value.startsWith('/') ? value : `/${value}`;
+}
+
+function ensureTrailingSlash(value) {
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+const viteStudentApiBasePath = (import.meta.env.VITE_STUDENT_API_BASE_PATH || '').trim();
+
+const studentApiBasePath = viteStudentApiBasePath
+  ? ensureTrailingSlash(ensureLeadingSlash(viteStudentApiBasePath))
+  : '/student/api/';
+
+export { studentApiBasePath };

--- a/ethicapp-student/frontend/src/layouts/StudentLayout.jsx
+++ b/ethicapp-student/frontend/src/layouts/StudentLayout.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Outlet } from 'react-router-dom';
+import { studentApi } from '../api/studentApi.js';
 import StudentTopbar from '../components/StudentTopbar.jsx';
 
 const SESSION_PLACEHOLDER = {
@@ -22,9 +23,9 @@ export default function StudentLayout() {
   }, [session]);
 
   useEffect(() => {
-    fetch('/student/api/session', { credentials: 'include' })
-      .then((response) => response.json())
-      .then((data) => {
+    studentApi
+      .get('session')
+      .then(({ data }) => {
         setSession(data);
         setLoadingSession(false);
       })

--- a/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
+++ b/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
@@ -1,5 +1,7 @@
+import axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useOutletContext, useParams } from 'react-router-dom';
+import { studentApi } from '../api/studentApi.js';
 import { formatSessionDate, sessionStatusLabel } from '../utils/sessionFormat.js';
 
 export default function SessionDetailPage() {
@@ -20,21 +22,18 @@ export default function SessionDetailPage() {
     setLoadingSessions(true);
     setSessionsError('');
 
-    fetch('/student/api/sessions', { credentials: 'include' })
-      .then(async (response) => {
-        if (!response.ok) {
-          const payload = await response.json().catch(() => ({}));
-          throw new Error(payload?.error ?? 'No se pudieron cargar los datos de la sesión');
-        }
-
-        return response.json();
-      })
-      .then((rows) => {
-        setJoinedSessions(Array.isArray(rows) ? rows : []);
+    studentApi
+      .get('sessions')
+      .then(({ data }) => {
+        setJoinedSessions(Array.isArray(data) ? data : []);
         setLoadingSessions(false);
       })
       .catch((error) => {
-        setSessionsError(error.message);
+        const message = axios.isAxiosError(error)
+          ? (error.response?.data?.error ?? 'No se pudieron cargar los datos de la sesión')
+          : 'No se pudieron cargar los datos de la sesión';
+
+        setSessionsError(message);
         setJoinedSessions([]);
         setLoadingSessions(false);
       });


### PR DESCRIPTION
### Motivation
- Reemplazar usos directos de `fetch` por un cliente HTTP centralizado para manejar credenciales y errores de forma consistente. 
- Hacer la ruta base de las llamadas al backend configurable por entorno para soportar despliegues con prefijos diferentes.

### Description
- Añadido `ethicapp-student/frontend/src/config/env.js` que expone `studentApiBasePath` configurable desde `VITE_STUDENT_API_BASE_PATH` y normaliza barras inicial/final, con `'/student/api/'` como valor por defecto. 
- Creado `ethicapp-student/frontend/src/api/studentApi.js` que exporta un cliente `axios` (`studentApi`) configurado con `baseURL: studentApiBasePath` y `withCredentials: true`.
- Reemplazados los `fetch` en `JoinSessionCard.jsx`, `SessionList.jsx`, `StudentLayout.jsx` y `SessionDetailPage.jsx` para usar el cliente `studentApi` y adaptar el manejo de errores a `axios`. 
- Actualizado `ethicapp-student/frontend/package.json` y `package-lock.json` para incluir la dependencia `axios` y documentada la nueva variable en `ethicapp-student/README.md`.

### Testing
- Ejecutado `cd ethicapp-student/frontend && npm run build`, que falló en este entorno por ausencia de `vite` instalado localmente y limitaciones del entorno, por lo que la compilación no pudo validarse aquí. 
- Intentado `npm install` y operaciones de instalación de `axios` en el entorno, las cuales estuvieron limitadas por la política/red del entorno; se actualizó el `package-lock.json` con la entrada de `axios` mediante instalación de bloqueo de paquete (`--package-lock-only`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6c015dc4832b81a0f7d778fb6eae)