### PR TITLE
Fix teacher profile hydration and English role translation

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
@@ -3,11 +3,7 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
     const TOAST_INFO_TIMEOUT_MS = 4 * 1000;
     const TOAST_ERROR_TIMEOUT_MS = 6 * 1000;
 
-    vm.genderOptions = [
-        { value: "F", label: "Femenino" },
-        { value: "M", label: "Masculino" },
-        { value: "O", label: "Otro" }
-    ];
+    vm.genderOptions = [];
 
     vm.profile = {
         firstname: "",
@@ -29,6 +25,18 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
     vm.profileRecaptchaWidgetId = null;
     vm.passwordResetRecaptchaWidgetId = null;
     vm.translate = (key) => $translate.instant(key);
+    vm.applyChanges = () => {
+        if (!$scope.$$destroyed) {
+            $scope.$applyAsync();
+        }
+    };
+    vm.refreshGenderOptions = () => {
+        vm.genderOptions = [
+            { value: "F", label: vm.translate("female") },
+            { value: "M", label: vm.translate("male") },
+            { value: "O", label: vm.translate("other") }
+        ];
+    };
 
     vm.getTopbarAvatar = () => vm.profile.profile_image_topbar_path || vm.defaultTopbarAvatar;
     vm.getProfileAvatar = () => vm.profile.profile_image_path || vm.defaultProfileAvatar;
@@ -129,9 +137,11 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
                 ...data,
                 sex: data.sex || "O"
             };
+            vm.applyChanges();
         } catch (error) {
             console.error("Could not load profile:", error);
             vm.showErrorToast(vm.translate("profile_load_error"));
+            vm.applyChanges();
         }
     };
 
@@ -155,9 +165,11 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
                 window.grecaptcha.reset(vm.profileRecaptchaWidgetId);
             }
             vm.showInfoToast(vm.translate("profile_update_success"));
+            vm.applyChanges();
         } catch (error) {
             console.error("Could not update profile:", error);
             vm.showErrorToast(vm.translate("profile_update_error"));
+            vm.applyChanges();
         }
     };
 
@@ -185,6 +197,7 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
                 window.grecaptcha.reset(vm.profileRecaptchaWidgetId);
             }
             vm.showInfoToast(vm.translate("profile_avatar_update_success"));
+            vm.applyChanges();
         } catch (error) {
             console.error("Could not upload avatar:", error);
             const message = error?.data?.error === "avatar_size_limit_exceeded"
@@ -193,12 +206,14 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
                     ? vm.translate("profile_avatar_invalid_type_error")
                     : vm.translate("profile_avatar_upload_error");
             vm.showErrorToast(message);
+            vm.applyChanges();
         }
     };
 
     vm.openPasswordResetModal = () => {
         vm.isPasswordResetModalOpen = true;
         setTimeout(vm.ensurePasswordResetRecaptcha, 200);
+        vm.applyChanges();
     };
 
     vm.closePasswordResetModal = () => {
@@ -206,6 +221,7 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
         if (vm.isRecaptchaEnabled && window.grecaptcha && vm.passwordResetRecaptchaWidgetId !== null) {
             window.grecaptcha.reset(vm.passwordResetRecaptchaWidgetId);
         }
+        vm.applyChanges();
     };
 
     vm.confirmPasswordReset = async () => {
@@ -219,14 +235,22 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
             await UserProfileService.requestPasswordReset(vm.profile.email, recaptchaResponse);
             vm.showInfoToast(vm.translate("profile_password_reset_success"));
             vm.closePasswordResetModal();
+            vm.applyChanges();
         } catch (error) {
             console.error("Could not trigger password reset:", error);
             vm.showErrorToast(vm.translate("profile_password_reset_error"));
+            vm.applyChanges();
         }
     };
 
+    vm.refreshGenderOptions();
     vm.loadProfile();
     setTimeout(vm.ensureProfileRecaptcha, 300);
+    const languageChangeListener = $scope.$on("$translateChangeSuccess", () => {
+        vm.refreshGenderOptions();
+        vm.applyChanges();
+    });
 
     $scope.vm = vm;
+    $scope.$on("$destroy", languageChangeListener);
 };

--- a/ethicapp/frontend/assets/locales/en.json
+++ b/ethicapp/frontend/assets/locales/en.json
@@ -155,6 +155,7 @@
 	"male":"Male",
 	"make_s": "Make Student",
 	"make_t": "Make Teacher",
+	"teacher": "Teacher",
 	"mandatoryComment": "Mandatory comment",
 	"minComment": "Minimum length of comment",
 	"mode": "Mode",

--- a/ethicapp/frontend/assets/locales/en_US.json
+++ b/ethicapp/frontend/assets/locales/en_US.json
@@ -359,6 +359,7 @@
 	"male": "Male",
 	"make_s": "Make Student",
 	"make_t": "Make Teacher",
+	"teacher": "Teacher",
 	"mandatoryComment": "Mandatory comment",
 	"minComment": "Minimum length of comment",
 	"mode": "Mode",


### PR DESCRIPTION
### Motivation

- The teacher profile page did not reliably hydrate fields after navigation, leaving inputs blank and preventing avatar updates from visibly refreshing the UI. 
- Gender option labels were hardcoded in Spanish causing incorrect text when English is active. 
- The English locale lacked the `teacher` translation key so the role label rendered incorrectly.

### Description

- Added a safe apply helper `vm.applyChanges()` that calls `$scope.$applyAsync()` and invoked it after async flows in `vm.loadProfile`, `vm.saveProfile`, `vm.uploadAvatar`, and password-reset modal actions to force UI refreshes (`ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js`).
- Replaced hardcoded gender labels with translated labels and added `vm.refreshGenderOptions()` that is invoked on language changes via `$translateChangeSuccess` and on init (`ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js`).
- Added the missing `"teacher": "Teacher"` key to `ethicapp/frontend/assets/locales/en.json` and `ethicapp/frontend/assets/locales/en_US.json` so the role displays correctly in English. 
- Cleanly unregisters the translate listener on scope destroy to avoid leaks (`$scope.$on("$destroy", ...)`).

### Testing

- Ran `npm run lint-js`, which failed due to pre-existing repository-wide lint issues not introduced by this change. 
- Ran `npx eslint ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js`, which reported existing stylistic warnings/errors in the legacy file style baseline but no functional errors introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed15b553bc832b8ea3ff6ee8e5cf72)