### PR TITLE
feat(student): recuperar y mostrar perfil del estudiante autenticado en topbar

### DIFF
--- a/ethicapp-student/frontend/src/App.jsx
+++ b/ethicapp-student/frontend/src/App.jsx
@@ -1,6 +1,11 @@
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
+import { StudentUserProvider } from './context/StudentUserContext.jsx';
 
 export default function App() {
-  return <RouterProvider router={router} />;
+  return (
+    <StudentUserProvider>
+      <RouterProvider router={router} />
+    </StudentUserProvider>
+  );
 }

--- a/ethicapp-student/frontend/src/api/studentApi.js
+++ b/ethicapp-student/frontend/src/api/studentApi.js
@@ -6,4 +6,8 @@ const studentApi = axios.create({
   withCredentials: true
 });
 
-export { studentApi };
+const legacyUserApi = axios.create({
+  withCredentials: true
+});
+
+export { studentApi, legacyUserApi };

--- a/ethicapp-student/frontend/src/context/StudentUserContext.jsx
+++ b/ethicapp-student/frontend/src/context/StudentUserContext.jsx
@@ -1,0 +1,66 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { legacyUserApi } from '../api/studentApi.js';
+
+const StudentUserContext = createContext(null);
+
+const USER_PLACEHOLDER = {
+  id: null,
+  firstname: '',
+  lastname: '',
+  name: '',
+  email: ''
+};
+
+function StudentUserProvider({ children }) {
+  const [user, setUser] = useState(USER_PLACEHOLDER);
+  const [loadingUser, setLoadingUser] = useState(false);
+
+  const refreshUser = useCallback(async () => {
+    setLoadingUser(true);
+
+    try {
+      const { data } = await legacyUserApi.get('/users/myinfo');
+      const userData = data?.data ?? USER_PLACEHOLDER;
+      setUser({
+        id: userData.id ?? null,
+        firstname: userData.firstname ?? '',
+        lastname: userData.lastname ?? '',
+        name: userData.name ?? '',
+        email: userData.email ?? ''
+      });
+    } catch (_error) {
+      setUser(USER_PLACEHOLDER);
+    } finally {
+      setLoadingUser(false);
+    }
+  }, []);
+
+  const clearUser = useCallback(() => {
+    setUser(USER_PLACEHOLDER);
+    setLoadingUser(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      loadingUser,
+      refreshUser,
+      clearUser
+    }),
+    [user, loadingUser, refreshUser, clearUser]
+  );
+
+  return <StudentUserContext.Provider value={value}>{children}</StudentUserContext.Provider>;
+}
+
+function useStudentUser() {
+  const context = useContext(StudentUserContext);
+
+  if (!context) {
+    throw new Error('useStudentUser must be used within StudentUserProvider');
+  }
+
+  return context;
+}
+
+export { StudentUserProvider, useStudentUser };

--- a/ethicapp-student/frontend/src/layouts/StudentLayout.jsx
+++ b/ethicapp-student/frontend/src/layouts/StudentLayout.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import { studentApi } from '../api/studentApi.js';
 import StudentTopbar from '../components/StudentTopbar.jsx';
+import { useStudentUser } from '../context/StudentUserContext.jsx';
 
 const SESSION_PLACEHOLDER = {
   isAuthenticated: false,
@@ -13,27 +14,44 @@ export default function StudentLayout() {
   const [session, setSession] = useState(SESSION_PLACEHOLDER);
   const [loadingSession, setLoadingSession] = useState(true);
   const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
+  const { user, loadingUser, refreshUser, clearUser } = useStudentUser();
 
   const userDisplayName = useMemo(() => {
     if (!session.isAuthenticated) {
       return 'Estudiante';
     }
 
+    const fullName = [user.firstname, user.lastname].filter(Boolean).join(' ').trim();
+
+    if (fullName) {
+      return fullName;
+    }
+
+    if (user.name) {
+      return user.name;
+    }
+
     return `Usuario #${session.uid}`;
-  }, [session]);
+  }, [session, user]);
 
   useEffect(() => {
     studentApi
       .get('session')
       .then(({ data }) => {
         setSession(data);
+        if (data?.isAuthenticated) {
+          refreshUser();
+        } else {
+          clearUser();
+        }
         setLoadingSession(false);
       })
       .catch(() => {
         setSession(SESSION_PLACEHOLDER);
+        clearUser();
         setLoadingSession(false);
       });
-  }, []);
+  }, [clearUser, refreshUser]);
 
   const handleLogout = () => {
     window.location.assign('/logout');
@@ -45,7 +63,11 @@ export default function StudentLayout() {
 
   return (
     <div className="d-flex flex-column min-vh-100 bg-body-tertiary">
-      <StudentTopbar loadingSession={loadingSession} userDisplayName={userDisplayName} onLogout={handleLogout} />
+      <StudentTopbar
+        loadingSession={loadingSession || loadingUser}
+        userDisplayName={userDisplayName}
+        onLogout={handleLogout}
+      />
 
       <main className="container py-4 py-md-5 flex-grow-1">
         <Outlet

--- a/ethicapp/backend/controllers/users/users-core.js
+++ b/ethicapp/backend/controllers/users/users-core.js
@@ -413,6 +413,8 @@ router.get("/users/myinfo", async (req, res) => {
                 SELECT 
                     u.id, 
                     u.name, 
+                    u.firstname,
+                    u.lastname,
                     u.mail as email
                 FROM users u
                 WHERE u.id = $1


### PR DESCRIPTION
### Motivation
- Mantener la información básica del estudiante disponible en toda la app para simplificar UX y evitar llamadas repetidas al backend. 
- El endpoint `GET /users/myinfo` debe exponer `firstname` y `lastname` además del `name` legado para permitir mostrar nombre y apellido por separado. 
- La topbar del estudiante debe mostrar nombre y apellido cuando estén disponibles, con fallback a `name` o al identificador.

### Description
- Se extendió `GET /users/myinfo` para incluir `firstname` y `lastname` en la respuesta (archivo `ethicapp/backend/controllers/users/users-core.js`).
- Se añadió un contexto global `StudentUserProvider` que expone `user`, `loadingUser`, `refreshUser` y `clearUser` para mantener el perfil del estudiante en `ethicapp-student/frontend/src/context/StudentUserContext.jsx`.
- Se creó un cliente axios `legacyUserApi` para consultar endpoints en raíz y no romper `studentApi` con base `/student/api/` (`ethicapp-student/frontend/src/api/studentApi.js`).
- La app de estudiante ahora se envuelve con `StudentUserProvider` (`ethicapp-student/frontend/src/App.jsx`) y `StudentLayout` solicita `/users/myinfo` tras validar la sesión, además actualiza la lógica de `userDisplayName` para priorizar `firstname + lastname`, luego `name` y finalmente `Usuario #uid` (`ethicapp-student/frontend/src/layouts/StudentLayout.jsx`).

### Testing
- Se intentó construir el frontend con `npm --prefix ethicapp-student/frontend run build` pero falló en este entorno por falta de la herramienta `vite` (`vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea92a2285c832b80bea3aacd7c8b3f)