### PR TITLE
Add design→case association with case search, download endpoints and editor typeahead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,3 +120,4 @@ When adding teacher-facing features in legacy EthicApp:
 3. Wire controllers/services in `teacher_admin.mjs`.
 4. Add/update teacher navigation entry points in `ethicapp/frontend/views/home.ejs`.
 5. When adding or modifying UI text in legacy EthicApp AngularJS views, add/update the corresponding translation keys in `ethicapp/frontend/assets/locales/` and use `{{'key'|translate}}` in templates instead of hardcoded strings.
+6. For role-based authorization in legacy backend endpoints, prefer `requireRole` from `ethicapp/backend/helpers/auth-helper.js`; it accepts either a single role (`"P"`) or an array (for example `["P", "A"]`) for professor/student shared access.

--- a/database/create_39.sql
+++ b/database/create_39.sql
@@ -1,0 +1,12 @@
+ALTER TABLE designs
+ADD COLUMN IF NOT EXISTS case_id integer;
+
+ALTER TABLE designs
+DROP CONSTRAINT IF EXISTS designs_case_id_fkey;
+
+ALTER TABLE designs
+ADD CONSTRAINT designs_case_id_fkey
+FOREIGN KEY (case_id) REFERENCES ethical_cases (id)
+ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_designs_case_id ON designs (case_id);

--- a/ethicapp/backend/controllers/cases.js
+++ b/ethicapp/backend/controllers/cases.js
@@ -49,7 +49,7 @@ router.get("/cases", async (req, res) => {
     }
 });
 
-router.get("/cases/:id", async (req, res) => {
+router.get("/cases/:id(\\d+)", async (req, res) => {
     if (!requireRole(req, res, "P")) {
         return;
     }
@@ -82,6 +82,80 @@ router.get("/cases/:id", async (req, res) => {
     } catch (error) {
         console.error("Error retrieving case by id:", error);
         return res.status(500).json({ status: "err", message: "Failed to load case." });
+    }
+});
+
+router.get("/cases/search", async (req, res) => {
+    if (!requireRole(req, res, ["P", "A"])) {
+        return;
+    }
+
+    const query = String(req.query.q || "").trim();
+    if (query.length < 2) {
+        return res.status(200).json({ status: "ok", result: [] });
+    }
+
+    try {
+        const cases = await rpg2.execSQL({
+            dbcon: config.dbconnString,
+            sql: `
+                SELECT id, title, author_firstname, author_lastname, author_email,
+                       pdf_path, creator, created_at, updated_at
+                FROM ethical_cases
+                WHERE LOWER(title) LIKE LOWER($1)
+                   OR LOWER(author_firstname) LIKE LOWER($1)
+                   OR LOWER(author_lastname) LIKE LOWER($1)
+                ORDER BY updated_at DESC, id DESC
+                LIMIT 20;
+            `,
+            sqlParams: [rpg2.param("plain", `%${query}%`)],
+        });
+
+        return res.status(200).json({
+            status: "ok",
+            result: cases.map(normalizeCase),
+        });
+    } catch (error) {
+        console.error("Error searching cases:", error);
+        return res.status(500).json({ status: "err", message: "Failed to search cases." });
+    }
+});
+
+router.get("/cases/:id(\\d+)/download-link", async (req, res) => {
+    if (!requireRole(req, res, ["P", "A"])) {
+        return;
+    }
+
+    const caseId = Number(req.params.id);
+    if (!Number.isInteger(caseId)) {
+        return res.status(400).json({ status: "err", message: "Invalid case id." });
+    }
+
+    try {
+        const caseObj = await rpg2.singleSQL({
+            dbcon: config.dbconnString,
+            sql: `
+                SELECT id, pdf_path
+                FROM ethical_cases
+                WHERE id = $1;
+            `,
+            sqlParams: [rpg2.param("plain", caseId)],
+        });
+
+        if (!caseObj || !caseObj.id) {
+            return res.status(404).json({ status: "err", message: "Case not found." });
+        }
+
+        return res.status(200).json({
+            status: "ok",
+            result: {
+                id: caseObj.id,
+                downloadUrl: caseObj.pdf_path,
+            },
+        });
+    } catch (error) {
+        console.error("Error retrieving case download link:", error);
+        return res.status(500).json({ status: "err", message: "Failed to load case file link." });
     }
 });
 
@@ -135,7 +209,7 @@ router.post("/cases", async (req, res) => {
     }
 });
 
-router.patch("/cases/:id", async (req, res) => {
+router.patch("/cases/:id(\\d+)", async (req, res) => {
     if (!requireRole(req, res, "P")) {
         return;
     }
@@ -204,7 +278,7 @@ router.patch("/cases/:id", async (req, res) => {
     }
 });
 
-router.delete("/cases/:id", async (req, res) => {
+router.delete("/cases/:id(\\d+)", async (req, res) => {
     if (!requireRole(req, res, "P")) {
         return;
     }

--- a/ethicapp/backend/controllers/designs.js
+++ b/ethicapp/backend/controllers/designs.js
@@ -4,6 +4,7 @@ import express from "express";
 import * as config from "../config/config.js"; 
 import * as rpg2 from "../db/rest-pg-2.js";
 import { hasTheUserRoleById } from '../helpers/users-helper.js';
+import { requireRole } from "../helpers/auth-helper.js";
 
 const router = express.Router();
 
@@ -43,7 +44,7 @@ router.get("/designs/:id", async (req, res) => {
 router.post("/designs", async (req, res) => {
     try {
         const sessionUid = req.session?.uid;
-        const { design } = req.body; // Extract the design object from the request body
+        const { design, caseId = null } = req.body; // Extract the design object from the request body
 
         // Validate session
         if (!sessionUid) {
@@ -61,13 +62,14 @@ router.post("/designs", async (req, res) => {
         const result = await rpg2.singleSQL({
             dbcon: config.dbconnString,
             sql: `
-                INSERT INTO designs (creator, design)
-                VALUES ($1, $2)
+                INSERT INTO designs (creator, design, case_id)
+                VALUES ($1, $2, $3)
                 RETURNING id
             `,
             sqlParams: [
                 rpg2.param("plain", sessionUid), // Pass the session user ID as creator
                 rpg2.param("plain", JSON.stringify(designNoId)), // Serialize the design object
+                rpg2.param("plain", caseId),
             ],
         });
 
@@ -87,7 +89,7 @@ router.patch("/designs/:id", async (req, res) => {
     try {
         const sessionUid = req.session?.uid;
         const designId = parseInt(req.params.id, 10); // Convert designId to an integer
-        const { design } = req.body; // Extract the updated design from the request body
+        const { design, caseId = null } = req.body; // Extract the updated design from the request body
 
         // Validate session
         if (!sessionUid) {
@@ -127,11 +129,13 @@ router.patch("/designs/:id", async (req, res) => {
             dbcon: config.dbconnString,
             sql: `
                 UPDATE designs
-                SET design = $1
-                WHERE id = $2
+                SET design = $1,
+                    case_id = $2
+                WHERE id = $3
             `,
             sqlParams: [
                 rpg2.param("plain", designNoId),
+                rpg2.param("plain", caseId),
                 rpg2.param("plain", designId),
             ],
         });
@@ -206,6 +210,7 @@ router.get("/users/:id/designs", async (req, res) => {
             dbcon: config.dbconnString,
             sql: `
                 SELECT id, design, public, locked
+                       , case_id
                 FROM designs
                 WHERE creator = $1
                 ORDER BY id DESC;
@@ -219,6 +224,7 @@ router.get("/users/:id/designs", async (req, res) => {
             id: row.id,
             public: row.public,
             locked: row.locked,
+            caseId: row.case_id,
         }));
 
         // Return the formatted designs
@@ -242,6 +248,7 @@ router.get("/designs", async (req, res) => {
             dbcon: config.dbconnString,
             sql: `
                 SELECT DISTINCT ON (id) id, design, public, locked, 
+                       case_id,
                        CASE WHEN creator = $1 THEN TRUE ELSE FALSE END AS user_owned
                 FROM designs
                 WHERE creator = $1 OR public = TRUE
@@ -256,6 +263,7 @@ router.get("/designs", async (req, res) => {
             id: row.id,
             public: row.public,
             locked: row.locked,
+            caseId: row.case_id,
             userOwned: row.user_owned,
         }));
 
@@ -478,6 +486,57 @@ router.get('/designs/:id/valid', async (req, res) => {
     } catch (err) {
         console.error('Error in GET /designs/:id/valid:', err);
         return res.status(500).json({ status: 'err', message: 'Internal Server Error' });
+    }
+});
+
+router.get("/designs/:id/case", async (req, res) => {
+    if (!requireRole(req, res, ["P", "A"])) {
+        return;
+    }
+
+    try {
+        const designId = parseInt(req.params.id, 10);
+        if (isNaN(designId)) {
+            return res.status(400).json({ status: "err", message: "Invalid design ID" });
+        }
+
+        const result = await rpg2.singleSQL({
+            dbcon: config.dbconnString,
+            sql: `
+                SELECT d.id AS design_id,
+                       c.id,
+                       c.title,
+                       c.author_firstname,
+                       c.author_lastname,
+                       c.author_email
+                FROM designs d
+                LEFT JOIN ethical_cases c ON c.id = d.case_id
+                WHERE d.id = $1;
+            `,
+            sqlParams: [rpg2.param("plain", designId)],
+        });
+
+        if (!result || !result.design_id) {
+            return res.status(404).json({ status: "err", message: "Design not found" });
+        }
+
+        if (!result.id) {
+            return res.status(200).json({ status: "ok", result: null });
+        }
+
+        return res.status(200).json({
+            status: "ok",
+            result: {
+                id: result.id,
+                title: result.title,
+                authorFirstname: result.author_firstname,
+                authorLastname: result.author_lastname,
+                authorEmail: result.author_email,
+            },
+        });
+    } catch (err) {
+        console.error("Error in GET /designs/:id/case:", err);
+        return res.status(500).json({ status: "err", message: "Internal Server Error" });
     }
 });
 

--- a/ethicapp/frontend/assets/js/controllers/teacher/design-editor.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/design-editor.controller.js
@@ -3,7 +3,7 @@ import * as phaseValidationHelpers from "../../helpers/phase-validation-helpers.
 import accordionStateHelpers from "../../helpers/accordeon-state-helpers.js"
 
 export function DesignEditorController($scope, $translate, $timeout,
-    $routeParams, DesignStateService, DesignCatalogService, toast) {
+    $routeParams, DesignStateService, DesignCatalogService, CasesCatalogService, toast) {
 
     const vm = this;
     vm.designId = 0;
@@ -14,6 +14,7 @@ export function DesignEditorController($scope, $translate, $timeout,
         global: [], // Global design-related errors
         phases: {}, // Specific per-phase errors
     };
+    vm.associatedCase = null;
     
     vm.init = async function() {
         // Retrieve the design from the route path
@@ -36,10 +37,68 @@ export function DesignEditorController($scope, $translate, $timeout,
             });
 
             await DesignStateService.setDesign(designId, designObj);
+            await vm.loadAssociatedCase();
 
             //vm.initializePhases();
             vm.initializeAccordionStates();
         }
+    };
+
+    vm.loadAssociatedCase = async function() {
+        vm.associatedCase = null;
+        if (!vm.designId) {
+            return;
+        }
+        try {
+            const response = await CasesCatalogService.getCaseByDesignId(vm.designId);
+            vm.associatedCase = response;
+            if (response && response.id) {
+                vm.design.caseId = response.id;
+                vm.selectedCase = vm.formatCaseLabel(response);
+            } else {
+                vm.design.caseId = null;
+                vm.selectedCase = "";
+            }
+        } catch (error) {
+            console.error("[DesignEditorController::loadAssociatedCase] Error loading associated case.", error);
+            vm.design.caseId = null;
+            vm.selectedCase = "";
+        } finally {
+            $scope.$applyAsync();
+        }
+    };
+
+    vm.searchCases = async function(query) {
+        return CasesCatalogService.searchCases(query);
+    };
+
+    vm.selectCase = function(caseItem) {
+        if (!caseItem) {
+            vm.design.caseId = null;
+            vm.associatedCase = null;
+            vm.selectedCase = "";
+            return;
+        }
+        vm.design.caseId = caseItem.id;
+        vm.associatedCase = caseItem;
+        vm.selectedCase = vm.formatCaseLabel(caseItem);
+    };
+
+    vm.clearAssociatedCase = function() {
+        vm.design.caseId = null;
+        vm.associatedCase = null;
+        vm.selectedCase = "";
+    };
+
+    vm.formatCaseLabel = function(caseItem) {
+        if (!caseItem) {
+            return "";
+        }
+        const hasAuthor = caseItem.authorFirstname || caseItem.authorLastname;
+        if (hasAuthor) {
+            return `${caseItem.title} (${caseItem.authorFirstname || ""} ${caseItem.authorLastname || ""})`.trim();
+        }
+        return caseItem.title;
     };
 
     vm.initializeAccordionStates = function () {

--- a/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
+++ b/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
@@ -129,7 +129,7 @@ app.controller("ErrorController",
         ErrorController]);
 app.controller("DesignEditorController", 
     ["$scope", "$translate", "$timeout", "$routeParams", "DesignStateService", 
-        "DesignCatalogService", "toast", DesignEditorController]);         
+        "DesignCatalogService", "CasesCatalogService", "toast", DesignEditorController]);         
 app.controller("VoidController", [VoidController]);
 
 app.service("DialogService", function(ngDialog) {

--- a/ethicapp/frontend/assets/js/services/cases-catalog.service.js
+++ b/ethicapp/frontend/assets/js/services/cases-catalog.service.js
@@ -20,6 +20,27 @@ let CasesCatalogService = ($http) => {
             return response.data.result;
         },
 
+        async getCaseByDesignId(designId) {
+            const response = await $http.get(`/designs/${designId}/case`);
+            return response.data.result;
+        },
+
+        async searchCases(query) {
+            const trimmedQuery = String(query || "").trim();
+            if (trimmedQuery.length < 2) {
+                return [];
+            }
+            const response = await $http.get("/cases/search", {
+                params: { q: trimmedQuery },
+            });
+            return Array.isArray(response.data.result) ? response.data.result : [];
+        },
+
+        async getCaseDownloadLink(caseId) {
+            const response = await $http.get(`/cases/${caseId}/download-link`);
+            return response.data.result;
+        },
+
         async createCase(caseData) {
             const formData = new FormData();
             formData.append("title", caseData.title);

--- a/ethicapp/frontend/assets/js/services/design-catalog.service.js
+++ b/ethicapp/frontend/assets/js/services/design-catalog.service.js
@@ -57,7 +57,10 @@ let DesignCatalogService = ($rootScope, $http) => {
         async createDesign(design) {
             try {
                 // Make the POST request to the API
-                const response = await $http.post("/designs", { design });
+                const response = await $http.post("/designs", {
+                    design,
+                    caseId: design.caseId ?? null,
+                });
 
                 // Check the response status
                 if (response.data.status === "ok") {
@@ -202,7 +205,10 @@ let DesignCatalogService = ($rootScope, $http) => {
                 const response = await $http({
                     url: `/designs/${designId}`,
                     method: "PATCH",
-                    data: { design: designObj }, // Send the updated design object in the request body
+                    data: {
+                        design: designObj,
+                        caseId: designObj.caseId ?? null,
+                    }, // Send the updated design object in the request body
                 });
         
                 // Check the response status

--- a/ethicapp/frontend/assets/locales/en.json
+++ b/ethicapp/frontend/assets/locales/en.json
@@ -323,5 +323,9 @@
 	"ethical_cases_open_file": "Open file",
 	"ethical_cases_current_file": "Current file",
 	"author_firstname": "Author First Name",
-	"author_lastname": "Author Last Name"
+	"author_lastname": "Author Last Name",
+	"design_associated_case_label": "Associated case",
+	"design_associated_case_placeholder": "Search case by title or author",
+	"design_no_case_associated": "No case is associated.",
+	"design_associated_case_current": "Current case"
 }

--- a/ethicapp/frontend/assets/locales/en_US.json
+++ b/ethicapp/frontend/assets/locales/en_US.json
@@ -557,5 +557,9 @@
 	"ethical_cases_open_file": "Open file",
 	"ethical_cases_current_file": "Current file",
 	"author_firstname": "Author First Name",
-	"author_lastname": "Author Last Name"
+	"author_lastname": "Author Last Name",
+	"design_associated_case_label": "Associated case",
+	"design_associated_case_placeholder": "Search case by title or author",
+	"design_no_case_associated": "No case is associated.",
+	"design_associated_case_current": "Current case"
 }

--- a/ethicapp/frontend/assets/locales/es.json
+++ b/ethicapp/frontend/assets/locales/es.json
@@ -325,5 +325,9 @@
 	"ethical_cases_open_file": "Abrir archivo",
 	"ethical_cases_current_file": "Archivo actual",
 	"author_firstname": "Nombre del autor",
-	"author_lastname": "Apellido del autor"
+	"author_lastname": "Apellido del autor",
+	"design_associated_case_label": "Caso asociado",
+	"design_associated_case_placeholder": "Buscar caso por título o autor",
+	"design_no_case_associated": "No hay caso asociado.",
+	"design_associated_case_current": "Caso actual"
 }

--- a/ethicapp/frontend/assets/locales/es_CL.json
+++ b/ethicapp/frontend/assets/locales/es_CL.json
@@ -567,5 +567,9 @@
 	"ethical_cases_open_file": "Abrir archivo",
 	"ethical_cases_current_file": "Archivo actual",
 	"author_firstname": "Nombre del autor",
-	"author_lastname": "Apellido del autor"
+	"author_lastname": "Apellido del autor",
+	"design_associated_case_label": "Caso asociado",
+	"design_associated_case_placeholder": "Buscar caso por título o autor",
+	"design_no_case_associated": "No hay caso asociado.",
+	"design_associated_case_current": "Caso actual"
 }

--- a/ethicapp/frontend/assets/static/views/teacher/design.edit.html
+++ b/ethicapp/frontend/assets/static/views/teacher/design.edit.html
@@ -3,6 +3,29 @@
         <div class="col-md-12 mb-2">
             
             <h2><i class="fa fa-paint-brush"></i> {{ 'edit_design_title' | translate }}</h2>
+            <div class="well well-sm">
+                <label for="designCaseSearch">{{ 'design_associated_case_label' | translate }}</label>
+                <input
+                    id="designCaseSearch"
+                    type="text"
+                    class="form-control"
+                    placeholder="{{ 'design_associated_case_placeholder' | translate }}"
+                    ng-model="dec.selectedCase"
+                    uib-typeahead="caseItem as dec.formatCaseLabel(caseItem) for caseItem in dec.searchCases($viewValue)"
+                    typeahead-on-select="dec.selectCase($item)"
+                    typeahead-editable="false"
+                    typeahead-min-length="2">
+                <p class="help-block" ng-if="!dec.associatedCase">
+                    {{ 'design_no_case_associated' | translate }}
+                </p>
+                <p class="help-block" ng-if="dec.associatedCase">
+                    <strong>{{ 'design_associated_case_current' | translate }}:</strong>
+                    {{ dec.formatCaseLabel(dec.associatedCase) }}
+                    <button type="button" class="btn btn-link btn-xs" ng-click="dec.clearAssociatedCase()">
+                        {{ 'remove' | translate }}
+                    </button>
+                </p>
+            </div>
         </div>
     </div>
     <div class="form-group">


### PR DESCRIPTION
### Motivation
- Allow instructional `designs` to be linked to an `ethical_case` so editors can attach a case to a design and students/teachers can retrieve that relation. 
- Provide a simple, responsive case lookup (typeahead) and file-download link for cases, usable by both teachers (`P`) and students (`A`).

### Description
- Database: added migration `database/create_39.sql` to add nullable `designs.case_id` with FK to `ethical_cases(id)` (`ON DELETE SET NULL`) and an index `idx_designs_case_id`.
- Backend (`ethicapp/backend/controllers`): added case-search and file-link endpoints to `cases.js`:
  - `GET /cases/search?q=...` accessible to roles `P` or `A`, searches `title`, `author_firstname` and `author_lastname` (case-insensitive `LIKE`).
  - `GET /cases/:id/download-link` accessible to roles `P` or `A`, returns `{ id, downloadUrl }`.
  - Constrained numeric `:id(\\d+)` routes to avoid collisions with `/cases/search`.
- Backend (`designs.js`): persist `case_id` on `POST /designs` and `PATCH /designs/:id`, include `caseId` in design lists, and add `GET /designs/:id/case` (roles `P` or `A`) to return associated case metadata or `null` when none is attached.
- Frontend (legacy AngularJS teacher UI): added a section under the design title in `design.edit.html` with a `uib-typeahead` input to search and attach/remove cases and explicit messaging when no case is associated.
- Frontend services/controllers:
  - `CasesCatalogService`: added `searchCases`, `getCaseByDesignId`, and `getCaseDownloadLink` methods.
  - `DesignCatalogService`: include `caseId` when creating/updating designs.
  - `DesignEditorController`: load associated case on init, manage selection/clear, and provide `formatCaseLabel` for typeahead labels.
  - Wired `CasesCatalogService` into `teacher-admin.mjs` and injected into the design editor controller.
- I18n: added translation keys for the new UI strings in `en.json`, `en_US.json`, `es.json`, and `es_CL.json`.
- Documentation: updated `AGENTS.md` (section 7) to recommend `requireRole` usage with single or multiple roles.

### Testing
- Ran `node --check` on modified JS/MJS files (`ethicapp/backend/controllers/cases.js`, `ethicapp/backend/controllers/designs.js`, `ethicapp/frontend/assets/js/controllers/teacher/design-editor.controller.js`, `ethicapp/frontend/assets/js/services/cases-catalog.service.js`, `ethicapp/frontend/assets/js/services/design-catalog.service.js`, `ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs`) — checks passed.
- Validated JSON locale files with `jq empty` for modified locale files — succeeded.
- Ran `npm run lint-js` — the command executed but reported many pre-existing lint errors across the legacy codebase unrelated to this change (lint did not pass repository-wide); the changes themselves were limited and compatible with existing patterns.
- No new automated unit tests were added in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0eca5420832baa7a412545130bd3)