### PR TITLE
Scope toast containers to profile, designs, and design-editor

### DIFF
--- a/ethicapp/frontend/assets/css/main.css
+++ b/ethicapp/frontend/assets/css/main.css
@@ -1693,15 +1693,15 @@ input.flat::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
     max-width: 720px;
 }
 
-.teacher-profile-page .toast-container {
+.teacher-profile-page .profile-toast-container {
     position: relative;
     z-index: 20;
     min-height: 2.5rem;
 }
 
 
-.teacher-profile-page .toast-container ul,
-.teacher-profile-page .toast-container li {
+.teacher-profile-page .profile-toast-container ul,
+.teacher-profile-page .profile-toast-container li {
     list-style: none !important;
     margin: 0;
     padding: 0;
@@ -2424,7 +2424,9 @@ h2{
     color: #a94442;
 }
 
-.toast-container .alert {
+.profile-toast-container .alert,
+.designs-toast-container .alert,
+.design-editor-toast-container .alert {
     min-height: 1.75em !important;
     height: auto !important;
     margin-left: auto;
@@ -2441,20 +2443,22 @@ h2{
     animation: fadeOut 5.0s ease-in-out forwards;
 }
 
-.designs-list .toast-container ul, .designs-list .toast-container li {
+.designs-list .designs-toast-container ul, .designs-list .designs-toast-container li {
     list-style: none !important;
     margin: 0;
     padding: 0;
 }
 
-.designs-list .toast-container .alert {
+.designs-list .designs-toast-container .alert {
     height: 1 !important;
     background: transparent;
     margin-top: 0px;
     margin-bottom: 0px;
 };
 
-.toast-container ul, .toast-container li {
+.profile-toast-container ul, .profile-toast-container li,
+.designs-toast-container ul, .designs-toast-container li,
+.design-editor-toast-container ul, .design-editor-toast-container li {
     list-style: none !important;
     margin: 0;
     padding: 0;

--- a/ethicapp/frontend/assets/js/controllers/teacher/browse-designs.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/browse-designs.controller.js
@@ -127,7 +127,7 @@ export function BrowseDesignsController($scope, $routeParams, toast, $translate,
                 toast.create({
                     timeout: 100 * 1000,
                     message: result,
-                    containerClass: 'toast-container',
+                    containerClass: 'designs-toast-container',
                     dismissible: false,
                     defaultToastClass: 'toast',
                     insertFromTop: true,

--- a/ethicapp/frontend/assets/js/controllers/teacher/design-editor.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/design-editor.controller.js
@@ -193,7 +193,7 @@ export function DesignEditorController($scope, $translate, $timeout,
                     toast.create({
                         timeout: 3 * 1000,
                         message: result,
-                        containerClass: 'toast-container',
+                        containerClass: 'design-editor-toast-container',
                         dismissible: false,
                         defaultToastClass: 'toast',
                         insertFromTop: true,
@@ -208,7 +208,7 @@ export function DesignEditorController($scope, $translate, $timeout,
                         message: 'Failed to save design',
                         className: 'alert-danger',
                         dismissible: false,
-                        containerClass: 'toast-container',
+                        containerClass: 'design-editor-toast-container',
                         defaultToastClass: 'toast',
                         insertFromTop: true
                     });

--- a/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/profile.controller.js
@@ -53,7 +53,7 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
         toast.create({
             timeout: TOAST_INFO_TIMEOUT_MS,
             message,
-            containerClass: "toast-container",
+            containerClass: "profile-toast-container",
             dismissible: false,
             defaultToastClass: "toast",
             insertFromTop: true
@@ -64,7 +64,7 @@ export const ProfileController = function ($scope, $translate, toast, UserProfil
             timeout: TOAST_ERROR_TIMEOUT_MS,
             message,
             className: "alert-danger",
-            containerClass: "toast-container",
+            containerClass: "profile-toast-container",
             dismissible: false,
             defaultToastClass: "toast",
             insertFromTop: true

--- a/ethicapp/frontend/assets/static/views/teacher/design.edit.html
+++ b/ethicapp/frontend/assets/static/views/teacher/design.edit.html
@@ -58,7 +58,7 @@
             </div>
             <div class="row">
                 <div class="col-md-12 text-center" style="height:1.5em">
-                    <div class="toast-container">
+                    <div class="design-editor-toast-container">
                         <toast></toast>
                     </div>
                 </div>

--- a/ethicapp/frontend/assets/static/views/teacher/design.index.html
+++ b/ethicapp/frontend/assets/static/views/teacher/design.index.html
@@ -30,7 +30,9 @@
         <div class="col-md-12">
             <div class="panel panel-default">
                 <div class="panel-heading designs-list" style="padding-top: 0px; padding-left: 8px; min-height: 1.25em; max-height: 1.25em; background: white;">
-                    <toast></toast>
+                    <div class="designs-toast-container">
+                        <toast></toast>
+                    </div>
                 </div>
                 <div class="panel-body">
                     <design-item ng-repeat="design in vm.userDesigns | filter: { metainfo: { title: vm.userSearch } } track by design.id"

--- a/ethicapp/frontend/assets/static/views/teacher/profile.html
+++ b/ethicapp/frontend/assets/static/views/teacher/profile.html
@@ -53,6 +53,14 @@
 
         <div class="form-group">
             <div class="col-sm-offset-3 col-sm-9">
+                <div class="profile-toast-container profile-toast-anchor">
+                    <toast></toast>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <div class="col-sm-offset-3 col-sm-9">
                 <button type="button" class="btn btn-default btn-sm mt-medio profile-save-btn" ng-click="vm.saveProfile()">{{ 'save_profile' | translate }}</button>
                 <small class="help-block">{{ 'profile_save_scope_hint' | translate }}</small>
             </div>


### PR DESCRIPTION
### Motivation

- Toast notifications were using a generic `.toast-container` which caused styling/placement conflicts across multiple teacher views, so to avoid collisions and scope toast appearance per view the container class needs to be specific.

### Description

- Introduced view-scoped toast container classes: `.profile-toast-container`, `.designs-toast-container`, and `.design-editor-toast-container` and updated CSS selectors and animations to target them. 
- Updated teacher-facing controllers to pass the new container class via the `containerClass` option in `toast.create()` calls for profile, design index/import flows, and design editor save/error flows. 
- Updated HTML templates to render `<toast>` wrapped in the new scoped container elements in `profile.html`, `design.index.html`, and `design.edit.html`. 
- Adjusted related CSS rules (including list/reset and `.alert` styling) to apply to the new container classes and kept the fade-out animation behavior.

### Testing

- Ran frontend build (`npm run build`) which completed successfully. 
- Executed frontend unit tests (`npm test`) and they passed. 
- Ran linter (`npm run lint`) with no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee05cd3b90832bb76303f1a2d12a3b)