### PR TITLE
Improve case form validation error message styling

### DIFF
--- a/ethicapp/frontend/assets/css/main.css
+++ b/ethicapp/frontend/assets/css/main.css
@@ -2342,6 +2342,16 @@ h2{
     max-width: 42rem;
 }
 
+.case-form-field .help-block {
+    margin-top: 5px;
+    margin-bottom: 0;
+    white-space: normal;
+}
+
+.case-form-field .help-block.text-danger {
+    color: #a94442;
+}
+
 .toast-container .alert {
     height: 1.75em !important;
     margin-left: auto;


### PR DESCRIPTION
### Motivation
- Validation messages in the teacher case form were visually offset and had excessive vertical spacing due to global paragraph rules (`p { white-space: pre-wrap; }`) and conflicting styles.
- The error text color could be overridden and should consistently use the Bootstrap danger red for visibility.

### Description
- Added scoped CSS rules in `ethicapp/frontend/assets/css/main.css` under `.case-form-field` to normalize help text behavior and spacing for validation messages.
- New rules set `white-space: normal`, `margin-top: 5px`, and `margin-bottom: 0` for `.case-form-field .help-block` to prevent template indentation from shifting the message and keep it visually attached to the input.
- Explicitly enforced the danger color for messages in the case form with `.case-form-field .help-block.text-danger { color: #a94442; }`.

### Testing
- Ran `npm run lint-css` (stylelint) against the repository; the run failed due to numerous pre-existing stylelint violations unrelated to this small, scoped change.
- Verified the CSS change via repository inspection and a `git` commit containing the styling edits; the change is intentionally scoped to `.case-form-field` to avoid side effects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb4664534832b90c67e86a6fd99a2)