### PR TITLE
Fix teacher profile form alignment and recaptcha/toast regressions

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
@@ -1,5 +1,7 @@
 export const ProfileController = function ($scope, $translate, toast, UserProfileService) {
     const vm = this;
+    const TOAST_INFO_TIMEOUT_MS = 4 * 1000;
+    const TOAST_ERROR_TIMEOUT_MS = 6 * 1000;
 
     vm.genderOptions = [
         { value: "F", label: "Femenino" },
@@ -30,6 +32,27 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
 
     vm.getTopbarAvatar = () => vm.profile.profile_image_topbar_path || vm.defaultTopbarAvatar;
     vm.getProfileAvatar = () => vm.profile.profile_image_path || vm.defaultProfileAvatar;
+    vm.showInfoToast = (message) => {
+        toast.create({
+            timeout: TOAST_INFO_TIMEOUT_MS,
+            message,
+            containerClass: "toast-container",
+            dismissible: false,
+            defaultToastClass: "toast",
+            insertFromTop: true
+        });
+    };
+    vm.showErrorToast = (message) => {
+        toast.create({
+            timeout: TOAST_ERROR_TIMEOUT_MS,
+            message,
+            className: "alert-danger",
+            containerClass: "toast-container",
+            dismissible: false,
+            defaultToastClass: "toast",
+            insertFromTop: true
+        });
+    };
 
     vm.getDisplayName = () => {
         const first = vm.profile.firstname || "";
@@ -70,8 +93,14 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
             return;
         }
 
+        if (container.dataset.recaptchaRendered === "true" || container.childElementCount > 0) {
+            container.dataset.recaptchaRendered = "true";
+            return;
+        }
+
         const widgetId = window.grecaptcha.render(containerId, { sitekey: siteKey });
         currentWidgetIdSetter.set(widgetId);
+        container.dataset.recaptchaRendered = "true";
     };
 
     vm.ensureProfileRecaptcha = () => {
@@ -102,7 +131,7 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
             };
         } catch (error) {
             console.error("Could not load profile:", error);
-            toast.error(vm.translate("profile_load_error"));
+            vm.showErrorToast(vm.translate("profile_load_error"));
         }
     };
 
@@ -110,7 +139,7 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
         try {
             const recaptchaResponse = vm.getRecaptchaToken(vm.profileRecaptchaWidgetId);
             if (vm.isRecaptchaEnabled && !recaptchaResponse) {
-                toast.warning(vm.translate("profile_recaptcha_save_warning"));
+                vm.showInfoToast(vm.translate("profile_recaptcha_save_warning"));
                 return;
             }
 
@@ -125,10 +154,10 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
             if (vm.isRecaptchaEnabled && window.grecaptcha && vm.profileRecaptchaWidgetId !== null) {
                 window.grecaptcha.reset(vm.profileRecaptchaWidgetId);
             }
-            toast.success(vm.translate("profile_update_success"));
+            vm.showInfoToast(vm.translate("profile_update_success"));
         } catch (error) {
             console.error("Could not update profile:", error);
-            toast.error(vm.translate("profile_update_error"));
+            vm.showErrorToast(vm.translate("profile_update_error"));
         }
     };
 
@@ -138,13 +167,13 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
 
     vm.uploadAvatar = async () => {
         if (!vm.selectedAvatarFile) {
-            toast.warning(vm.translate("profile_avatar_select_jpg_or_png_warning"));
+            vm.showInfoToast(vm.translate("profile_avatar_select_jpg_or_png_warning"));
             return;
         }
 
         const recaptchaResponse = vm.getRecaptchaToken(vm.profileRecaptchaWidgetId);
         if (vm.isRecaptchaEnabled && !recaptchaResponse) {
-            toast.warning(vm.translate("profile_avatar_recaptcha_warning"));
+            vm.showInfoToast(vm.translate("profile_avatar_recaptcha_warning"));
             return;
         }
 
@@ -155,7 +184,7 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
             if (vm.isRecaptchaEnabled && window.grecaptcha && vm.profileRecaptchaWidgetId !== null) {
                 window.grecaptcha.reset(vm.profileRecaptchaWidgetId);
             }
-            toast.success(vm.translate("profile_avatar_update_success"));
+            vm.showInfoToast(vm.translate("profile_avatar_update_success"));
         } catch (error) {
             console.error("Could not upload avatar:", error);
             const message = error?.data?.error === "avatar_size_limit_exceeded"
@@ -163,7 +192,7 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
                 : error?.data?.error === "invalid_avatar_type"
                     ? vm.translate("profile_avatar_invalid_type_error")
                     : vm.translate("profile_avatar_upload_error");
-            toast.error(message);
+            vm.showErrorToast(message);
         }
     };
 
@@ -183,16 +212,16 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
         try {
             const recaptchaResponse = vm.getRecaptchaToken(vm.passwordResetRecaptchaWidgetId);
             if (vm.isRecaptchaEnabled && !recaptchaResponse) {
-                toast.warning(vm.translate("profile_reset_recaptcha_warning"));
+                vm.showInfoToast(vm.translate("profile_reset_recaptcha_warning"));
                 return;
             }
 
             await UserProfileService.requestPasswordReset(vm.profile.email, recaptchaResponse);
-            toast.success(vm.translate("profile_password_reset_success"));
+            vm.showInfoToast(vm.translate("profile_password_reset_success"));
             vm.closePasswordResetModal();
         } catch (error) {
             console.error("Could not trigger password reset:", error);
-            toast.error(vm.translate("profile_password_reset_error"));
+            vm.showErrorToast(vm.translate("profile_password_reset_error"));
         }
     };
 

--- a/ethicapp/frontend/assets/static/views/teacher/profile.html
+++ b/ethicapp/frontend/assets/static/views/teacher/profile.html
@@ -44,19 +44,34 @@
             </div>
         </div>
 
-        <div id="profile-recaptcha-container" ng-if="vm.isRecaptchaEnabled" class="mt-medio g-recaptcha"></div>
+        <div class="form-group" ng-if="vm.isRecaptchaEnabled">
+            <div class="col-sm-offset-3 col-sm-9">
+                <div id="profile-recaptcha-container" class="mt-medio"></div>
+            </div>
+        </div>
 
-        <button type="button" class="btn btn-default btn-sm mt-medio profile-save-btn" ng-click="vm.saveProfile()">{{ 'save_profile' | translate }}</button>
+        <div class="form-group">
+            <div class="col-sm-offset-3 col-sm-9">
+                <button type="button" class="btn btn-default btn-sm mt-medio profile-save-btn" ng-click="vm.saveProfile()">{{ 'save_profile' | translate }}</button>
+            </div>
+        </div>
     </form>
 
     <hr>
 
-    <div>
-        <p>{{ 'password_reset_notice' | translate }} <strong>{{ vm.profile.email }}</strong>.</p>
-
-        <button type="button" class="btn btn-default btn-sm mt-medio" ng-click="vm.openPasswordResetModal()">
-            {{ 'change_password' | translate }}
-        </button>
+    <div class="form-horizontal">
+        <div class="form-group">
+            <div class="col-sm-offset-3 col-sm-9">
+                <p>{{ 'password_reset_notice' | translate }} <strong>{{ vm.profile.email }}</strong>.</p>
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="col-sm-offset-3 col-sm-9">
+                <button type="button" class="btn btn-default btn-sm mt-medio" ng-click="vm.openPasswordResetModal()">
+                    {{ 'change_password' | translate }}
+                </button>
+            </div>
+        </div>
     </div>
 
     <div class="modal fade" ng-class="{'in': vm.isPasswordResetModalOpen}" ng-style="{display: vm.isPasswordResetModalOpen ? 'block' : 'none'}" tabindex="-1" role="dialog" aria-hidden="{{ !vm.isPasswordResetModalOpen }}">
@@ -68,7 +83,7 @@
                 </div>
                 <div class="modal-body">
                     <p>{{ 'password_reset_modal_message' | translate }} <strong>{{ vm.profile.email }}</strong>.</p>
-                    <div id="password-reset-recaptcha-container" ng-if="vm.isRecaptchaEnabled" class="mt-medio g-recaptcha"></div>
+                    <div id="password-reset-recaptcha-container" ng-if="vm.isRecaptchaEnabled" class="mt-medio"></div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" ng-click="vm.closePasswordResetModal()">{{ 'cancel' | translate }}</button>

--- a/ethicapp/frontend/views/partials/teacher/profile.html
+++ b/ethicapp/frontend/views/partials/teacher/profile.html
@@ -44,19 +44,34 @@
             </div>
         </div>
 
-        <div id="profile-recaptcha-container" ng-if="vm.isRecaptchaEnabled" class="mt-medio g-recaptcha"></div>
+        <div class="form-group" ng-if="vm.isRecaptchaEnabled">
+            <div class="col-sm-offset-3 col-sm-9">
+                <div id="profile-recaptcha-container" class="mt-medio"></div>
+            </div>
+        </div>
 
-        <button type="button" class="btn btn-default btn-sm mt-medio profile-save-btn" ng-click="vm.saveProfile()">{{ 'save_profile' | translate }}</button>
+        <div class="form-group">
+            <div class="col-sm-offset-3 col-sm-9">
+                <button type="button" class="btn btn-default btn-sm mt-medio profile-save-btn" ng-click="vm.saveProfile()">{{ 'save_profile' | translate }}</button>
+            </div>
+        </div>
     </form>
 
     <hr>
 
-    <div>
-        <p>{{ 'password_reset_notice' | translate }} <strong>{{ vm.profile.email }}</strong>.</p>
-
-        <button type="button" class="btn btn-default btn-sm mt-medio" ng-click="vm.openPasswordResetModal()">
-            {{ 'change_password' | translate }}
-        </button>
+    <div class="form-horizontal">
+        <div class="form-group">
+            <div class="col-sm-offset-3 col-sm-9">
+                <p>{{ 'password_reset_notice' | translate }} <strong>{{ vm.profile.email }}</strong>.</p>
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="col-sm-offset-3 col-sm-9">
+                <button type="button" class="btn btn-default btn-sm mt-medio" ng-click="vm.openPasswordResetModal()">
+                    {{ 'change_password' | translate }}
+                </button>
+            </div>
+        </div>
     </div>
 
     <div class="modal fade" ng-class="{'in': vm.isPasswordResetModalOpen}" ng-style="{display: vm.isPasswordResetModalOpen ? 'block' : 'none'}" tabindex="-1" role="dialog" aria-hidden="{{ !vm.isPasswordResetModalOpen }}">
@@ -68,7 +83,7 @@
                 </div>
                 <div class="modal-body">
                     <p>{{ 'password_reset_modal_message' | translate }} <strong>{{ vm.profile.email }}</strong>.</p>
-                    <div id="password-reset-recaptcha-container" ng-if="vm.isRecaptchaEnabled" class="mt-medio g-recaptcha"></div>
+                    <div id="password-reset-recaptcha-container" ng-if="vm.isRecaptchaEnabled" class="mt-medio"></div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" ng-click="vm.closePasswordResetModal()">{{ 'cancel' | translate }}</button>


### PR DESCRIPTION
### Motivation
- The profile page form had layout issues: reCAPTCHA and the "Save profile" button were misaligned with other fields, and the "Change password" block did not line up with the form grid.
- The console showed duplicate reCAPTCHA renders and runtime errors from using `toast.warning` / `toast.error` methods which are not available in the current toast API.

### Description
- Adjusted profile templates (`ethicapp/frontend/assets/static/views/teacher/profile.html` and `ethicapp/frontend/views/partials/teacher/profile.html`) to wrap the reCAPTCHA, save button, and change-password notice/button in Bootstrap `.form-group` rows using `.col-sm-offset-3 .col-sm-9` so controls align with the rest of the `form-horizontal` layout and the save button is on its own row.
- Removed `g-recaptcha` class from containers that are manually rendered by `grecaptcha.render(...)` to avoid automatic duplicate rendering.
- Added a defensive guard in `ensureRecaptchaWidget` (controller: `ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js`) that skips rendering if the container already has content or a `data-recaptcha-rendered` marker to prevent duplicate-render console errors.
- Replaced calls to nonexistent toast helpers (`toast.warning`, `toast.success`, `toast.error`) with `toast.create(...)` wrappers (`vm.showInfoToast` and `vm.showErrorToast`) and constants for timeouts, ensuring toast usage is compatible with the teacher-module toast API.

### Testing
- Ran `npm run lint-js`; the command executed but failed due to a large number of pre-existing lint issues in the repository unrelated to these changes, and no new lint errors were introduced by the modified profile files.
- Verified templates and controller diffs to confirm reCAPTCHA containers and save/change-password rows are aligned and that `grecaptcha.render` guard and toast wrappers are in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed13558058832ba361aee497565aa6)