### PR TITLE
Mostrar fase activa en Detalle de sesión (ethicapp-student)

### DIFF
--- a/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
+++ b/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
@@ -69,6 +69,7 @@ export default function SessionDetailPage() {
   }, [activityState]);
 
   const currentPhaseNumber = activityState?.descriptor?.currentPhaseNumber ?? null;
+  const currentPhaseId = activityState?.descriptor?.currentPhaseId ?? null;
 
   return (
     <section className="mx-auto" style={{ maxWidth: '860px' }}>
@@ -108,6 +109,12 @@ export default function SessionDetailPage() {
 
                 <dt className="col-sm-3">Tipo</dt>
                 <dd className="col-sm-9">{selectedSession.type ?? 'Sin tipo'}</dd>
+
+                <dt className="col-sm-3">Fase activa #</dt>
+                <dd className="col-sm-9">{currentPhaseNumber ?? 'No disponible'}</dd>
+
+                <dt className="col-sm-3">Fase activa ID</dt>
+                <dd className="col-sm-9">{currentPhaseId ?? 'No disponible'}</dd>
               </dl>
 
               {loadingActivityState ? <p className="text-muted mt-3 mb-0">Cargando estado completo de la actividad...</p> : null}


### PR DESCRIPTION
### Motivation
- Mostrar en la vista de Detalle de sesión la información de la fase activa tomada del `descriptor` que viene en el `full_state` (`/activities/:id/users/:user_id/full_state`) para facilitar la verificación de consistencia cuando la UI muestra fases inconsistentes (p. ej. siempre pegada en 1). 

### Description
- Se modificó `frontend/src/pages/SessionDetailPage.jsx` para leer `currentPhaseId` desde `activityState.descriptor` y añadir dos filas en el `<dl>` de metadata que muestran `Fase activa #` (`currentPhaseNumber`) y `Fase activa ID` (`currentPhaseId`) con fallback `No disponible` cuando no están presentes. 

### Testing
- Se comprobó localmente la lista de scripts con `npm run`, se intentó `npm run lint` pero falló porque no existe el script `lint`, y se intentó `npm run build` que falló en este entorno por falta del binario `vite`, por lo que no se pudieron ejecutar builds automáticos aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9c00a4d4832baf4e1199e824afb8)