### PR TITLE
Fix infinite /designs fetch loop when design catalog is empty

### DIFF
--- a/ethicapp/frontend/assets/js/services/design-catalog.service.js
+++ b/ethicapp/frontend/assets/js/services/design-catalog.service.js
@@ -1,6 +1,7 @@
 let DesignCatalogService = ($rootScope, $http) => {
     const service = {
         designs: [],
+        hasLoadedDesigns: false,
         listeners: {}, // Subscribed listeners
 
         async loadDesigns() {
@@ -10,6 +11,7 @@ let DesignCatalogService = ($rootScope, $http) => {
                 // Validate the response structure
                 if (response.data.status === "ok" && Array.isArray(response.data.result)) {
                     service.designs = response.data.result; // Assign the fetched designs
+                    service.hasLoadedDesigns = true;
                     
                     // Notify listeners
                     service.notifyListeners("onDesignCatalogUpdated", { 
@@ -24,14 +26,14 @@ let DesignCatalogService = ($rootScope, $http) => {
         },
 
         async getDesigns(reload = false) {
-            if (reload || service.designs.length === 0) {
+            if (reload || !service.hasLoadedDesigns) {
                 await service.loadDesigns();
             }
             return service.designs;
         },
 
         async getUserDesigns(reload = false) {
-            if (reload || service.designs.length === 0) {
+            if (reload || !service.hasLoadedDesigns) {
                 await service.loadDesigns();
             }
             const result = service.designs.filter(design => design.userOwned === true);
@@ -39,7 +41,7 @@ let DesignCatalogService = ($rootScope, $http) => {
         },
 
         async getPublicDesigns(reload = false) {
-            if (reload || service.designs.length === 0) {
+            if (reload || !service.hasLoadedDesigns) {
                 await service.loadDesigns();
             }
             const result = service.designs.filter(design => design.public === true && 
@@ -48,7 +50,7 @@ let DesignCatalogService = ($rootScope, $http) => {
         },
 
         async getDesignById(id, reload = false) {
-            if (reload || service.designs.length === 0) {
+            if (reload || !service.hasLoadedDesigns) {
                 await service.loadDesigns();
             }
             return service.designs.find(design => design.id === id) || null;


### PR DESCRIPTION
### Motivation
- Users reported an infinite client-side request loop to `GET /designs` when launching a new activity (`/activities/new`) on a fresh database with no designs.
- Investigation showed `BrowseDesignsController` subscribes to `onDesignCatalogUpdated` and calls `forceFetchDesigns()`, while `DesignCatalogService` treated an empty array (`[]`) as "not loaded", causing repeated calls and listener notifications that created a feedback loop.

### Description
- Added a `hasLoadedDesigns` boolean flag to `DesignCatalogService` to mark that a successful `loadDesigns()` request completed even if `result` is empty at `ethicapp/frontend/assets/js/services/design-catalog.service.js`.
- Set `hasLoadedDesigns = true` after a successful response in `loadDesigns()` and replaced `service.designs.length === 0` checks with `!service.hasLoadedDesigns` in `getDesigns`, `getUserDesigns`, `getPublicDesigns`, and `getDesignById`.
- This prevents redundant reloads when the server returns an empty but valid `result`, breaking the controller↔service notification loop that caused the repeated `GET /designs` requests.
- Performed static inspection of `GET /designs` backend endpoint (`ethicapp/backend/controllers/designs.js`) and `nginx/conf.d/dev.conf` to confirm the endpoint returns JSON and there are no nginx redirects that would explain the observed loop.

### Testing
- Ran `npx eslint` on the changed file (`ethicapp/frontend/assets/js/services/design-catalog.service.js`), which executed but reported pre-existing lint violations; the lint run failed for style issues unrelated to the functional change.
- No other automated unit/integration tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0f4d3d5c832b9ac29bda905a1543)