### PR TITLE
Fix topbar avatar rendering to keep circular shape

### DIFF
--- a/ethicapp/backend/views/home.ejs
+++ b/ethicapp/backend/views/home.ejs
@@ -26,7 +26,7 @@
         </ul>
       </div>
       <div class="topbar-avatar-wrap margin-right-3 simple-padding-top">
-        <img ng-src="{{ vm.getTopbarAvatar() }}" alt="Avatar" class="circle_profile">
+        <img ng-src="{{ vm.getTopbarAvatar() }}" alt="Avatar" class="circle_profile topbar-avatar-img">
       </div>
       <strong class="margin-right-8"><a href="#!/profile" style="color: white;"> {{ vm.getDisplayName() || ('profile' | translate) }}
         </a></strong>

--- a/ethicapp/frontend/assets/css/custom.css
+++ b/ethicapp/frontend/assets/css/custom.css
@@ -93,6 +93,20 @@ body {
     background: #5cb85c;
 }
 
+.topbar-avatar-wrap .topbar-avatar-img {
+    width: 30px !important;
+    height: 30px !important;
+    min-width: 30px;
+    min-height: 30px;
+    max-width: 30px;
+    max-height: 30px;
+    border-radius: 50%;
+    object-fit: cover;
+    object-position: center;
+    display: block;
+    flex-shrink: 0;
+}
+
 .circle_profile {
     -moz-border-radius: 50%;
     -webkit-border-radius: 50%;

--- a/ethicapp/frontend/assets/css/main.css
+++ b/ethicapp/frontend/assets/css/main.css
@@ -1428,6 +1428,20 @@ input.flat::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
     flex-shrink: 0;
 }
 
+.topbar-avatar-wrap .topbar-avatar-img {
+    width: 30px !important;
+    height: 30px !important;
+    min-width: 30px;
+    min-height: 30px;
+    max-width: 30px;
+    max-height: 30px;
+    border-radius: 50%;
+    object-fit: cover;
+    object-position: center;
+    display: block;
+    flex-shrink: 0;
+}
+
 .topbar-avatar-wrap .circle_profile {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
### Motivation
- Avatars in the teacher topbar were rendering as an ellipse (e.g. ~30x26) instead of a perfect circle despite thumbnails being square, so provide a targeted CSS fix to keep the topbar avatar circular.

### Description
- Added a `topbar-avatar-img` class to the topbar image element in `ethicapp/backend/views/home.ejs` to decouple topbar-specific styling from the generic avatar class.
- Added a specific CSS rule `.topbar-avatar-wrap .topbar-avatar-img` in `ethicapp/frontend/assets/css/main.css` and `ethicapp/frontend/assets/css/custom.css` that enforces `30px` width/height, `border-radius: 50%`, and `object-fit: cover` so the image renders as a circle without distortion.
- Preserved the existing generic `.circle_profile` rules for other usages and increased specificity for the topbar rule to avoid cascade overrides.
- Fixed an accidental duplicated selector in `main.css` (`.topbar-avatar-wrap .topbar-avatar-wrap .topbar-avatar-img` → `.topbar-avatar-wrap .topbar-avatar-img`).

### Testing
- Ran `npm run lint-css` which executed `stylelint` and failed due to many pre-existing legacy Stylelint errors in the repo that are unrelated to this change.
- No other automated tests or unit tests were present/ran for this visual/CSS change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf932c2ec832b855088a3f4bde0ee)