### PR TITLE
Add Create a Case card to teacher home quick actions

### DIFF
--- a/ethicapp/frontend/assets/locales/en.json
+++ b/ethicapp/frontend/assets/locales/en.json
@@ -64,6 +64,7 @@
 	"delete": "Delete",
 	"description": "Description",
 	"designActivity": "Design an Activity",
+	"createACase": "Create a Case",
 	"designMsg": "Create Activity Design",
 	"designMsgInfo": "Choose the activity type and enter a title to identify the design.",
 	"designs": "Designs",

--- a/ethicapp/frontend/assets/locales/en_US.json
+++ b/ethicapp/frontend/assets/locales/en_US.json
@@ -71,6 +71,7 @@
 	"delete": "Delete",
 	"description": "Description",
 	"designActivity": "Design an Activity",
+	"createACase": "Create a Case",
 	"designMsg": "Create Activity Design",
 	"designMsgInfo": "Choose the activity type and enter a title to identify the design.",
 	"designs": "Designs",

--- a/ethicapp/frontend/assets/locales/es.json
+++ b/ethicapp/frontend/assets/locales/es.json
@@ -219,6 +219,7 @@
 	"home": "Inicio",
 	"activities": "Actividades",
 	"designActivity": "Diseñar una Actividad",
+	"createACase": "Crear un caso",
 	"launchAnActivity": "Lanzar una Actividad",
 	"shareActivityDesign": "Compartir un Diseño de Actividad",
 	"searchSharedDesign": "Buscar Diseños Compartidos",

--- a/ethicapp/frontend/assets/locales/es_CL.json
+++ b/ethicapp/frontend/assets/locales/es_CL.json
@@ -433,6 +433,7 @@
 	"teacher_workbench" : "La Casa del Profesor",
 	"activities": "Actividades",
 	"designActivity": "Diseñar una Actividad",
+	"createACase": "Crear un caso",
 	"launchAnActivity": "Lanzar una Actividad",
 	"shareActivityDesign": "Compartir un Diseño de Actividad",
 	"searchDesigns" : "Buscar Diseños",

--- a/ethicapp/frontend/assets/static/views/teacher/home.html
+++ b/ethicapp/frontend/assets/static/views/teacher/home.html
@@ -12,7 +12,16 @@
                 <div class="panel-body">
                     <div class="row">
                         <!-- Tarjeta 1 -->
-                        <div class="col-md-4 col-sm-4 col-xs-12 text-center">
+                        <div class="col-md-3 col-sm-6 col-xs-12 text-center">
+                            <div ng-click="navigateTo('/cases/new')" class="home-card">
+                                <img src="/assets/images/cards/create-case.jpeg" class="img-responsive center-block" alt="Create a case">
+                                <div class="home-card-caption">
+                                    {{'createACase' | translate}}
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Tarjeta 2 -->
+                        <div class="col-md-3 col-sm-6 col-xs-12 text-center">
                             <div ng-click="navigateTo('/designs/new')" class="home-card">
                                 <img src="/assets/images/cards/design-activity.jpeg" class="img-responsive center-block" alt="Design an activity">
                                 <div class="home-card-caption">
@@ -20,8 +29,8 @@
                                 </div>
                             </div>
                         </div>
-                        <!-- Tarjeta 2 -->
-                        <div class="col-md-4 col-sm-4 col-xs-12 text-center">
+                        <!-- Tarjeta 3 -->
+                        <div class="col-md-3 col-sm-6 col-xs-12 text-center">
                             <div ng-click="navigateTo('/activities/new')" class="home-card">
                                 <img src="/assets/images/cards/launch-activity.jpeg" class="img-responsive center-block" alt="Launch an activity">
                                 <div class="home-card-caption">
@@ -29,8 +38,8 @@
                                 </div>
                             </div>
                         </div>
-                        <!-- Tarjeta 3 -->
-                        <div class="col-md-4 col-sm-4 col-xs-12 text-center">
+                        <!-- Tarjeta 4 -->
+                        <div class="col-md-3 col-sm-6 col-xs-12 text-center">
                             <div ng-click="navigateTo('/designs')" class="home-card">
                                 <img src="/assets/images/cards/search-designs.jpeg" class="img-responsive center-block" alt="Search designs">
                                 <div class="home-card-caption">


### PR DESCRIPTION
### Motivation
- The teacher home currently shows three quick-action cards but has space for a fourth; adding a direct shortcut to create a case improves discoverability and parity with the Recent Activities panel width. 
- The change should keep layout parity so the card row and the recent activities panel remain the same container width and responsive across viewports.

### Description
- Added a new first card in `ethicapp/frontend/assets/static/views/teacher/home.html` that navigates to `'/cases/new'`, uses the image `/assets/images/cards/create-case.jpeg`, and displays the translation key `createACase`.
- Adjusted card column classes from `col-md-4 col-sm-4` to `col-md-3 col-sm-6 col-xs-12` so four cards fit in a single desktop row while preserving responsiveness on smaller screens.
- Added the `createACase` translation key to the locale files `ethicapp/frontend/assets/locales/en.json`, `en_US.json`, `es.json`, and `es_CL.json`.
- No backend logic or CSS rules were changed by this PR; visual spacing still depends on existing `.home-card` styles.

### Testing
- Validated that all modified locale JSON files parse as valid JSON using `python - <<'PY' ... json.load(...) ... PY`, and the validation succeeded.
- Reviewed diffs with `git diff` to confirm the new card is inserted as the first card and column classes were updated; the review was successful.
- No automated build, lint or unit tests were run for this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6d7ea770832b8d687347523c219d)