### PR TITLE
Add reusable validated case form component and improve create/edit UX

### DIFF
--- a/ethicapp/frontend/assets/css/main.css
+++ b/ethicapp/frontend/assets/css/main.css
@@ -2338,6 +2338,10 @@ h2{
     border: 1px solid #ffc107; /* Orange border */
 }
 
+.case-form-field {
+    max-width: 42rem;
+}
+
 .toast-container .alert {
     height: 1.75em !important;
     margin-left: auto;

--- a/ethicapp/frontend/assets/js/components/case-form-editor.component.js
+++ b/ethicapp/frontend/assets/js/components/case-form-editor.component.js
@@ -1,0 +1,46 @@
+const CaseFormEditorController = function() {
+    const vm = this;
+
+    vm.$onInit = function() {
+        vm.hasAttemptedSubmit = false;
+    };
+
+    vm.onSubmit = function(form) {
+        vm.hasAttemptedSubmit = true;
+        if (!form || !form.$valid || !vm.onSave) {
+            return;
+        }
+
+        vm.onSave();
+    };
+
+    vm.shouldShowError = function(control) {
+        if (!control) {
+            return false;
+        }
+
+        return control.$invalid && (control.$touched || vm.hasAttemptedSubmit);
+    };
+
+    vm.handlePdfSelected = function(files) {
+        if (vm.onPdfSelected) {
+            vm.onPdfSelected({ files });
+        }
+    };
+};
+
+const caseFormEditorComponent = {
+    bindings: {
+        formModel:      "=",
+        submitLabelKey: "@",
+        isPdfRequired:  "<",
+        showCurrentPdf: "<",
+        onSave:         "&",
+        onCancel:       "&",
+        onPdfSelected:  "&",
+    },
+    controller:  CaseFormEditorController,
+    templateUrl: "/assets/static/views/teacher/fragments/case-form-editor.template.html",
+};
+
+export default caseFormEditorComponent;

--- a/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
+++ b/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
@@ -196,6 +196,7 @@ import itemDuplicatorComponent from "../../components/item-duplicator.component.
 import designErrorSummaryComponent from "../../components/design-error-summary.component.js";
 import itemMoverComponent from '../../components/item-mover.component.js';
 import designItemComponent from '../../components/design-item.component.js';
+import caseFormEditorComponent from "../../components/case-form-editor.component.js";
 
 app.component('activityDescription', activityDescriptionComponent);
 app.component('designDescription', designDescriptionComponent);
@@ -210,6 +211,7 @@ app.component('designErrorSummary', designErrorSummaryComponent);
 app.component('rankingItemEditor', rankingItemEditorComponent);
 app.component('sdItemEditor', sdItemEditorComponent);
 app.component('designItem', designItemComponent);
+app.component("caseFormEditor", caseFormEditorComponent);
 
 import { userRolesFilter } from '../../filters/user-roles.filter.js';
 app.filter("roleTranslate", ["$translate", userRolesFilter]);

--- a/ethicapp/frontend/assets/locales/en.json
+++ b/ethicapp/frontend/assets/locales/en.json
@@ -334,6 +334,10 @@
 	"ethical_cases_file": "Case PDF",
 	"ethical_cases_open_file": "Open file",
 	"ethical_cases_current_file": "Current file",
+
+	"ethical_cases_validation_required": "This field is required.",
+	"ethical_cases_validation_email": "Please enter a valid email address.",
+	"ethical_cases_validation_pdf_required": "A PDF file is required.",
 	"empty_cases_message": "There are no ethical cases yet, but you can",
 	"empty_cases_link": "create one now",
 	"author_firstname": "Author First Name",

--- a/ethicapp/frontend/assets/locales/en_US.json
+++ b/ethicapp/frontend/assets/locales/en_US.json
@@ -568,6 +568,10 @@
 	"ethical_cases_file": "Case PDF",
 	"ethical_cases_open_file": "Open file",
 	"ethical_cases_current_file": "Current file",
+
+	"ethical_cases_validation_required": "This field is required.",
+	"ethical_cases_validation_email": "Please enter a valid email address.",
+	"ethical_cases_validation_pdf_required": "A PDF file is required.",
 	"empty_cases_message": "There are no ethical cases yet, but you can",
 	"empty_cases_link": "create one now",
 	"author_firstname": "Author First Name",

--- a/ethicapp/frontend/assets/locales/es.json
+++ b/ethicapp/frontend/assets/locales/es.json
@@ -336,6 +336,10 @@
 	"ethical_cases_file": "PDF del caso",
 	"ethical_cases_open_file": "Abrir archivo",
 	"ethical_cases_current_file": "Archivo actual",
+
+	"ethical_cases_validation_required": "Este campo es obligatorio.",
+	"ethical_cases_validation_email": "Ingresa un correo electrónico válido.",
+	"ethical_cases_validation_pdf_required": "Debes seleccionar un archivo PDF.",
 	"empty_cases_message": "Aún no hay casos, pero puedes",
 	"empty_cases_link": "crear uno ahora",
 	"author_firstname": "Nombre del autor",

--- a/ethicapp/frontend/assets/locales/es_CL.json
+++ b/ethicapp/frontend/assets/locales/es_CL.json
@@ -578,6 +578,10 @@
 	"ethical_cases_file": "PDF del caso",
 	"ethical_cases_open_file": "Abrir archivo",
 	"ethical_cases_current_file": "Archivo actual",
+
+	"ethical_cases_validation_required": "Este campo es obligatorio.",
+	"ethical_cases_validation_email": "Ingresa un correo electrónico válido.",
+	"ethical_cases_validation_pdf_required": "Debes seleccionar un archivo PDF.",
 	"empty_cases_message": "Aún no hay casos, pero puedes",
 	"empty_cases_link": "crear uno ahora",
 	"author_firstname": "Nombre del autor",

--- a/ethicapp/frontend/assets/static/views/teacher/cases.edit.html
+++ b/ethicapp/frontend/assets/static/views/teacher/cases.edit.html
@@ -1,36 +1,13 @@
 <div ng-controller="CasesController as vm" ng-init="vm.loadCase()">
     <h2>{{ 'ethical_cases_edit_title' | translate }}</h2>
 
-    <form name="editCaseForm" ng-submit="editCaseForm.$valid && vm.updateCase()" novalidate>
-        <div class="form-group">
-            <label>{{ 'title' | translate }}</label>
-            <input type="text" class="form-control" ng-model="vm.form.title" required>
-        </div>
-
-        <div class="form-group">
-            <label>{{ 'author_firstname' | translate }}</label>
-            <input type="text" class="form-control" ng-model="vm.form.authorFirstname" required>
-        </div>
-
-        <div class="form-group">
-            <label>{{ 'author_lastname' | translate }}</label>
-            <input type="text" class="form-control" ng-model="vm.form.authorLastname" required>
-        </div>
-
-        <div class="form-group">
-            <label>{{ 'email' | translate }}</label>
-            <input type="email" class="form-control" ng-model="vm.form.authorEmail" required>
-        </div>
-
-        <div class="form-group">
-            <label>{{ 'ethical_cases_file' | translate }}</label>
-            <p ng-if="vm.form.currentPdfPath">
-                <a ng-href="{{ vm.form.currentPdfPath }}" target="_blank" rel="noopener noreferrer">{{ 'ethical_cases_current_file' | translate }}</a>
-            </p>
-            <input type="file" class="form-control" accept="application/pdf" onchange="angular.element(this).scope().vm.handlePdfSelected(this.files)">
-        </div>
-
-        <button type="submit" class="btn btn-primary">{{ 'saveChanges' | translate }}</button>
-        <button type="button" class="btn btn-default" ng-click="navigateTo('/cases')">{{ 'back' | translate }}</button>
-    </form>
+    <case-form-editor
+        form-model="vm.form"
+        submit-label-key="saveChanges"
+        is-pdf-required="false"
+        show-current-pdf="true"
+        on-save="vm.updateCase()"
+        on-cancel="navigateTo('/cases')"
+        on-pdf-selected="vm.handlePdfSelected(files)">
+    </case-form-editor>
 </div>

--- a/ethicapp/frontend/assets/static/views/teacher/cases.new.html
+++ b/ethicapp/frontend/assets/static/views/teacher/cases.new.html
@@ -1,33 +1,13 @@
 <div ng-controller="CasesController as vm">
     <h2>{{ 'ethical_cases_new_title' | translate }}</h2>
 
-    <form name="newCaseForm" ng-submit="newCaseForm.$valid && vm.createCase()" novalidate>
-        <div class="form-group">
-            <label>{{ 'title' | translate }}</label>
-            <input type="text" class="form-control" ng-model="vm.form.title" required>
-        </div>
-
-        <div class="form-group">
-            <label>{{ 'author_firstname' | translate }}</label>
-            <input type="text" class="form-control" ng-model="vm.form.authorFirstname" required>
-        </div>
-
-        <div class="form-group">
-            <label>{{ 'author_lastname' | translate }}</label>
-            <input type="text" class="form-control" ng-model="vm.form.authorLastname" required>
-        </div>
-
-        <div class="form-group">
-            <label>{{ 'email' | translate }}</label>
-            <input type="email" class="form-control" ng-model="vm.form.authorEmail" required>
-        </div>
-
-        <div class="form-group">
-            <label>{{ 'ethical_cases_file' | translate }}</label>
-            <input type="file" class="form-control" accept="application/pdf" onchange="angular.element(this).scope().vm.handlePdfSelected(this.files)" required>
-        </div>
-
-        <button type="submit" class="btn btn-primary">{{ 'save' | translate }}</button>
-        <button type="button" class="btn btn-default" ng-click="navigateTo('/cases')">{{ 'back' | translate }}</button>
-    </form>
+    <case-form-editor
+        form-model="vm.form"
+        submit-label-key="save"
+        is-pdf-required="true"
+        show-current-pdf="false"
+        on-save="vm.createCase()"
+        on-cancel="navigateTo('/cases')"
+        on-pdf-selected="vm.handlePdfSelected(files)">
+    </case-form-editor>
 </div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/case-form-editor.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/case-form-editor.template.html
@@ -1,0 +1,88 @@
+<form name="caseForm" ng-submit="$ctrl.onSubmit(caseForm)" novalidate>
+    <div class="form-group case-form-field">
+        <label for="caseTitle">{{ 'title' | translate }}</label>
+        <input
+            id="caseTitle"
+            type="text"
+            name="title"
+            class="form-control"
+            ng-model="$ctrl.formModel.title"
+            ng-class="{'input-warning': $ctrl.shouldShowError(caseForm.title)}"
+            required>
+        <p class="help-block text-danger" ng-if="$ctrl.shouldShowError(caseForm.title)">
+            {{ 'ethical_cases_validation_required' | translate }}
+        </p>
+    </div>
+
+    <div class="form-group case-form-field">
+        <label for="caseAuthorFirstname">{{ 'author_firstname' | translate }}</label>
+        <input
+            id="caseAuthorFirstname"
+            type="text"
+            name="authorFirstname"
+            class="form-control"
+            ng-model="$ctrl.formModel.authorFirstname"
+            ng-class="{'input-warning': $ctrl.shouldShowError(caseForm.authorFirstname)}"
+            required>
+        <p class="help-block text-danger" ng-if="$ctrl.shouldShowError(caseForm.authorFirstname)">
+            {{ 'ethical_cases_validation_required' | translate }}
+        </p>
+    </div>
+
+    <div class="form-group case-form-field">
+        <label for="caseAuthorLastname">{{ 'author_lastname' | translate }}</label>
+        <input
+            id="caseAuthorLastname"
+            type="text"
+            name="authorLastname"
+            class="form-control"
+            ng-model="$ctrl.formModel.authorLastname"
+            ng-class="{'input-warning': $ctrl.shouldShowError(caseForm.authorLastname)}"
+            required>
+        <p class="help-block text-danger" ng-if="$ctrl.shouldShowError(caseForm.authorLastname)">
+            {{ 'ethical_cases_validation_required' | translate }}
+        </p>
+    </div>
+
+    <div class="form-group case-form-field">
+        <label for="caseAuthorEmail">{{ 'email' | translate }}</label>
+        <input
+            id="caseAuthorEmail"
+            type="email"
+            name="authorEmail"
+            class="form-control"
+            ng-model="$ctrl.formModel.authorEmail"
+            ng-class="{'input-warning': $ctrl.shouldShowError(caseForm.authorEmail)}"
+            required>
+        <p class="help-block text-danger" ng-if="$ctrl.shouldShowError(caseForm.authorEmail) && caseForm.authorEmail.$error.required">
+            {{ 'ethical_cases_validation_required' | translate }}
+        </p>
+        <p class="help-block text-danger" ng-if="$ctrl.shouldShowError(caseForm.authorEmail) && caseForm.authorEmail.$error.email">
+            {{ 'ethical_cases_validation_email' | translate }}
+        </p>
+    </div>
+
+    <div class="form-group case-form-field">
+        <label for="casePdf">{{ 'ethical_cases_file' | translate }}</label>
+        <p ng-if="$ctrl.showCurrentPdf && $ctrl.formModel.currentPdfPath">
+            <a ng-href="{{ $ctrl.formModel.currentPdfPath }}" target="_blank" rel="noopener noreferrer">
+                {{ 'ethical_cases_current_file' | translate }}
+            </a>
+        </p>
+        <input
+            id="casePdf"
+            type="file"
+            name="pdf"
+            class="form-control"
+            accept="application/pdf"
+            ngf-select="$ctrl.handlePdfSelected($files)"
+            ng-class="{'input-warning': $ctrl.shouldShowError(caseForm.pdf)}"
+            ng-required="$ctrl.isPdfRequired">
+        <p class="help-block text-danger" ng-if="$ctrl.shouldShowError(caseForm.pdf) && caseForm.pdf.$error.required">
+            {{ 'ethical_cases_validation_pdf_required' | translate }}
+        </p>
+    </div>
+
+    <button type="submit" class="btn btn-primary">{{ $ctrl.submitLabelKey | translate }}</button>
+    <button type="button" class="btn btn-default" ng-click="$ctrl.onCancel()">{{ 'back' | translate }}</button>
+</form>


### PR DESCRIPTION
### Motivation
- The create/edit case views duplicated form markup, lacked per-field validation feedback, and used full-width text inputs that reduced readability.

### Description
- Introduce a reusable `caseFormEditor` component (`ethicapp/frontend/assets/js/components/case-form-editor.component.js`) with submission handling, touched/submit-aware validation state, and a callback for file selection.
- Add the component template (`ethicapp/frontend/assets/static/views/teacher/fragments/case-form-editor.template.html`) implementing per-field error messages, email validation, required-PDF handling, and `ngf-select` for file selection.
- Replace the duplicated forms in `cases.new.html` and `cases.edit.html` to use the new component and register it in `ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs`.
- Improve form UX by limiting input width with a new `.case-form-field` CSS rule in `ethicapp/frontend/assets/css/main.css` and add i18n keys for validation messages in `en`, `en_US`, `es`, and `es_CL` locale files.

### Testing
- Ran `npx eslint --fix ethicapp/frontend/assets/js/components/case-form-editor.component.js`, which completed successfully for the new component file.
- Verified edited locale JSON files parse with `node` (JSON.parse) to ensure syntactic correctness across the four locale files edited.
- Ran `npm run lint-js`; it reported failures but these are from extensive pre-existing repository lint errors outside the scope of this change and do not affect the new component's linting outcome.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb142e190832bacf217932b19d0a7)