### PR TITLE
Fix profile avatar reCAPTCHA/toast UX and topbar avatar shape

### DIFF
--- a/ethicapp/frontend/assets/css/main.css
+++ b/ethicapp/frontend/assets/css/main.css
@@ -1418,6 +1418,12 @@ input.flat::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
     border-radius: 50%;
     height: 30px;
     width: 30px;
+    min-width: 30px;
+    min-height: 30px;
+    max-width: 30px;
+    max-height: 30px;
+    aspect-ratio: 1 / 1;
+    flex-shrink: 0;
     background: transparent;
     object-fit: cover;
     object-position: center;
@@ -1654,8 +1660,12 @@ input.flat::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
     min-height: 2.5rem;
 }
 
-.teacher-profile-page .profile-toast-anchor {
-    margin-top: 0.75rem;
+
+.teacher-profile-page .toast-container ul,
+.teacher-profile-page .toast-container li {
+    list-style: none !important;
+    margin: 0;
+    padding: 0;
 }
 
 .profile-save-btn {

--- a/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
@@ -79,15 +79,14 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
     };
 
     vm.getRecaptchaToken = (widgetId) => {
-        if (!vm.isRecaptchaEnabled) {
+        if (!vm.isRecaptchaEnabled || !window.grecaptcha) {
             return null;
         }
 
-        if (!window.grecaptcha || widgetId === null || widgetId === undefined) {
-            return null;
-        }
+        const token = (widgetId === null || widgetId === undefined)
+            ? window.grecaptcha.getResponse()
+            : window.grecaptcha.getResponse(widgetId);
 
-        const token = window.grecaptcha.getResponse(widgetId);
         return token || null;
     };
 

--- a/ethicapp/frontend/assets/static/views/teacher/profile.html
+++ b/ethicapp/frontend/assets/static/views/teacher/profile.html
@@ -59,9 +59,6 @@
             <div class="col-sm-offset-3 col-sm-9">
                 <button type="button" class="btn btn-default btn-sm mt-medio profile-save-btn" ng-click="vm.saveProfile()">{{ 'save_profile' | translate }}</button>
                 <small class="help-block">{{ 'profile_save_scope_hint' | translate }}</small>
-                <div class="toast-container profile-toast-anchor">
-                    <toast></toast>
-                </div>
             </div>
         </div>
     </form>

--- a/ethicapp/frontend/views/partials/teacher/profile.html
+++ b/ethicapp/frontend/views/partials/teacher/profile.html
@@ -59,9 +59,6 @@
             <div class="col-sm-offset-3 col-sm-9">
                 <button type="button" class="btn btn-default btn-sm mt-medio profile-save-btn" ng-click="vm.saveProfile()">{{ 'save_profile' | translate }}</button>
                 <small class="help-block">{{ 'profile_save_scope_hint' | translate }}</small>
-                <div class="toast-container profile-toast-anchor">
-                    <toast></toast>
-                </div>
             </div>
         </div>
     </form>


### PR DESCRIPTION
### Motivation
- The teacher profile avatar flow showed incorrect reCAPTCHA failures, duplicate toasts, a bullet before toast text, and a distorted (elliptical) topbar avatar.

### Description
- Updated `vm.getRecaptchaToken` in `ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js` to check `window.grecaptcha` and fallback to `grecaptcha.getResponse()` when no widget id is available to avoid false negative captcha checks.
- Removed the duplicate `<toast>` mount point from the profile templates `ethicapp/frontend/views/partials/teacher/profile.html` and `ethicapp/frontend/assets/static/views/teacher/profile.html` so toasts render only from the top-level container.
- Added profile-scoped CSS to reset `ul`/`li` list style inside the profile toast container (`.teacher-profile-page .toast-container ul, .teacher-profile-page .toast-container li`) to remove bullet markers.
- Hardened the topbar avatar CSS (`.circle_profile`) in `ethicapp/frontend/assets/css/main.css` by enforcing fixed min/max sizes, `aspect-ratio: 1/1`, and `flex-shrink: 0` to keep the image circular and prevent ellipses.

### Testing
- Ran `npm run lint-js` to surface JS issues; the command failed due to many pre-existing legacy lint errors outside the scope of these changes, and no new lint rules were introduced by this PR (lint failure not caused by the touched files).
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed64cc7a20832b8ed58fc84f5a4a8c)