### PR TITLE
Add teacher-facing ethical cases CRUD (API, AngularJS, DB, i18n)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Given the mix of legacy code, prototype-quality code, and AI-assisted developmen
 - All new JavaScript dependencies must support **ES Modules**.
 - Avoid adding new CommonJS code in new development.
 - Avoid legacy JavaScript patterns in new modules.
+- All newly implemented code (identifiers, comments, and user-facing technical labels) must be written in English.
 - Minimize architectural and code anti-patterns, especially:
   - oversized monolithic components,
   - low-cohesion modules,
@@ -118,3 +119,4 @@ When adding teacher-facing features in legacy EthicApp:
 2. Expose AngularJS services for API communication in `assets/js/services`.
 3. Wire controllers/services in `teacher_admin.mjs`.
 4. Add/update teacher navigation entry points in `ethicapp/frontend/views/home.ejs`.
+5. When adding or modifying UI text in legacy EthicApp AngularJS views, add/update the corresponding translation keys in `ethicapp/frontend/assets/locales/` and use `{{'key'|translate}}` in templates instead of hardcoded strings.

--- a/database/create_38.sql
+++ b/database/create_38.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS ethical_cases (
+    id serial PRIMARY KEY,
+    title text NOT NULL,
+    author_firstname text NOT NULL,
+    author_lastname text NOT NULL,
+    author_email text NOT NULL,
+    pdf_path text NOT NULL,
+    creator integer NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    created_at timestamp without time zone DEFAULT NOW(),
+    updated_at timestamp without time zone DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ethical_cases_creator ON ethical_cases (creator);

--- a/ethicapp/backend/app.js
+++ b/ethicapp/backend/app.js
@@ -27,6 +27,7 @@ import group_messages from "./controllers/group-messages.js";
 import content_analysis from "./controllers/content-analysis-controller.js";
 import admin_panel from "./controllers/admin-panel-api.js";
 import legacy_ethics from "./controllers/legacy-ethics.js";
+import cases from "./controllers/cases.js";
 
 import fs from "fs";
 
@@ -162,8 +163,8 @@ app.use("/", requireLegacyAuth, designs);
 app.use("/", requireLegacyAuth, group_messages);
 app.use("/", requireLegacyAuth, content_analysis);
 app.use("/", requireLegacyAuth, legacy_ethics); // Legacy endpoints
+app.use("/", requireLegacyAuth, cases);
 
-//app.use("/", validateSession, cases);
 app.use("/", admin_panel);
 
 // app.use("/", validateSession, rubrica);

--- a/ethicapp/backend/controllers/cases.js
+++ b/ethicapp/backend/controllers/cases.js
@@ -1,0 +1,242 @@
+"use strict";
+
+import express from "express";
+import * as config from "../config/config.js";
+import * as rpg2 from "../db/rest-pg-2.js";
+import { requireRole } from "../helpers/auth-helper.js";
+
+const router = express.Router();
+
+function normalizeCase(row) {
+    return {
+        id: row.id,
+        title: row.title,
+        authorFirstname: row.author_firstname,
+        authorLastname: row.author_lastname,
+        authorEmail: row.author_email,
+        pdfPath: row.pdf_path,
+        creator: row.creator,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+}
+
+router.get("/cases", async (req, res) => {
+    if (!requireRole(req, res, "P")) {
+        return;
+    }
+
+    try {
+        const cases = await rpg2.execSQL({
+            dbcon: config.dbconnString,
+            sql: `
+                SELECT id, title, author_firstname, author_lastname, author_email,
+                       pdf_path, creator, created_at, updated_at
+                FROM ethical_cases
+                WHERE creator = $1
+                ORDER BY id DESC;
+            `,
+            sqlParams: [rpg2.param("plain", req.session.uid)],
+        });
+
+        return res.status(200).json({
+            status: "ok",
+            result: cases.map(normalizeCase),
+        });
+    } catch (error) {
+        console.error("Error fetching cases:", error);
+        return res.status(500).json({ status: "err", message: "Failed to load cases." });
+    }
+});
+
+router.get("/cases/:id", async (req, res) => {
+    if (!requireRole(req, res, "P")) {
+        return;
+    }
+
+    const caseId = Number(req.params.id);
+    if (!Number.isInteger(caseId)) {
+        return res.status(400).json({ status: "err", message: "Invalid case id." });
+    }
+
+    try {
+        const caseObj = await rpg2.singleSQL({
+            dbcon: config.dbconnString,
+            sql: `
+                SELECT id, title, author_firstname, author_lastname, author_email,
+                       pdf_path, creator, created_at, updated_at
+                FROM ethical_cases
+                WHERE id = $1 AND creator = $2;
+            `,
+            sqlParams: [
+                rpg2.param("plain", caseId),
+                rpg2.param("plain", req.session.uid),
+            ],
+        });
+
+        if (!caseObj || !caseObj.id) {
+            return res.status(404).json({ status: "err", message: "Case not found." });
+        }
+
+        return res.status(200).json({ status: "ok", result: normalizeCase(caseObj) });
+    } catch (error) {
+        console.error("Error retrieving case by id:", error);
+        return res.status(500).json({ status: "err", message: "Failed to load case." });
+    }
+});
+
+router.post("/cases", async (req, res) => {
+    if (!requireRole(req, res, "P")) {
+        return;
+    }
+
+    const {
+        title,
+        author_firstname: authorFirstname,
+        author_lastname: authorLastname,
+        author_email: authorEmail,
+    } = req.body;
+
+    if (!title || !authorFirstname || !authorLastname || !authorEmail) {
+        return res.status(400).json({ status: "err", message: "Missing required fields." });
+    }
+
+    if (!req.files?.pdf || req.files.pdf.mimetype !== "application/pdf") {
+        return res.status(400).json({ status: "err", message: "A PDF file is required." });
+    }
+
+    try {
+        const pdfPath = "assets/uploads" + req.files.pdf.file.split("uploads")[1];
+
+        const createdCase = await rpg2.singleSQL({
+            dbcon: config.dbconnString,
+            sql: `
+                INSERT INTO ethical_cases
+                    (title, author_firstname, author_lastname, author_email, pdf_path, creator)
+                VALUES
+                    ($1, $2, $3, $4, $5, $6)
+                RETURNING id, title, author_firstname, author_lastname, author_email,
+                          pdf_path, creator, created_at, updated_at;
+            `,
+            sqlParams: [
+                rpg2.param("plain", title),
+                rpg2.param("plain", authorFirstname),
+                rpg2.param("plain", authorLastname),
+                rpg2.param("plain", authorEmail),
+                rpg2.param("plain", pdfPath),
+                rpg2.param("plain", req.session.uid),
+            ],
+        });
+
+        return res.status(201).json({ status: "ok", result: normalizeCase(createdCase) });
+    } catch (error) {
+        console.error("Error creating case:", error);
+        return res.status(500).json({ status: "err", message: "Failed to create case." });
+    }
+});
+
+router.patch("/cases/:id", async (req, res) => {
+    if (!requireRole(req, res, "P")) {
+        return;
+    }
+
+    const caseId = Number(req.params.id);
+    if (!Number.isInteger(caseId)) {
+        return res.status(400).json({ status: "err", message: "Invalid case id." });
+    }
+
+    const {
+        title,
+        author_firstname: authorFirstname,
+        author_lastname: authorLastname,
+        author_email: authorEmail,
+    } = req.body;
+
+    if (!title || !authorFirstname || !authorLastname || !authorEmail) {
+        return res.status(400).json({ status: "err", message: "Missing required fields." });
+    }
+
+    try {
+        const existingCase = await rpg2.singleSQL({
+            dbcon: config.dbconnString,
+            sql: "SELECT id, pdf_path FROM ethical_cases WHERE id = $1 AND creator = $2;",
+            sqlParams: [rpg2.param("plain", caseId), rpg2.param("plain", req.session.uid)],
+        });
+
+        if (!existingCase || !existingCase.id) {
+            return res.status(404).json({ status: "err", message: "Case not found." });
+        }
+
+        const hasPdf = req.files?.pdf && req.files.pdf.mimetype === "application/pdf";
+        const pdfPath = hasPdf
+            ? "assets/uploads" + req.files.pdf.file.split("uploads")[1]
+            : existingCase.pdf_path;
+
+        const updatedCase = await rpg2.singleSQL({
+            dbcon: config.dbconnString,
+            sql: `
+                UPDATE ethical_cases
+                SET title = $1,
+                    author_firstname = $2,
+                    author_lastname = $3,
+                    author_email = $4,
+                    pdf_path = $5,
+                    updated_at = NOW()
+                WHERE id = $6 AND creator = $7
+                RETURNING id, title, author_firstname, author_lastname, author_email,
+                          pdf_path, creator, created_at, updated_at;
+            `,
+            sqlParams: [
+                rpg2.param("plain", title),
+                rpg2.param("plain", authorFirstname),
+                rpg2.param("plain", authorLastname),
+                rpg2.param("plain", authorEmail),
+                rpg2.param("plain", pdfPath),
+                rpg2.param("plain", caseId),
+                rpg2.param("plain", req.session.uid),
+            ],
+        });
+
+        return res.status(200).json({ status: "ok", result: normalizeCase(updatedCase) });
+    } catch (error) {
+        console.error("Error updating case:", error);
+        return res.status(500).json({ status: "err", message: "Failed to update case." });
+    }
+});
+
+router.delete("/cases/:id", async (req, res) => {
+    if (!requireRole(req, res, "P")) {
+        return;
+    }
+
+    const caseId = Number(req.params.id);
+    if (!Number.isInteger(caseId)) {
+        return res.status(400).json({ status: "err", message: "Invalid case id." });
+    }
+
+    try {
+        const deleted = await rpg2.singleSQL({
+            dbcon: config.dbconnString,
+            sql: `
+                DELETE FROM ethical_cases
+                WHERE id = $1 AND creator = $2
+                RETURNING id;
+            `,
+            sqlParams: [
+                rpg2.param("plain", caseId),
+                rpg2.param("plain", req.session.uid),
+            ],
+        });
+
+        if (!deleted || !deleted.id) {
+            return res.status(404).json({ status: "err", message: "Case not found." });
+        }
+
+        return res.status(200).json({ status: "ok", message: "Case deleted." });
+    } catch (error) {
+        console.error("Error deleting case:", error);
+        return res.status(500).json({ status: "err", message: "Failed to delete case." });
+    }
+});
+
+export default router;

--- a/ethicapp/backend/views/home.ejs
+++ b/ethicapp/backend/views/home.ejs
@@ -51,6 +51,11 @@
                 <i class="fa fa-paint-brush" aria-hidden="true"></i> {{ 'nav_pill_title_designs' | translate }}
             </a>
         </li>
+        <li>
+            <a href="#!/cases">
+                <i class="fa fa-book" aria-hidden="true"></i> {{ 'nav_pill_title_cases' | translate }}
+            </a>
+        </li>
     </ul>
   </div>  
   <div class="main_body vl"> <!--Right side-->

--- a/ethicapp/frontend/assets/js/controllers/teacher/cases.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/cases.controller.js
@@ -1,0 +1,57 @@
+/*eslint func-style: ["error", "expression"]*/
+export function CasesController($scope, $routeParams, CasesCatalogService) {
+    const vm = this;
+    vm.cases = [];
+    vm.form = {
+        title: "",
+        authorFirstname: "",
+        authorLastname: "",
+        authorEmail: "",
+        pdf: null,
+        currentPdfPath: null,
+    };
+
+    vm.loadCases = async function() {
+        vm.cases = await CasesCatalogService.getCases(true);
+        $scope.$applyAsync();
+    };
+
+    vm.loadCase = async function() {
+        const caseId = Number($routeParams.id);
+        if (!Number.isInteger(caseId)) {
+            return;
+        }
+
+        const caseObj = await CasesCatalogService.getCaseById(caseId);
+        vm.form.title = caseObj.title;
+        vm.form.authorFirstname = caseObj.authorFirstname;
+        vm.form.authorLastname = caseObj.authorLastname;
+        vm.form.authorEmail = caseObj.authorEmail;
+        vm.form.currentPdfPath = caseObj.pdfPath;
+        $scope.$applyAsync();
+    };
+
+    vm.handlePdfSelected = function(files) {
+        vm.form.pdf = files && files.length > 0 ? files[0] : null;
+    };
+
+    vm.createCase = async function() {
+        await CasesCatalogService.createCase(vm.form);
+        $scope.navigateTo("/cases");
+    };
+
+    vm.updateCase = async function() {
+        const caseId = Number($routeParams.id);
+        if (!Number.isInteger(caseId)) {
+            return;
+        }
+
+        await CasesCatalogService.updateCase(caseId, vm.form);
+        $scope.navigateTo("/cases");
+    };
+
+    vm.deleteCase = async function(caseId) {
+        await CasesCatalogService.deleteCase(caseId);
+        await vm.loadCases();
+    };
+}

--- a/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
+++ b/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
@@ -5,6 +5,7 @@ import { ActivityStateService } from "../../services/activity-state.service.js";
 import { ActivityCatalogService } from "../../services/activity-catalog.service.js";
 import { DesignStateService } from "../../services/design-state.service.js";
 import { DesignCatalogService } from "../../services/design-catalog.service.js";
+import { CasesCatalogService } from "../../services/cases-catalog.service.js";
 import UserInformationService from "../../services/user-information.service.js";
 import SocketService from '../../services/socket.service.js';
 
@@ -24,7 +25,8 @@ app.factory("ActivityStateService", ["$http", "TeacherSocketService", ActivitySt
     .factory("ActivityCatalogService", ["$http", ActivityCatalogService])
     .factory("DesignCatalogService", ["$rootScope", "$http", DesignCatalogService])
     .factory("DesignStateService", ["$rootScope", "$http", DesignStateService])
-    .factory("UserInformationService", ["$http", UserInformationService]);
+    .factory("UserInformationService", ["$http", UserInformationService])
+    .factory("CasesCatalogService", ["$http", CasesCatalogService]);
 
 import { LocalesController } from "../../controllers/common/locales.controller.js";
 import { ActivityController } from "../../controllers/teacher/activity.controller.js";
@@ -41,6 +43,7 @@ import { VoidController } from "../../controllers/common/void.controller.js";
 import { ngQuillConfigProvider } from "../../helpers/util.js";
 import { DesignEditorController } from "../../controllers/teacher/design-editor.controller.js";
 import { DesignViewerController } from "../../controllers/teacher/design-viewer.controller.js";
+import { CasesController } from "../../controllers/teacher/cases.controller.js";
 
 import { TeacherRouter } from "./teacher-routes.js";
 app.config(TeacherRouter);
@@ -114,6 +117,8 @@ app.controller("DesignAttachmentsController",
     ["$scope", "DesignStateService" ,"$http", "Notification", "$timeout", DesignAttachmentsController]);
 app.controller("DesignViewerController", 
     ["$scope", "$routeParams", "DesignCatalogService", DesignViewerController]);
+app.controller("CasesController",
+    ["$scope", "$routeParams", "CasesCatalogService", CasesController]);
 app.controller("DocumentsController", 
     ["$scope", "$http", "Notification", "$timeout", "ActivityStateService",
         DocumentsController]);

--- a/ethicapp/frontend/assets/js/modules/teacher/teacher-routes.js
+++ b/ethicapp/frontend/assets/js/modules/teacher/teacher-routes.js
@@ -33,6 +33,15 @@ function TeacherRouter($routeProvider) {
         .when('/users', {
             templateUrl: 'static/views/teacher/users.html',
         })
+        .when('/cases', {
+            templateUrl: 'static/views/teacher/cases.index.html',
+        })
+        .when('/cases/new', {
+            templateUrl: 'static/views/teacher/cases.new.html',
+        })
+        .when('/cases/:id/edit', {
+            templateUrl: 'static/views/teacher/cases.edit.html',
+        })
         .when('/error/:errorCode/:backSteps', {
             templateUrl: function(params) {
               return 'static/views/teacher/error.' + params.errorCode + '.html';

--- a/ethicapp/frontend/assets/js/services/cases-catalog.service.js
+++ b/ethicapp/frontend/assets/js/services/cases-catalog.service.js
@@ -1,0 +1,67 @@
+let CasesCatalogService = ($http) => {
+    const service = {
+        cases: [],
+
+        async loadCases() {
+            const response = await $http.get("/cases");
+            service.cases = Array.isArray(response.data.result) ? response.data.result : [];
+            return service.cases;
+        },
+
+        async getCases(reload = false) {
+            if (reload || service.cases.length === 0) {
+                await service.loadCases();
+            }
+            return service.cases;
+        },
+
+        async getCaseById(caseId) {
+            const response = await $http.get(`/cases/${caseId}`);
+            return response.data.result;
+        },
+
+        async createCase(caseData) {
+            const formData = new FormData();
+            formData.append("title", caseData.title);
+            formData.append("author_firstname", caseData.authorFirstname);
+            formData.append("author_lastname", caseData.authorLastname);
+            formData.append("author_email", caseData.authorEmail);
+            formData.append("pdf", caseData.pdf);
+
+            const response = await $http.post("/cases", formData, {
+                headers: { "Content-Type": undefined },
+            });
+
+            await service.getCases(true);
+            return response.data.result;
+        },
+
+        async updateCase(caseId, caseData) {
+            const formData = new FormData();
+            formData.append("title", caseData.title);
+            formData.append("author_firstname", caseData.authorFirstname);
+            formData.append("author_lastname", caseData.authorLastname);
+            formData.append("author_email", caseData.authorEmail);
+
+            if (caseData.pdf) {
+                formData.append("pdf", caseData.pdf);
+            }
+
+            const response = await $http.patch(`/cases/${caseId}`, formData, {
+                headers: { "Content-Type": undefined },
+            });
+
+            await service.getCases(true);
+            return response.data.result;
+        },
+
+        async deleteCase(caseId) {
+            await $http.delete(`/cases/${caseId}`);
+            await service.getCases(true);
+        },
+    };
+
+    return service;
+};
+
+export { CasesCatalogService };

--- a/ethicapp/frontend/assets/locales/en.json
+++ b/ethicapp/frontend/assets/locales/en.json
@@ -313,4 +313,15 @@
 	"selectActivityType": "Select an activity type",
 	"SemanticDescription": "Semantic Differential: It allows for questions about the case in which students make their ethical judgment using numeric scales that relate opposite terms, for example, Fair-Unfair, Responsible-Irresponsible, etc. The scales can range from dichotomous (two values) up to ten values.",
 	"RankingDescription": "Ranking: It allows for questions about the case in which students must rank the actors based on a question regarding an ethical criterion. For example, \"Rank the actors by placing first the one you believe acted in the most prudent manner\"."
+,
+	"nav_pill_title_cases": "Cases",
+	"ethical_cases_title": "Ethical Cases",
+	"ethical_cases_create": "New Case",
+	"ethical_cases_new_title": "Create Ethical Case",
+	"ethical_cases_edit_title": "Edit Ethical Case",
+	"ethical_cases_file": "Case PDF",
+	"ethical_cases_open_file": "Open file",
+	"ethical_cases_current_file": "Current file",
+	"author_firstname": "Author First Name",
+	"author_lastname": "Author Last Name"
 }

--- a/ethicapp/frontend/assets/locales/en_US.json
+++ b/ethicapp/frontend/assets/locales/en_US.json
@@ -547,6 +547,15 @@
 	"internal_server_error": "Internal Server Error (500)",
 	"internal_server_error_explanation": "Something went wrong, please try again later.",
 	"go_back": "Go Back to the Previous Page"
+,
+	"nav_pill_title_cases": "Cases",
+	"ethical_cases_title": "Ethical Cases",
+	"ethical_cases_create": "New Case",
+	"ethical_cases_new_title": "Create Ethical Case",
+	"ethical_cases_edit_title": "Edit Ethical Case",
+	"ethical_cases_file": "Case PDF",
+	"ethical_cases_open_file": "Open file",
+	"ethical_cases_current_file": "Current file",
+	"author_firstname": "Author First Name",
+	"author_lastname": "Author Last Name"
 }
-
-

--- a/ethicapp/frontend/assets/locales/es.json
+++ b/ethicapp/frontend/assets/locales/es.json
@@ -315,4 +315,15 @@
 	"selectActivityType": "Escoja un tipo de actividad",
 	"SemanticDescription": "Diferenciales Semáticos: Permite realizar preguntas sobre el caso en donde los estudiantes realizan su juicio ético mediante escalas numéricas que relacionan términos opuestos, por ejemplo, Justo-Injusto, Responsable-Irresponsable, etc. Las escalas pueden ser dicotómicas (dos valores) hasta de diez valores.",
 	"RankingDescription": "Ordenación: Permite realizar preguntas sobre el caso en donde los estudiantes deben ordenar los actores de acuerdo a una pregunta sobre un criterio ético. Por ejemplo, \"Ordene los actores poniendo en el primer lugar aquel que usted considera que actuó de la forma más prudente\"."
+,
+	"nav_pill_title_cases": "Casos",
+	"ethical_cases_title": "Casos éticos",
+	"ethical_cases_create": "Nuevo caso",
+	"ethical_cases_new_title": "Crear caso ético",
+	"ethical_cases_edit_title": "Editar caso ético",
+	"ethical_cases_file": "PDF del caso",
+	"ethical_cases_open_file": "Abrir archivo",
+	"ethical_cases_current_file": "Archivo actual",
+	"author_firstname": "Nombre del autor",
+	"author_lastname": "Apellido del autor"
 }

--- a/ethicapp/frontend/assets/locales/es_CL.json
+++ b/ethicapp/frontend/assets/locales/es_CL.json
@@ -557,5 +557,15 @@
 	"internal_server_error": "Error Interno del Servidor (500)",
 	"internal_server_error_explanation": "Algo salió mal, por favor intenta nuevamente más tarde.",
 	"go_back": "Volver a la página anterior"
+,
+	"nav_pill_title_cases": "Casos",
+	"ethical_cases_title": "Casos éticos",
+	"ethical_cases_create": "Nuevo caso",
+	"ethical_cases_new_title": "Crear caso ético",
+	"ethical_cases_edit_title": "Editar caso ético",
+	"ethical_cases_file": "PDF del caso",
+	"ethical_cases_open_file": "Abrir archivo",
+	"ethical_cases_current_file": "Archivo actual",
+	"author_firstname": "Nombre del autor",
+	"author_lastname": "Apellido del autor"
 }
-

--- a/ethicapp/frontend/assets/static/views/teacher/cases.edit.html
+++ b/ethicapp/frontend/assets/static/views/teacher/cases.edit.html
@@ -1,0 +1,36 @@
+<div ng-controller="CasesController as vm" ng-init="vm.loadCase()">
+    <h2>{{ 'ethical_cases_edit_title' | translate }}</h2>
+
+    <form name="editCaseForm" ng-submit="editCaseForm.$valid && vm.updateCase()" novalidate>
+        <div class="form-group">
+            <label>{{ 'title' | translate }}</label>
+            <input type="text" class="form-control" ng-model="vm.form.title" required>
+        </div>
+
+        <div class="form-group">
+            <label>{{ 'author_firstname' | translate }}</label>
+            <input type="text" class="form-control" ng-model="vm.form.authorFirstname" required>
+        </div>
+
+        <div class="form-group">
+            <label>{{ 'author_lastname' | translate }}</label>
+            <input type="text" class="form-control" ng-model="vm.form.authorLastname" required>
+        </div>
+
+        <div class="form-group">
+            <label>{{ 'email' | translate }}</label>
+            <input type="email" class="form-control" ng-model="vm.form.authorEmail" required>
+        </div>
+
+        <div class="form-group">
+            <label>{{ 'ethical_cases_file' | translate }}</label>
+            <p ng-if="vm.form.currentPdfPath">
+                <a ng-href="{{ vm.form.currentPdfPath }}" target="_blank" rel="noopener noreferrer">{{ 'ethical_cases_current_file' | translate }}</a>
+            </p>
+            <input type="file" class="form-control" accept="application/pdf" onchange="angular.element(this).scope().vm.handlePdfSelected(this.files)">
+        </div>
+
+        <button type="submit" class="btn btn-primary">{{ 'saveChanges' | translate }}</button>
+        <button type="button" class="btn btn-default" ng-click="navigateTo('/cases')">{{ 'back' | translate }}</button>
+    </form>
+</div>

--- a/ethicapp/frontend/assets/static/views/teacher/cases.index.html
+++ b/ethicapp/frontend/assets/static/views/teacher/cases.index.html
@@ -1,0 +1,48 @@
+<div ng-controller="CasesController as vm" ng-init="vm.loadCases()">
+    <div class="row">
+        <div class="col-md-12">
+            <h2><i class="fa fa-book"></i> {{ 'ethical_cases_title' | translate }}</h2>
+            <button class="btn btn-primary" ng-click="navigateTo('/cases/new')" style="margin-top: 1rem; margin-bottom: 1rem;">
+                <i class="fa fa-plus" aria-hidden="true"></i> {{ 'ethical_cases_create' | translate }}
+            </button>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>{{ 'title' | translate }}</th>
+                        <th>{{ 'author_firstname' | translate }}</th>
+                        <th>{{ 'author_lastname' | translate }}</th>
+                        <th>{{ 'email' | translate }}</th>
+                        <th>{{ 'ethical_cases_file' | translate }}</th>
+                        <th>{{ 'actions' | translate }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-repeat="caseItem in vm.cases track by caseItem.id">
+                        <td>{{ caseItem.title }}</td>
+                        <td>{{ caseItem.authorFirstname }}</td>
+                        <td>{{ caseItem.authorLastname }}</td>
+                        <td>{{ caseItem.authorEmail }}</td>
+                        <td>
+                            <a ng-if="caseItem.pdfPath" ng-href="{{ caseItem.pdfPath }}" target="_blank" rel="noopener noreferrer">
+                                {{ 'ethical_cases_open_file' | translate }}
+                            </a>
+                        </td>
+                        <td>
+                            <button class="btn btn-default btn-sm" ng-click="navigateTo('/cases/' + caseItem.id + '/edit')">
+                                {{ 'edit' | translate }}
+                            </button>
+                            <button class="btn btn-danger btn-sm" ng-click="vm.deleteCase(caseItem.id)">
+                                {{ 'delete' | translate }}
+                            </button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/ethicapp/frontend/assets/static/views/teacher/cases.new.html
+++ b/ethicapp/frontend/assets/static/views/teacher/cases.new.html
@@ -1,0 +1,33 @@
+<div ng-controller="CasesController as vm">
+    <h2>{{ 'ethical_cases_new_title' | translate }}</h2>
+
+    <form name="newCaseForm" ng-submit="newCaseForm.$valid && vm.createCase()" novalidate>
+        <div class="form-group">
+            <label>{{ 'title' | translate }}</label>
+            <input type="text" class="form-control" ng-model="vm.form.title" required>
+        </div>
+
+        <div class="form-group">
+            <label>{{ 'author_firstname' | translate }}</label>
+            <input type="text" class="form-control" ng-model="vm.form.authorFirstname" required>
+        </div>
+
+        <div class="form-group">
+            <label>{{ 'author_lastname' | translate }}</label>
+            <input type="text" class="form-control" ng-model="vm.form.authorLastname" required>
+        </div>
+
+        <div class="form-group">
+            <label>{{ 'email' | translate }}</label>
+            <input type="email" class="form-control" ng-model="vm.form.authorEmail" required>
+        </div>
+
+        <div class="form-group">
+            <label>{{ 'ethical_cases_file' | translate }}</label>
+            <input type="file" class="form-control" accept="application/pdf" onchange="angular.element(this).scope().vm.handlePdfSelected(this.files)" required>
+        </div>
+
+        <button type="submit" class="btn btn-primary">{{ 'save' | translate }}</button>
+        <button type="button" class="btn btn-default" ng-click="navigateTo('/cases')">{{ 'back' | translate }}</button>
+    </form>
+</div>


### PR DESCRIPTION
### Motivation

- Provide teachers a CRUD interface to manage ethical cases (title, author, email, PDF) from the legacy teacher UI and via API. 
- Keep the implementation consistent with the legacy app architecture (Express controllers, AngularJS services/controllers, static views, and DB migration) and the repository rules (new user-facing labels in English).
- Note: uploaded PDFs are saved under existing `uploads` handling; old uploaded files are not garbage-collected and the runtime behavior depends on session/auth and uploads path configuration.

### Description

- Backend: added a new Express controller with teacher-protected endpoints in `ethicapp/backend/controllers/cases.js` implementing `GET /cases`, `POST /cases`, `GET /cases/:id`, `PATCH /cases/:id`, and `DELETE /cases/:id`, using `rest-pg-2.js` for DB access and `req.files.pdf` for PDF uploads. Mounted it in `ethicapp/backend/app.js` under `requireLegacyAuth`.
- Database: new migration `database/create_38.sql` creating table `ethical_cases` with columns for title, author_firstname, author_lastname, author_email, `pdf_path`, `creator`, and timestamps plus an index on `creator`.
- Frontend (AngularJS legacy): added service `ethicapp/frontend/assets/js/services/cases-catalog.service.js` and controller `ethicapp/frontend/assets/js/controllers/teacher/cases.controller.js`, wired them in `ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs`, and added routes in `ethicapp/frontend/assets/js/modules/teacher/teacher-routes.js` for `/cases`, `/cases/new`, and `/cases/:id/edit`.
- Views & i18n: added static templates `ethicapp/frontend/assets/static/views/teacher/cases.index.html`, `cases.new.html`, and `cases.edit.html`, added sidebar navigation entry in `ethicapp/backend/views/home.ejs`, and added translation keys to `ethicapp/frontend/assets/locales/en.json`, `es.json`, `en_US.json`, and `es_CL.json` (labels and navigation). 
- Repo guidance: updated `AGENTS.md` to require new code/user-facing labels in English and to explicitly remind contributors to add translation keys when modifying legacy AngularJS views.

### Testing

- JSON validation: ran `python`/`json.loads` on updated locale files (`ethicapp/frontend/assets/locales/*.json`) and all passed (success).
- Syntax checks: ran `node --check` on `ethicapp/backend/controllers/cases.js`, `ethicapp/frontend/assets/js/services/cases-catalog.service.js`, and `ethicapp/frontend/assets/js/controllers/teacher/cases.controller.js`; all checks succeeded (no syntax errors).
- Notes: integration/end-to-end tests were not run in this environment; runtime verification requires the app to run with session/auth middleware and the configured uploads directory. Manual verification steps and possible follow-ups are documented in the PR body (verify file upload flow, permissions, and front-end navigation in a running dev environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf078ba90832bb2e40dc989587f61)