### PR TITLE
Fix profile hydration and disable caching for /users/profile

### DIFF
--- a/ethicapp/backend/controllers/users/user-profile.js
+++ b/ethicapp/backend/controllers/users/user-profile.js
@@ -64,6 +64,10 @@ router.get("/users/profile", async (req, res) => {
     if (!requireRole(req, res, "P")) return;
 
     try {
+        res.set("Cache-Control", "no-store, no-cache, must-revalidate, private");
+        res.set("Pragma", "no-cache");
+        res.set("Expires", "0");
+
         const result = await execSQL({
             dbcon: config.dbconnString,
             sql: `

--- a/ethicapp/backend/views/home.ejs
+++ b/ethicapp/backend/views/home.ejs
@@ -5,7 +5,7 @@
 <% if (recaptchaEnabled) { %>
 <script src="https://www.google.com/recaptcha/api.js?render=explicit" async defer></script>
 <% } %>
-  <div ng-controller="ProfileController" class="top-bar-mini cflex" ng-hide="false">
+  <div ng-controller="ProfileController as vm" class="top-bar-mini cflex" ng-hide="false">
     <div class="cf1">
       <a href="/home" class="simple-margin-left">
         <img src="assets/images/logos/ethicapp-logo-emboss.png" class="logoEthicapp" alt="Logo">
@@ -25,9 +25,9 @@
           </li>
         </ul>
       </div>
-      <img ng-src="{{ getTopbarAvatar() }}" alt="Avatar"
+      <img ng-src="{{ vm.getTopbarAvatar() }}" alt="Avatar"
         class="circle_profile cf1 text-right margin-right-3 simple-padding-top">
-      <strong class="margin-right-8"><a href="#!/profile" style="color: white;"> {{ getDisplayName() || ('profile' | translate) }}
+      <strong class="margin-right-8"><a href="#!/profile" style="color: white;"> {{ vm.getDisplayName() || ('profile' | translate) }}
         </a></strong>
       <a href="logout" class="text-white ml-2" title="{{'exitEthicapp' | translate}}">
         <i class="fa fa-sign-out fa-2x"></i>

--- a/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
@@ -1,5 +1,5 @@
 export const ProfileController = function ($scope, $translate, toast, UserProfileService) {
-    const vm = $scope;
+    const vm = this;
 
     vm.genderOptions = [
         { value: "F", label: "Femenino" },
@@ -198,4 +198,6 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
 
     vm.loadProfile();
     setTimeout(vm.ensureProfileRecaptcha, 300);
+
+    $scope.vm = vm;
 };


### PR DESCRIPTION
### Motivation
- Navigating to `#!/profile` did not hydrate teacher profile fields (avatar, firstname, lastname) because the top bar used `vm.*` bindings while the controller was registered without the `controllerAs` alias.
- The `GET /users/profile` endpoint returned `304 Not Modified` responses, allowing stale cached profile payloads to be used by the client. 
- A small compatibility fix was needed to restore correct bindings without a large refactor of legacy code.

### Description
- Updated `ethicapp/backend/views/home.ejs` to use `ng-controller="ProfileController as vm"` and switched top-bar bindings to `vm.getTopbarAvatar()` and `vm.getDisplayName()`.
- Updated `ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js` to use `const vm = this` and expose the controller instance on scope via `$scope.vm = vm` for backward compatibility with existing templates.
- Added response headers to `GET /users/profile` in `ethicapp/backend/controllers/users/user-profile.js` to disable HTTP caching by setting `Cache-Control`, `Pragma`, and `Expires` so the client receives fresh profile data.
- Risk: the change is scoped to profile rendering and the profile API; the repository still contains unrelated legacy lint issues.

### Testing
- Ran `npm run lint-js`; the task failed due to pre-existing lint errors across many legacy files and these failures are unrelated to the three files changed.
- No unit tests were added or modified for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed117ad7d4832b9790d13e8abad349)