### PR TITLE
Emitir notificación ligera `onPhaseTransition`, endpoint para obtener estado de fase y cliente websocket estudiantil

### DIFF
--- a/ethicapp-student/frontend/src/config/env.js
+++ b/ethicapp-student/frontend/src/config/env.js
@@ -7,9 +7,12 @@ function ensureTrailingSlash(value) {
 }
 
 const viteStudentApiBasePath = (import.meta.env.VITE_STUDENT_API_BASE_PATH || '').trim();
+const viteStudentSocketUrl = (import.meta.env.VITE_STUDENT_SOCKET_URL || '').trim();
 
 const studentApiBasePath = viteStudentApiBasePath
   ? ensureTrailingSlash(ensureLeadingSlash(viteStudentApiBasePath))
   : '/student/api/';
 
-export { studentApiBasePath };
+const studentSocketUrl = viteStudentSocketUrl || (typeof window !== 'undefined' ? window.location.origin : '');
+
+export { studentApiBasePath, studentSocketUrl };

--- a/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
+++ b/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useOutletContext, useParams } from 'react-router-dom';
 import { studentApi } from '../api/studentApi.js';
 import { useStudentActivityState } from '../context/StudentActivityStateContext.jsx';
+import { getStudentSocket } from '../services/studentSocket.js';
 import { formatSessionDate, sessionStatusLabel } from '../utils/sessionFormat.js';
 
 export default function SessionDetailPage() {
@@ -63,6 +64,78 @@ export default function SessionDetailPage() {
       // El error ya queda reflejado en el contexto.
     });
   }, [loadFullState, selectedSession, session.isAuthenticated, session.uid]);
+
+  useEffect(() => {
+    if (!session.isAuthenticated || !selectedSession) {
+      return;
+    }
+
+    let isUnmounted = false;
+    let socket = null;
+    const activeSessionId = Number(selectedSession.id);
+
+    const handlePhaseTransition = (...payload) => {
+      console.debug('[student socket] onPhaseTransition', {
+        sessionId: activeSessionId,
+        payload
+      });
+    };
+
+    const handleShareResponse = (payload) => {
+      console.debug('[student socket] onShareResponse', {
+        sessionId: activeSessionId,
+        payload
+      });
+    };
+
+    const handleEndSession = (payload) => {
+      console.debug('[student socket] onEndSession', {
+        sessionId: activeSessionId,
+        payload
+      });
+    };
+
+    const handleChatMessage = (payload) => {
+      console.debug('[student socket] onChatMessage', {
+        sessionId: activeSessionId,
+        payload
+      });
+    };
+
+    getStudentSocket()
+      .then((instance) => {
+        if (isUnmounted) {
+          return;
+        }
+
+        socket = instance;
+        socket.emit('joinSession', activeSessionId);
+        socket.on('onPhaseTransition', handlePhaseTransition);
+        socket.on('onShareResponse', handleShareResponse);
+        socket.on('onEndSession', handleEndSession);
+        socket.on('onChatMessage', handleChatMessage);
+      })
+      .catch((error) => {
+        console.debug('[student socket] could not initialize websocket client', {
+          sessionId: activeSessionId,
+          error
+        });
+      });
+
+    return () => {
+      isUnmounted = true;
+
+      if (!socket) {
+        return;
+      }
+
+      socket.emit('leaveSession', activeSessionId);
+      socket.off('onPhaseTransition', handlePhaseTransition);
+      socket.off('onShareResponse', handleShareResponse);
+      socket.off('onEndSession', handleEndSession);
+      socket.off('onChatMessage', handleChatMessage);
+    };
+  }, [selectedSession, session.isAuthenticated]);
 
   const phaseTabs = useMemo(() => {
     return Array.isArray(activityState?.phases) ? activityState.phases : [];

--- a/ethicapp-student/frontend/src/services/studentSocket.js
+++ b/ethicapp-student/frontend/src/services/studentSocket.js
@@ -1,0 +1,55 @@
+import { studentSocketUrl } from '../config/env.js';
+
+let socketInstance = null;
+let socketScriptPromise = null;
+
+function loadSocketIoClientScript() {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('Socket.IO client is only available in browser environments.'));
+  }
+
+  if (window.io) {
+    return Promise.resolve(window.io);
+  }
+
+  if (socketScriptPromise) {
+    return socketScriptPromise;
+  }
+
+  socketScriptPromise = new Promise((resolve, reject) => {
+    const existingScript = document.querySelector('script[data-student-socket-io-client="true"]');
+
+    if (existingScript) {
+      existingScript.addEventListener('load', () => resolve(window.io));
+      existingScript.addEventListener('error', () =>
+        reject(new Error('Failed to load Socket.IO client script.'))
+      );
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = `${studentSocketUrl}/socket.io/socket.io.js`;
+    script.async = true;
+    script.dataset.studentSocketIoClient = 'true';
+    script.onload = () => resolve(window.io);
+    script.onerror = () => reject(new Error('Failed to load Socket.IO client script.'));
+    document.head.appendChild(script);
+  });
+
+  return socketScriptPromise;
+}
+
+export async function getStudentSocket() {
+  if (socketInstance) {
+    return socketInstance;
+  }
+
+  const ioClient = await loadSocketIoClientScript();
+
+  socketInstance = ioClient(`${studentSocketUrl}/student`, {
+    withCredentials: true,
+    transports: ['websocket', 'polling']
+  });
+
+  return socketInstance;
+}

--- a/ethicapp/backend/controllers/activities.js
+++ b/ethicapp/backend/controllers/activities.js
@@ -433,7 +433,7 @@ router.post("/activities/:session_id/phase_transition", async (req, res) => {
         await redisClient.del(`descriptor:${sessionId}`);
 
         // Notify students the phase has changed!
-        studentNotifications.phaseTransition(sessionId, phaseId);
+        studentNotifications.phaseTransition(sessionId);
 
         res.status(200).json({ status: "ok", message: "Session transitioned to the new phase." });
     } catch (err) {
@@ -728,6 +728,40 @@ router.patch("/activities/:session_id/toggle_archived", async (req, res) => {
     } catch (err) {
         console.error("Error in /activities/:session_id/toggle_archived:", err);
         return res.status(500).json({ status: "err", message: "Internal Server Error" });
+    }
+});
+
+/**
+ * Returns the initial state for the current active phase of a session.
+ *
+ * GET /activities/:session_id/current_phase_state
+ */
+router.get("/activities/:session_id/current_phase_state", async (req, res) => {
+    const sessionId = Number(req.params.session_id);
+    const invalidate = req.query.invalidate === "true";
+
+    if (!sessionId || isNaN(sessionId)) {
+        return res.status(400).json({ error: "Invalid session ID." });
+    }
+
+    if (!requireRole(req, res, "A")) {
+        return;
+    }
+
+    try {
+        const { descriptor } = await StudentActivityStatusHelper.
+            getCachedStudentActivityDescriptor(sessionId, invalidate);
+        const currentPhaseId = Number(descriptor?.currentPhaseId);
+
+        if (!currentPhaseId || isNaN(currentPhaseId)) {
+            return res.status(404).json({ error: "No active phase found for this session." });
+        }
+
+        const initialPhaseState = await StudentActivityStatusHelper.buildInitialPhaseState(currentPhaseId);
+        return res.status(200).json(initialPhaseState);
+    } catch (error) {
+        console.error(`Error retrieving current phase state for session ${sessionId}:`, error);
+        return res.status(500).json({ error: "Internal server error." });
     }
 });
 

--- a/ethicapp/backend/sockets/student.socket.js
+++ b/ethicapp/backend/sockets/student.socket.js
@@ -1,5 +1,4 @@
 import * as ChatHelper from "../helpers/chat-helper.js";
-import { buildInitialPhaseState } from "../helpers/student-activity-state-helper.js";
 
 let studentSocketInit = (socket, socketNamespace) => {
     console.debug('Student connected');
@@ -50,10 +49,9 @@ let studentSocketInit = (socket, socketNamespace) => {
 // Teacher-Student socket notifications (from backend)
 const toStudentsNotifications = (socketNamespace) => {
     return {
-        phaseTransition: async (sessionId, phaseId) => {
-            const initialPhaseState = await buildInitialPhaseState(phaseId);
+        phaseTransition: (sessionId) => {
             socketNamespace.to(`session-${sessionId}`).
-                emit("onPhaseTransition", initialPhaseState );
+                emit("onPhaseTransition");
         },
 
         chatMessage: (groupId, messages) => {


### PR DESCRIPTION
### Motivation
- Evitar enviar por socket un objeto pesado con el estado inicial de la fase y delegar la construcción/consulta del estado al cliente tras recibir la notificación. 
- Proporcionar al cliente estudiantil un mecanismo estándar y robusto (websocket + petición HTTP) para reaccionar a transiciones de fase y recuperar el `initialPhaseState` cuando lo necesite.

### Description
- Simplificado el emisor de notificaciones en `ethicapp/backend/sockets/student.socket.js` para que `phaseTransition` emita solo el evento `onPhaseTransition` sin payload. 
- Ajustado `POST /activities/:session_id/phase_transition` en `ethicapp/backend/controllers/activities.js` para usar la notificación simplificada y mantener la invalidación de caché (`redisClient.del('descriptor:{sessionId}')`).
- Agregado endpoint `GET /activities/:session_id/current_phase_state` en `ethicapp/backend/controllers/activities.js` que valida permisos, obtiene `currentPhaseId` desde `getCachedStudentActivityDescriptor` y retorna el `initialPhaseState` usando `StudentActivityStatusHelper.buildInitialPhaseState`.
- En el frontend estudiantil se añadió `VITE_STUDENT_SOCKET_URL` y `studentSocketUrl` en `ethicapp-student/frontend/src/config/env.js` y se creó `ethicapp-student/frontend/src/services/studentSocket.js` para inicializar un singleton websocket cargando dinámicamente el script cliente de Socket.IO (`/socket.io/socket.io.js`) evitando añadir la dependencia al bundle en este entorno.
- Se suscribió la página `SessionDetailPage` a los eventos websocket (`onPhaseTransition`, `onShareResponse`, `onEndSession`, `onChatMessage`) y se implementaron handlers que hacen `console.debug` para validar la recepción, además de emitir `joinSession` / `leaveSession` y limpiar listeners al desmontar.

### Testing
- Se ejecutó `node --check` sobre los archivos backend modificados (`ethicapp/backend/controllers/activities.js` y `ethicapp/backend/sockets/student.socket.js`) y pasó sin errores. 
- Intentos automáticos de instalar/compilar el frontend fallaron por limitaciones del entorno: `npm --prefix ethicapp-student/frontend install --package-lock-only` devolvió `403` al intentar descargar `socket.io-client`, y `npm --prefix ethicapp-student/frontend run build` falló con `vite: not found`, por lo que no se pudo validar la construcción del frontend en este contenedor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa73b4640832b90fbb2103a890d07)