### PR TITLE
Fix 403 on /mng by removing premature NGINX role gate

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -243,9 +243,6 @@ server {
         error_page 401 = @auth_redirect;
         error_page 403 = @forbidden;
 
-        if ($auth_user_role != "S") {
-            return 403;
-        }
 
         proxy_pass http://management_console_upstream;
         proxy_http_version 1.1;

--- a/nginx/conf.d/dev.conf
+++ b/nginx/conf.d/dev.conf
@@ -215,9 +215,6 @@ http {
       error_page 401 = @auth_redirect;
       error_page 403 = @forbidden;
 
-      if ($auth_user_role != "S") {
-        return 403;
-      }
 
       proxy_pass http://management_console_api;
       proxy_http_version 1.1;
@@ -235,9 +232,6 @@ http {
       error_page 401 = @auth_redirect;
       error_page 403 = @forbidden;
 
-      if ($auth_user_role != "S") {
-        return 403;
-      }
 
       proxy_pass http://management_console_frontend;
       proxy_http_version 1.1;


### PR DESCRIPTION
### Motivation
- Requests to `/mng/` were returning `403` for valid admin users because NGINX evaluated `if ($auth_user_role != "S")` before `auth_request` populated `$auth_user_role`.
- The goal is to avoid premature role checks in NGINX and rely on authenticated session information forwarded to the management-console backend for authorization.

### Description
- Removed inline NGINX role checks `if ($auth_user_role != "S") { return 403; }` from `nginx/conf.d/dev.conf` (both `/mng/` and `/mng/api/`) and `nginx/conf.d/default.conf` (`/mng/`).
- Preserved `auth_request /_auth_check` and the forwarding of `X-User-Id` and `X-User-Role` headers to upstream services.
- Kept role enforcement in the management-console backend via the `requireManagementRole` middleware which checks `req.session.role === 'S'` after session hydration from proxy headers.

### Testing
- Ran `git diff --check` on the repo and it completed with no problems (success).
- Attempted `docker compose config` but the `docker` binary is not available in this environment, so integration rendering could not be executed (skipped).
- Attempted `nginx -t -c /workspace/ethicapp-main/nginx/conf.d/dev.conf` but the `nginx` binary is not available in this environment, so runtime config validation could not be executed (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb72ee1f8832b80fdb041293ca88e)