### PR TITLE
Cargar `full_state` en cliente estudiante y corregir bugs en helpers/backend

### DIFF
--- a/ethicapp-student/frontend/src/App.jsx
+++ b/ethicapp-student/frontend/src/App.jsx
@@ -1,11 +1,14 @@
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
 import { StudentUserProvider } from './context/StudentUserContext.jsx';
+import { StudentActivityStateProvider } from './context/StudentActivityStateContext.jsx';
 
 export default function App() {
   return (
     <StudentUserProvider>
-      <RouterProvider router={router} />
+      <StudentActivityStateProvider>
+        <RouterProvider router={router} />
+      </StudentActivityStateProvider>
     </StudentUserProvider>
   );
 }

--- a/ethicapp-student/frontend/src/context/StudentActivityStateContext.jsx
+++ b/ethicapp-student/frontend/src/context/StudentActivityStateContext.jsx
@@ -1,0 +1,76 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import axios from 'axios';
+import { legacyUserApi } from '../api/studentApi.js';
+
+const StudentActivityStateContext = createContext(null);
+
+export function StudentActivityStateProvider({ children }) {
+  const [stateBySession, setStateBySession] = useState({});
+  const [loadingBySession, setLoadingBySession] = useState({});
+  const [errorBySession, setErrorBySession] = useState({});
+
+  const loadFullState = useCallback(async ({ sessionId, userId, invalidate = false }) => {
+    const parsedSessionId = Number(sessionId);
+    const parsedUserId = Number(userId);
+
+    if (!Number.isInteger(parsedSessionId) || parsedSessionId <= 0) {
+      throw new Error('sessionId inválido');
+    }
+
+    if (!Number.isInteger(parsedUserId) || parsedUserId <= 0) {
+      throw new Error('userId inválido');
+    }
+
+    setLoadingBySession((prev) => ({ ...prev, [parsedSessionId]: true }));
+    setErrorBySession((prev) => ({ ...prev, [parsedSessionId]: '' }));
+
+    try {
+      const { data } = await legacyUserApi.get(
+        `/activities/${parsedSessionId}/users/${parsedUserId}/full_state`,
+        {
+          params: {
+            invalidate
+          }
+        }
+      );
+
+      const fullState = data?.state ?? null;
+
+      setStateBySession((prev) => ({ ...prev, [parsedSessionId]: fullState }));
+      setLoadingBySession((prev) => ({ ...prev, [parsedSessionId]: false }));
+
+      return fullState;
+    } catch (error) {
+      const message = axios.isAxiosError(error)
+        ? (error.response?.data?.error ?? 'No se pudo cargar el estado completo de la actividad')
+        : 'No se pudo cargar el estado completo de la actividad';
+
+      setStateBySession((prev) => ({ ...prev, [parsedSessionId]: null }));
+      setErrorBySession((prev) => ({ ...prev, [parsedSessionId]: message }));
+      setLoadingBySession((prev) => ({ ...prev, [parsedSessionId]: false }));
+      throw error;
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      stateBySession,
+      loadingBySession,
+      errorBySession,
+      loadFullState
+    }),
+    [errorBySession, loadFullState, loadingBySession, stateBySession]
+  );
+
+  return <StudentActivityStateContext.Provider value={value}>{children}</StudentActivityStateContext.Provider>;
+}
+
+export function useStudentActivityState() {
+  const context = useContext(StudentActivityStateContext);
+
+  if (!context) {
+    throw new Error('useStudentActivityState debe usarse dentro de StudentActivityStateProvider');
+  }
+
+  return context;
+}

--- a/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
+++ b/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useOutletContext, useParams } from 'react-router-dom';
 import { studentApi } from '../api/studentApi.js';
+import { useStudentActivityState } from '../context/StudentActivityStateContext.jsx';
 import { formatSessionDate, sessionStatusLabel } from '../utils/sessionFormat.js';
 
 export default function SessionDetailPage() {
@@ -10,6 +11,7 @@ export default function SessionDetailPage() {
   const [joinedSessions, setJoinedSessions] = useState([]);
   const [loadingSessions, setLoadingSessions] = useState(true);
   const [sessionsError, setSessionsError] = useState('');
+  const { stateBySession, loadingBySession, errorBySession, loadFullState } = useStudentActivityState();
 
   useEffect(() => {
     if (!session.isAuthenticated) {
@@ -43,6 +45,30 @@ export default function SessionDetailPage() {
     const parsedSessionId = Number(sessionId);
     return joinedSessions.find((joinedSession) => joinedSession.id === parsedSessionId) ?? null;
   }, [joinedSessions, sessionId]);
+
+  const selectedSessionId = Number(sessionId);
+  const activityState = stateBySession[selectedSessionId] ?? null;
+  const loadingActivityState = loadingBySession[selectedSessionId] ?? false;
+  const activityStateError = errorBySession[selectedSessionId] ?? '';
+
+  useEffect(() => {
+    if (!session.isAuthenticated || !selectedSession || !session.uid) {
+      return;
+    }
+
+    loadFullState({
+      sessionId: selectedSession.id,
+      userId: session.uid
+    }).catch(() => {
+      // El error ya queda reflejado en el contexto.
+    });
+  }, [loadFullState, selectedSession, session.isAuthenticated, session.uid]);
+
+  const phaseTabs = useMemo(() => {
+    return Array.isArray(activityState?.phases) ? activityState.phases : [];
+  }, [activityState]);
+
+  const currentPhaseNumber = activityState?.descriptor?.currentPhaseNumber ?? null;
 
   return (
     <section className="mx-auto" style={{ maxWidth: '860px' }}>
@@ -83,6 +109,33 @@ export default function SessionDetailPage() {
                 <dt className="col-sm-3">Tipo</dt>
                 <dd className="col-sm-9">{selectedSession.type ?? 'Sin tipo'}</dd>
               </dl>
+
+              {loadingActivityState ? <p className="text-muted mt-3 mb-0">Cargando estado completo de la actividad...</p> : null}
+
+              {activityStateError ? (
+                <div className="alert alert-warning mt-3 mb-0" role="alert">
+                  {activityStateError}
+                </div>
+              ) : null}
+
+              {!loadingActivityState && !activityStateError && phaseTabs.length > 0 ? (
+                <section className="mt-4" aria-label="Fases de la actividad">
+                  <h3 className="h6 mb-2">Fases</h3>
+                  <div className="d-flex gap-2 flex-wrap">
+                    {phaseTabs.map((phase) => {
+                      const isCurrent = Number(phase.number) === Number(currentPhaseNumber);
+                      return (
+                        <span
+                          key={phase.id ?? phase.number}
+                          className={`phase-pill ${isCurrent ? 'phase-pill--current' : 'phase-pill--inactive'}`}
+                        >
+                          Fase {phase.number}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </section>
+              ) : null}
             </div>
           </article>
         ) : (

--- a/ethicapp-student/frontend/src/styles/student.scss
+++ b/ethicapp-student/frontend/src/styles/student.scss
@@ -10,3 +10,26 @@
   box-shadow: 0 .5rem 1rem rgba(0,0,0,.1);
   cursor: pointer;
 }
+
+.phase-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.875rem;
+  background: #fff;
+}
+
+.phase-pill--current {
+  border-color: #198754;
+  color: #198754;
+  font-weight: 600;
+}
+
+.phase-pill--inactive {
+  border-color: #fd7e14;
+  color: #b35a00;
+}

--- a/ethicapp/backend/controllers/activities.js
+++ b/ethicapp/backend/controllers/activities.js
@@ -751,7 +751,7 @@ router.get('/activities/:id/users/:user_id/full_state', async (req, res) => {
     try {
         // Step 1: Get the descriptor
         const { descriptor } = await StudentActivityStatusHelper.
-            getCachedStudentActivityDescriptor(sessionId);
+            getCachedStudentActivityDescriptor(sessionId, invalidate);
 
         if (!descriptor || !descriptor.design) {
             return res.status(404).json({ error: 'Descriptor not found for the given session.' });
@@ -759,14 +759,14 @@ router.get('/activities/:id/users/:user_id/full_state', async (req, res) => {
 
         // Step 2: Get the phases
         const { phases } = await StudentActivityStatusHelper.
-            getCachedStudentActivityPhases(sessionId);
+            getCachedStudentActivityPhases(sessionId, invalidate);
 
         if (!phases || phases.length === 0) {
             return res.status(404).json({ error: 'No phases found for the given session.' });
         }
 
         // Step 3: Determine design type
-        const designType = StudentActivityStatusHelper.
+        const designType = descriptor?.design?.type || await StudentActivityStatusHelper.
             getDesignTypeBySessionId(sessionId);
 
         if (!designType) {
@@ -778,7 +778,8 @@ router.get('/activities/:id/users/:user_id/full_state', async (req, res) => {
             getCachedStudentActivityTasks(
                 designType,
                 sessionId,
-                phases
+                phases,
+                invalidate
             );
 
         // Step 5: Get responses for each phase
@@ -787,7 +788,8 @@ router.get('/activities/:id/users/:user_id/full_state', async (req, res) => {
                 designType, 
                 sessionId,
                 userId,
-                phasesWithTasks
+                phasesWithTasks,
+                invalidate
             );
             
         // Step 6: Get peer responses for each phase
@@ -796,23 +798,27 @@ router.get('/activities/:id/users/:user_id/full_state', async (req, res) => {
                 designType,
                 sessionId,
                 userId,
-                phasesWithResponses
+                phasesWithResponses,
+                invalidate
             );
 
         // Step 7: Get groups and integrate into phases
-        await StudentActivityStatusHelper.getCachedStudentActivityGroups(
+        const phasesWithGroups = await StudentActivityStatusHelper.getCachedStudentActivityGroups(
             sessionId,
             userId,
-            phasesWithPeerResponses
+            phasesWithPeerResponses,
+            invalidate
         );
 
-            // Step 8: Get group messages
+        // Step 8: Get group messages
         const phasesWithGroupMessages = await StudentActivityStatusHelper.
             getCachedStudentActivityGroupMessages(
                 designType,
                 sessionId,
-                phasesWithPeerResponses,
-                groupId);
+                userId,
+                phasesWithGroups,
+                invalidate
+            );
 
         // Step 9: Assemble the state object
         const state = {

--- a/ethicapp/backend/helpers/student-activity-state-helper.js
+++ b/ethicapp/backend/helpers/student-activity-state-helper.js
@@ -84,13 +84,15 @@ export async function getStudentActivityDescriptor(sessionId) {
         const descriptorQuery = `
             SELECT 
                 s.descr AS description,
-                a.design AS design,
+                d.design AS design,
                 st.number AS currentphasenumber,
                 st.id AS currentphaseid
             FROM 
                 sessions s
             JOIN 
                 activity a ON s.id = a.session
+            JOIN
+                designs d ON d.id = a.design
             JOIN 
                 stages st ON st.id = s.current_stage
             WHERE 
@@ -186,7 +188,7 @@ export async function getStudentActivityPhases(sessionId) {
         // Query to get the phases
         const phasesQuery = `
             SELECT
-                st.id
+                st.id,
                 st.number, 
                 st.type AS mode, 
                 st.anon, 
@@ -609,10 +611,10 @@ export async function getStudentActivityTasks_ranking(sessionId, phases) {
             }
 
             tasksByPhase[actor.phase_number].push({
-                id: actor.actor_id,
-                name: actor.actor_name,
-                isOrdered: actor.is_ordered,
-                requiresJustification: actor.requires_justification,
+                id: actor.item_id,
+                name: actor.item_name,
+                justifyOrder: actor.justify_order,
+                requiresJustification: actor.justify_item,
                 minWordCount: actor.min_word_count,
             });
         });
@@ -1163,6 +1165,52 @@ export async function getStudentActivityGroupMessages(designType, sessionId, gro
     } catch (error) {
         console.error(`Failed to get group messages for design type ${designType}:`, error);
         return phases;
+    }
+}
+
+export async function getDesignTypeBySessionId(sessionId) {
+    if (!sessionId || isNaN(Number(sessionId))) {
+        console.error("Invalid sessionId:", sessionId);
+        return null;
+    }
+
+    const cacheKey = `session:${sessionId}:design_type`;
+
+    try {
+        const cachedDesignType = await redisClient.get(cacheKey);
+        if (cachedDesignType) {
+            return cachedDesignType;
+        }
+
+        const result = await rpg2.execSQL({
+            dbcon: config.dbconnString,
+            sql: `
+                SELECT d.design AS design
+                FROM activity a
+                JOIN designs d ON d.id = a.design
+                WHERE a.session = $1
+                ORDER BY a.id DESC
+                LIMIT 1;
+            `,
+            sqlParams: [rpg2.param('plain', Number(sessionId))],
+        });
+
+        if (!Array.isArray(result) || result.length === 0) {
+            return null;
+        }
+
+        const designValue = result[0].design;
+        const design = typeof designValue === "string" ? JSON.parse(designValue) : designValue;
+        const designType = design?.type ?? null;
+
+        if (designType) {
+            await redisClient.set(cacheKey, designType, { EX: 3600 });
+        }
+
+        return designType;
+    } catch (error) {
+        console.error(`Unable to determine design type for sessionId ${sessionId}:`, error);
+        return null;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Habilitar que al entrar a una sesión el cliente estudiante cargue el estado consolidado (`full_state`) que el backend mantiene en Redis para rehidratar la UI por fases.
- Corregir errores y casos frágiles en los helpers y en el endpoint `GET /activities/:id/users/:user_id/full_state` que podían provocar fallos en tiempo de ejecución (variables indefinidas, SQL mal formado, mapeos de columnas inconsistentes).
- Proveer una arquitectura reutilizable en el frontend para exponer el `full_state` a futuros componentes de la interfaz.

### Description
- Backend: `ethicapp/backend/helpers/student-activity-state-helper.js`
  - `getStudentActivityDescriptor` ahora obtiene `designs.design` (JSON) y devuelve `descriptor.design` para poder leer `descriptor.design.type`.
  - Corrige un `SELECT` que omitía una coma en `getStudentActivityPhases` y normaliza el mapa de columnas en `getStudentActivityTasks_ranking` (aliases consistentes: `item_id`, `item_name`, `justify_order`, `justify_item`).
  - Agrega `getDesignTypeBySessionId(sessionId)` con cache en Redis como fallback para determinar `design.type` cuando no está en el descriptor.
- Backend: `ethicapp/backend/controllers/activities.js`
  - `full_state` ahora propaga el parámetro `invalidate` a todos los helpers cacheados, evita uso de la variable indefinida `groupId`, encadena correctamente la salida de grupos hacia la obtención de mensajes y usa `descriptor.design.type` con fallback a `getDesignTypeBySessionId`.
- Frontend (ethicapp-student):
  - Nuevo contexto `StudentActivityStateContext` (`frontend/src/context/StudentActivityStateContext.jsx`) que centraliza carga/estado/error de `full_state` por sesión y expone `loadFullState`.
  - `App.jsx` envuelve la aplicación con `StudentActivityStateProvider` para hacerlo accesible globalmente.
  - `SessionDetailPage.jsx` llama `loadFullState` al entrar a una sesión, consume el `state` y renderiza las fases como pills/tabs "Fase 1..N"; la fase actual (`descriptor.currentPhaseNumber`) se muestra con borde y texto verde, las demás con borde anaranjado.
  - Estilos añadidos en `frontend/src/styles/student.scss` con clases `phase-pill`, `phase-pill--current` y `phase-pill--inactive`.

### Testing
- Ejecutado `node --check` sobre los controladores y helpers del backend (`ethicapp/backend/controllers/activities.js` y `ethicapp/backend/helpers/student-activity-state-helper.js`) y ambos pasaron la comprobación de sintaxis.
- Intenté comprobar sintaxis de archivos frontend con `node --check` incluyendo archivos `.jsx`, pero `node` falló por `ERR_UNKNOWN_FILE_EXTENSION` al procesar `.jsx` en este entorno, por lo que no se completó una verificación estática de los módulos React.
- Intenté `npm run build` en `ethicapp-student/frontend` pero falló por entorno (`vite` no disponible): `sh: 1: vite: not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea96b34378832b9693eb543e8e72b9)