### PR TITLE
Normalize upload paths and fix Windows backslash handling in cases and user-profile controllers

### DIFF
--- a/ethicapp/backend/controllers/cases.js
+++ b/ethicapp/backend/controllers/cases.js
@@ -13,17 +13,14 @@ function buildPublicUploadPath(uploadedFilePath) {
         return null;
     }
 
-    const normalizedPath = path.normalize(uploadedFilePath);
-    const uploadDirToken = `${path.sep}uploads${path.sep}`;
-    const uploadDirIndex = normalizedPath.lastIndexOf(uploadDirToken);
+    const normalizedPath = path.normalize(uploadedFilePath).replaceAll("\\", "/");
+    const uploadPathMatch = normalizedPath.match(/(?:^|\/)uploads\/(.+)$/);
 
-    if (uploadDirIndex === -1) {
+    if (!uploadPathMatch) {
         return null;
     }
 
-    const relativeToUploads = normalizedPath
-        .slice(uploadDirIndex + uploadDirToken.length)
-        .replaceAll(path.sep, "/");
+    const relativeToUploads = uploadPathMatch[1];
 
     return `/uploads/${relativeToUploads}`;
 }

--- a/ethicapp/backend/controllers/users/user-profile.js
+++ b/ethicapp/backend/controllers/users/user-profile.js
@@ -36,12 +36,17 @@ const validateProfileRecaptcha = async (req, res) => {
 const getAbsoluteUploadPath = (reqFilePath) => {
     if (!reqFilePath) return null;
 
-    const normalized = path.normalize(reqFilePath);
+    const normalized = path.normalize(reqFilePath).replaceAll("\\", "/");
     if (path.isAbsolute(normalized)) {
         return normalized;
     }
 
-    return path.resolve(process.cwd(), normalized);
+    const uploadsPathPrefix = `${config.uploadsPath.replaceAll("\\", "/").replace(/\/+$/, "")}/`;
+    const relativePath = normalized.startsWith(uploadsPathPrefix)
+        ? normalized.slice(uploadsPathPrefix.length)
+        : normalized;
+
+    return path.resolve(uploadsRoot, relativePath);
 };
 
 const buildAvatarPaths = (uid) => {


### PR DESCRIPTION
### Motivation

- Ensure uploaded file paths are parsed and resolved consistently across platforms by handling backslashes and varying `uploads` path formats. 
- Prevent incorrect public URLs and absolute/relative resolution errors when clients or storage use Windows-style paths or when `config.uploadsPath` is included in provided paths.

### Description

- Updated `buildPublicUploadPath` to normalize backslashes to forward slashes and use a regex to extract the path relative to the `uploads` directory, returning `null` if no match is found. 
- Updated `getAbsoluteUploadPath` to normalize backslashes to forward slashes, detect absolute paths, strip any leading `config.uploadsPath` prefix, and resolve remaining relative paths against the configured `uploadsRoot`. 
- Standardized returned relative/public paths to use forward slashes and ensured `path.resolve` is used to produce canonical absolute paths.

### Testing

- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5ab262dc832b870668fd4f44a0ea)