### PR TITLE
Fix topbar profile name not updating after saving user profile

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
@@ -160,7 +160,6 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
                 g_recaptcha_response: recaptchaResponse
             });
 
-            await vm.loadProfile();
             if (vm.isRecaptchaEnabled && window.grecaptcha && vm.profileRecaptchaWidgetId !== null) {
                 window.grecaptcha.reset(vm.profileRecaptchaWidgetId);
             }
@@ -192,7 +191,6 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
         try {
             await UserProfileService.uploadAvatar(vm.selectedAvatarFile, recaptchaResponse);
             vm.selectedAvatarFile = null;
-            await vm.loadProfile();
             if (vm.isRecaptchaEnabled && window.grecaptcha && vm.profileRecaptchaWidgetId !== null) {
                 window.grecaptcha.reset(vm.profileRecaptchaWidgetId);
             }
@@ -250,7 +248,13 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
         vm.refreshGenderOptions();
         vm.applyChanges();
     });
+    const profileUpdateListener = $scope.$on("user-profile:updated", () => {
+        vm.loadProfile();
+    });
 
     $scope.vm = vm;
-    $scope.$on("$destroy", languageChangeListener);
+    $scope.$on("$destroy", () => {
+        languageChangeListener();
+        profileUpdateListener();
+    });
 };

--- a/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
+++ b/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
@@ -25,7 +25,7 @@ app.factory("ActivityStateService", ["$http", "TeacherSocketService", ActivitySt
     .factory("ActivityCatalogService", ["$http", ActivityCatalogService])
     .factory("DesignCatalogService", ["$rootScope", "$http", DesignCatalogService])
     .factory("DesignStateService", ["$rootScope", "$http", DesignStateService])
-    .factory("UserProfileService", ["$http", "Upload", UserProfileService])
+    .factory("UserProfileService", ["$http", "$rootScope", "Upload", UserProfileService])
     .factory("CasesCatalogService", ["$http", CasesCatalogService]);
 
 import { LocalesController } from "../../controllers/common/locales.controller.js";

--- a/ethicapp/frontend/assets/js/services/user-profile.service.js
+++ b/ethicapp/frontend/assets/js/services/user-profile.service.js
@@ -1,6 +1,10 @@
-let UserProfileService = function ($http, Upload) {
+let UserProfileService = function ($http, $rootScope, Upload) {
     const service = {
         profileCache: null,
+        notifyProfileChanged() {
+            service.profileCache = null;
+            $rootScope.$broadcast("user-profile:updated");
+        },
 
         async getProfile(reload = false) {
             if (service.profileCache && !reload) {
@@ -19,7 +23,7 @@ let UserProfileService = function ($http, Upload) {
 
         async updateProfile(payload) {
             const response = await $http.post("/users/profile", payload);
-            service.profileCache = null;
+            service.notifyProfileChanged();
             return response.data;
         },
 
@@ -34,7 +38,7 @@ let UserProfileService = function ($http, Upload) {
                 data
             });
 
-            service.profileCache = null;
+            service.notifyProfileChanged();
             return response.data;
         },
 


### PR DESCRIPTION
### Motivation
- The topbar display name did not refresh after saving the user profile because the topbar and profile page each mount independent `ProfileController` instances and updates in one instance did not notify the other.

### Description
- Injected `$rootScope` into `UserProfileService` and added `notifyProfileChanged()` which clears the profile cache and broadcasts `user-profile:updated`.
- `updateProfile()` and `uploadAvatar()` now call `notifyProfileChanged()` after successful updates to ensure global sync.
- `ProfileController` now listens for `user-profile:updated` and calls `vm.loadProfile()` when the event is received, and the controller unregisters listeners on `$destroy` to avoid leaks.
- Updated DI registration in `teacher-admin.mjs` so the factory provides `$rootScope` to `UserProfileService`.

### Testing
- Ran `npm run lint-js` which failed due to pre-existing repository-wide lint errors unrelated to this change (lint did not pass).
- Ran `npx eslint` for the three modified files (`user-profile.service.js`, `profile.controller.js`, `teacher-admin.mjs`) which reported style issues from the existing baseline and therefore did not fully pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5d626d24832b857b8e4002748a9b)