### PR TITLE
Fix Redis SET TTL arguments in activity cache helpers

### DIFF
--- a/ethicapp/backend/helpers/student-activity-state-helper.js
+++ b/ethicapp/backend/helpers/student-activity-state-helper.js
@@ -403,9 +403,7 @@ export async function getCachedStudentActivityTasks(designType, sessionId, phase
         }, {});
 
         // Cache the result in Redis
-        await redisClient.set(cacheKey, JSON.stringify(tasksByPhase), {
-            EX: 300, // Expiration: 5 minutes
-        });
+        await redisClient.set(cacheKey, JSON.stringify(tasksByPhase), 'EX', 300); // Expiration: 5 minutes
 
         return updatedPhases;
     } catch (error) {
@@ -669,9 +667,7 @@ export async function getCachedStudentActivityResponses(designType, sessionId, u
         const responsesByPhase = await studentActivityResponseGetters[designType](sessionId, userId, phases);
 
         // Cache the result
-        await redisClient.set(cacheKey, JSON.stringify(responsesByPhase), {
-            EX: 300, // Expiration: 5 minutes
-        });
+        await redisClient.set(cacheKey, JSON.stringify(responsesByPhase), 'EX', 300); // Expiration: 5 minutes
 
         // Attach responses to the corresponding phases
         phases.forEach(phase => {
@@ -887,9 +883,7 @@ export async function getCachedStudentActivityPeerResponses(designType, sessionI
         const peerResponsesByPhase = await studentActivityPeerResponseGetters[designType](sessionId, userId);
 
         // Cache the result
-        await redisClient.set(cacheKey, JSON.stringify(peerResponsesByPhase), {
-            EX: 300,
-        });
+        await redisClient.set(cacheKey, JSON.stringify(peerResponsesByPhase), 'EX', 300);
 
         // Attach responses to the corresponding phases
         phases.forEach(phase => {
@@ -1130,7 +1124,7 @@ export async function getCachedStudentActivityGroupMessages(designType, sessionI
         const messagesByPhase = await studentActivityGroupMessageGetters[designType](sessionId, userId, phases);
 
         // Cache the result
-        await redisClient.set(cacheKey, JSON.stringify(messagesByPhase), { EX: 300 });
+        await redisClient.set(cacheKey, JSON.stringify(messagesByPhase), 'EX', 300);
 
         // Attach messages to phases
         phases.forEach(phase => {
@@ -1204,7 +1198,7 @@ export async function getDesignTypeBySessionId(sessionId) {
         const designType = design?.type ?? null;
 
         if (designType) {
-            await redisClient.set(cacheKey, designType, { EX: 3600 });
+            await redisClient.set(cacheKey, designType, 'EX', 3600);
         }
 
         return designType;


### PR DESCRIPTION
### Motivation
- Corregir errores de cacheo Redis que producían `ERR syntax error` por pasar opciones TTL como un objeto (`{ EX: ... }`) incompatible con el cliente `ioredis` configurado, lo que hacía que el comando `SET` recibiera `"[object Object]"` en sus argumentos.

### Description
- Reemplacé las llamadas a `redisClient.set(...)` que pasaban TTL como objeto por el formato compatible `set(key, value, 'EX', ttl)` en `ethicapp/backend/helpers/student-activity-state-helper.js` para las operaciones de cacheo de `tasks`, `responses`, `peerResponses`, `groupMessages` y `design_type`.
- El cambio deja consistentes las funciones `getCachedStudentActivityTasks`, `getCachedStudentActivityResponses`, `getCachedStudentActivityPeerResponses`, `getCachedStudentActivityGroupMessages` y `getDesignTypeBySessionId` para evitar errores de sintaxis en Redis.

### Testing
- Ejecuté la comprobación de sintaxis con `node --check ethicapp/backend/helpers/student-activity-state-helper.js` y finalizó sin errores.
- Verifiqué por búsqueda que las llamadas `redisClient.set(` usan ahora el patrón `..., 'EX', <ttl>` en `ethicapp/backend/helpers/student-activity-state-helper.js` con `rg` y la búsqueda devolvió las modificaciones esperadas.
- Se comprobó el estado del árbol de trabajo con `git status --short` para confirmar que el archivo modificado está presente (local verification passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9a22bf8c832bae43e1afe4637e76)