### PR TITLE
Normalize EthicApp upload storage to /app/backend/uploads

### DIFF
--- a/ethicapp/Dockerfile
+++ b/ethicapp/Dockerfile
@@ -18,8 +18,8 @@ COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # Crear directorios persistentes
-RUN mkdir -p /app/uploads /app/sessions \
-    && chmod 777 /app/uploads \
-    && chmod 755 /app/sessions
+RUN mkdir -p /app/backend/uploads /app/backend/sessions \
+    && chmod 777 /app/backend/uploads \
+    && chmod 755 /app/backend/sessions
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/ethicapp/backend/app.js
+++ b/ethicapp/backend/app.js
@@ -78,11 +78,13 @@ app.use(cors(corsOptions));
 
 // Asset handling
 const assetPath = path.join(__dirname, "../frontend/assets");
+const uploadsAbsolutePath = path.resolve(process.cwd(), config.uploadsPath);
 app.use(express.static(assetPath));
 app.use(assetVersions("/assets", assetPath));
 
 // Uploads
-app.use("/uploads", express.static(path.join(__dirname, "../frontend/assets/uploads")));
+app.use("/uploads", express.static(uploadsAbsolutePath));
+app.use("/assets/uploads", express.static(uploadsAbsolutePath));
 
 // view engine setup
 app.set("views", path.join(__dirname, "views"));

--- a/ethicapp/backend/config/config.js
+++ b/ethicapp/backend/config/config.js
@@ -1,4 +1,4 @@
 const dbconnString = "tcp://postgres:postgres@postgresql:5432/ethicapp";
-const uploadsPath = "../frontend/assets/uploads";
+const uploadsPath = process.env.UPLOADS_PATH || "uploads";
 
 export { dbconnString, uploadsPath };

--- a/ethicapp/backend/controllers/cases.js
+++ b/ethicapp/backend/controllers/cases.js
@@ -1,11 +1,32 @@
 "use strict";
 
 import express from "express";
+import path from "path";
 import * as config from "../config/config.js";
 import * as rpg2 from "../db/rest-pg-2.js";
 import { requireRole } from "../helpers/auth-helper.js";
 
 const router = express.Router();
+
+function buildPublicUploadPath(uploadedFilePath) {
+    if (!uploadedFilePath || typeof uploadedFilePath !== "string") {
+        return null;
+    }
+
+    const normalizedPath = path.normalize(uploadedFilePath);
+    const uploadDirToken = `${path.sep}uploads${path.sep}`;
+    const uploadDirIndex = normalizedPath.lastIndexOf(uploadDirToken);
+
+    if (uploadDirIndex === -1) {
+        return null;
+    }
+
+    const relativeToUploads = normalizedPath
+        .slice(uploadDirIndex + uploadDirToken.length)
+        .replaceAll(path.sep, "/");
+
+    return `/uploads/${relativeToUploads}`;
+}
 
 function normalizeCase(row) {
     return {
@@ -180,7 +201,11 @@ router.post("/cases", async (req, res) => {
     }
 
     try {
-        const pdfPath = "assets/uploads" + req.files.pdf.file.split("uploads")[1];
+        const pdfPath = buildPublicUploadPath(req.files.pdf.file);
+
+        if (!pdfPath) {
+            return res.status(500).json({ status: "err", message: "Failed to persist PDF path." });
+        }
 
         const createdCase = await rpg2.singleSQL({
             dbcon: config.dbconnString,
@@ -242,9 +267,12 @@ router.patch("/cases/:id(\\d+)", async (req, res) => {
         }
 
         const hasPdf = req.files?.pdf && req.files.pdf.mimetype === "application/pdf";
-        const pdfPath = hasPdf
-            ? "assets/uploads" + req.files.pdf.file.split("uploads")[1]
-            : existingCase.pdf_path;
+        const uploadedPdfPath = hasPdf ? buildPublicUploadPath(req.files.pdf.file) : null;
+        const pdfPath = hasPdf ? uploadedPdfPath : existingCase.pdf_path;
+
+        if (hasPdf && !pdfPath) {
+            return res.status(500).json({ status: "err", message: "Failed to persist PDF path." });
+        }
 
         const updatedCase = await rpg2.singleSQL({
             dbcon: config.dbconnString,

--- a/ethicapp/backend/controllers/users/user-profile.js
+++ b/ethicapp/backend/controllers/users/user-profile.js
@@ -5,7 +5,6 @@ import fs from "fs";
 import path from "path";
 import { promisify } from "util";
 import { execFile } from "child_process";
-import { fileURLToPath } from "url";
 import * as config from "../../config/config.js";
 import { execSQL, param } from "../../db/rest-pg-2.js";
 import { requireRole } from "../../helpers/auth-helper.js";
@@ -14,9 +13,7 @@ import * as RecaptchaHelper from "../../helpers/recaptcha-helper.js";
 const execFileAsync = promisify(execFile);
 const router = express.Router();
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const uploadsRoot = path.resolve(__dirname, config.uploadsPath);
+const uploadsRoot = path.resolve(process.cwd(), config.uploadsPath);
 const profileUploadsRelativeDir = path.join("user-profile");
 const profileUploadsDir = path.join(uploadsRoot, profileUploadsRelativeDir);
 const AVATAR_MAX_SIZE_BYTES = 300 * 1024;


### PR DESCRIPTION
### Motivation
- Fix inconsistent upload storage where case PDFs and other uploads were written under `frontend/assets/uploads` (ephemeral in Docker) instead of the backend persistent volume mounted at `/app/backend/uploads` per `docker-compose.yml`.
- Ensure avatars and generated derivative files also land in the same persistent uploads root so files survive container restarts.

### Description
- Centralized upload path configuration by changing `ethicapp/backend/config/config.js` to use `process.env.UPLOADS_PATH` with a default of `uploads` so runtime writes resolve under the backend `WORKDIR` (`/app/backend`).
- Updated `ethicapp/backend/app.js` to serve static uploads from the resolved `config.uploadsPath` and added a backward-compatible alias `
`/assets/uploads` to avoid breaking existing DB links.
- Replaced hardcoded `assets/uploads...` logic in `ethicapp/backend/controllers/cases.js` with a `buildPublicUploadPath` helper that normalizes the uploaded file path and persists public URLs under `/uploads/...`, with defensive checks on failure.
- Aligned avatar output paths in `ethicapp/backend/controllers/users/user-profile.js` to resolve from `process.cwd() + config.uploadsPath` so generated avatar files are written into the backend uploads directory.
- Adjusted `ethicapp/Dockerfile` to pre-create and set permissions on `/app/backend/uploads` and `/app/backend/sessions` to match the volume layout in `docker-compose.yml`.

### Testing
- Ran static checks with `node --check ethicapp/backend/app.js` which succeeded.
- Ran static checks with `node --check ethicapp/backend/controllers/cases.js` which succeeded.
- Ran static checks with `node --check ethicapp/backend/controllers/users/user-profile.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed471c5d58832bb511e4bc21d4f806)