### PR TITLE
Invalidate descriptor cache on phase transition and await socket payload

### DIFF
--- a/ethicapp/backend/controllers/activities.js
+++ b/ethicapp/backend/controllers/activities.js
@@ -9,6 +9,7 @@ import * as StatusCodes from "../../common/modules/session-status.js"
 import { requireRole, requireOwnershipOrRole } from "../helpers/auth-helper.js"
 import * as StudentActivityStatusHelper from "../helpers/student-activity-state-helper.js"
 import { studentNotifications } from "../config/socket.config.js";
+import redisClient from "../db/redis.js";
 
 const router = express.Router();
 
@@ -427,6 +428,9 @@ router.post("/activities/:session_id/phase_transition", async (req, res) => {
         if (result.rowCount === 0) {
             return res.status(404).json({ error: "Session not found or no update performed." });
         }
+
+        // Invalidate cached descriptor so students read the updated current phase.
+        await redisClient.del(`descriptor:${sessionId}`);
 
         // Notify students the phase has changed!
         studentNotifications.phaseTransition(sessionId, phaseId);

--- a/ethicapp/backend/sockets/student.socket.js
+++ b/ethicapp/backend/sockets/student.socket.js
@@ -50,8 +50,8 @@ let studentSocketInit = (socket, socketNamespace) => {
 // Teacher-Student socket notifications (from backend)
 const toStudentsNotifications = (socketNamespace) => {
     return {
-        phaseTransition: (sessionId, phaseId) => {
-            const initialPhaseState = buildInitialPhaseState(phaseId);
+        phaseTransition: async (sessionId, phaseId) => {
+            const initialPhaseState = await buildInitialPhaseState(phaseId);
             socketNamespace.to(`session-${sessionId}`).
                 emit("onPhaseTransition", initialPhaseState );
         },


### PR DESCRIPTION
### Motivation
- The descriptor read by students was sometimes stale because `sessions.current_stage` was updated in the database but the Redis cached descriptor (`descriptor:{sessionId}`) was not invalidated, leaving students pinned to the old phase.
- The WebSocket transition payload was built with an async function (`buildInitialPhaseState`) but emitted without awaiting it, which could send a `Promise` instead of a ready phase object to clients.

### Description
- Import `redisClient` in `ethicapp/backend/controllers/activities.js` and invalidate the descriptor cache with `await redisClient.del(`descriptor:${sessionId}`)` immediately after a successful `UPDATE` of the session's `current_stage`.
- Make the `phaseTransition` notifier in `ethicapp/backend/sockets/student.socket.js` asynchronous and `await buildInitialPhaseState(phaseId)` before emitting the `onPhaseTransition` event so clients receive a concrete phase object.
- Updated files: `ethicapp/backend/controllers/activities.js` and `ethicapp/backend/sockets/student.socket.js`.

### Testing
- Performed a module import smoke test with `node -e "import('./ethicapp/backend/controllers/activities.js'); import('./ethicapp/backend/sockets/student.socket.js'); console.log('ok')"`, which loaded the modified modules (printed `ok`) but reported missing optional dependency `pg-native` and Redis connection errors to `127.0.0.1:6379`, so cache invalidation could not be exercised end-to-end in this environment.
- No unit tests were added for these changes in this PR; code changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa1fa29a0832b89413733504f5d92)