### PR TITLE
Add EthicApp logo, topbar logout and Font Awesome icons to management-console

### DIFF
--- a/management-console/frontend/index.html
+++ b/management-console/frontend/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+      referrerpolicy="no-referrer"
+    />
     <title>EthicApp Management Console</title>
   </head>
   <body>

--- a/management-console/frontend/src/assets/logos/ethicapp-logo.svg
+++ b/management-console/frontend/src/assets/logos/ethicapp-logo.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 679 161" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-133.592,-108.434)">
+        <g transform="matrix(1,0,0,1,-157.043,-10.4363)">
+            <text x="281.335px" y="239.02px" style="font-family:'Poppins-Bold', 'Poppins';font-weight:700;font-size:150px;fill:rgb(38,73,236);">EthicApp</text>
+        </g>
+    </g>
+</svg>

--- a/management-console/frontend/src/components/layout/ManagementLayout.jsx
+++ b/management-console/frontend/src/components/layout/ManagementLayout.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
-import { Container, Nav, Navbar } from 'react-bootstrap';
+import { Button, Container, Nav, Navbar } from 'react-bootstrap';
 import { Link, useLocation } from 'react-router-dom';
 import { useI18n } from '../../app/providers.jsx';
+import logo from '../../assets/logos/ethicapp-logo.svg';
 
 function ManagementLayout({ children }) {
   const { t } = useI18n();
@@ -11,16 +12,33 @@ function ManagementLayout({ children }) {
     <div className="min-vh-100 bg-light">
       <Navbar bg="dark" data-bs-theme="dark" expand="lg">
         <Container>
-          <Navbar.Brand as={Link} to="/users">
-            {t('app.title')}
+          <Navbar.Brand>
+            <a
+              href="https://www.ethicapp.info"
+              target="_blank"
+              rel="noreferrer"
+              className="ethicapp-logo-topbar"
+            >
+              <img src={logo} alt="EthicApp" className="ethicapp-logo-topbar-img" />
+            </a>
           </Navbar.Brand>
           <Navbar.Toggle aria-controls="mng-nav" />
           <Navbar.Collapse id="mng-nav">
             <Nav className="me-auto" activeKey={location.pathname}>
               <Nav.Link as={Link} to="/users" eventKey="/users">
+                <i className="fa-solid fa-users me-2" aria-hidden="true" />
                 {t('nav.users')}
               </Nav.Link>
             </Nav>
+            <Button
+              variant="outline-light"
+              size="sm"
+              onClick={() => window.location.assign('/logout')}
+              className="d-inline-flex align-items-center"
+            >
+              <i className="fa-solid fa-right-from-bracket me-2" aria-hidden="true" />
+              {t('nav.logout')}
+            </Button>
           </Navbar.Collapse>
         </Container>
       </Navbar>

--- a/management-console/frontend/src/i18n/locales/en_US.js
+++ b/management-console/frontend/src/i18n/locales/en_US.js
@@ -4,7 +4,8 @@ export default {
     subtitle: 'Single-tenant user operations'
   },
   nav: {
-    users: 'Users'
+    users: 'Users',
+    logout: 'Log out'
   },
   filters: {
     keywords: 'Search by first name, last name, email, or identifier',

--- a/management-console/frontend/src/i18n/locales/es_CL.js
+++ b/management-console/frontend/src/i18n/locales/es_CL.js
@@ -4,7 +4,8 @@ export default {
     subtitle: 'Operaciones de usuarios para entorno single-tenant'
   },
   nav: {
-    users: 'Usuarios'
+    users: 'Usuarios',
+    logout: 'Cerrar sesión'
   },
   filters: {
     keywords: 'Buscar por nombre, apellido, email o identificador',

--- a/management-console/frontend/src/pages/UserShowPage.jsx
+++ b/management-console/frontend/src/pages/UserShowPage.jsx
@@ -147,8 +147,12 @@ function UserShowPage() {
     <Card>
       <Card.Body>
         <div className="d-flex justify-content-between align-items-center mb-3">
-          <Card.Title>{t('pages.userShow.heading')}</Card.Title>
+          <Card.Title className="d-flex align-items-center gap-2 mb-0">
+            <i className="fa-solid fa-id-card text-primary" aria-hidden="true" />
+            <span>{t('pages.userShow.heading')}</span>
+          </Card.Title>
           <Button variant="outline-secondary" as={Link} to="/users">
+            <i className="fa-solid fa-arrow-left me-2" aria-hidden="true" />
             {t('pages.userShow.back')}
           </Button>
         </div>
@@ -236,15 +240,21 @@ function UserShowPage() {
           </Row>
 
           <div className="d-flex gap-2 mt-4">
-            <Button type="submit">{t('pages.userShow.actions.save')}</Button>
+            <Button type="submit">
+              <i className="fa-solid fa-floppy-disk me-2" aria-hidden="true" />
+              {t('pages.userShow.actions.save')}
+            </Button>
             <Button type="button" variant="outline-primary" onClick={() => navigate('/users')}>
+              <i className="fa-solid fa-xmark me-2" aria-hidden="true" />
               {t('pages.userShow.actions.cancel')}
             </Button>
             <Button type="button" variant="warning" onClick={onTriggerPasswordReset}>
+              <i className="fa-solid fa-key me-2" aria-hidden="true" />
               {t('pages.userShow.actions.triggerPasswordReset')}
             </Button>
             {form.role === 'P' ? (
               <Button type="button" variant="dark" onClick={onImpersonateProfessor}>
+                <i className="fa-solid fa-user-secret me-2" aria-hidden="true" />
                 {t('pages.userShow.actions.impersonateProfessor')}
               </Button>
             ) : null}

--- a/management-console/frontend/src/pages/UsersPage.jsx
+++ b/management-console/frontend/src/pages/UsersPage.jsx
@@ -104,7 +104,10 @@ function UsersPage() {
   return (
     <Card>
       <Card.Body>
-        <Card.Title>{t('pages.users.heading')}</Card.Title>
+        <Card.Title className="d-flex align-items-center gap-2">
+          <i className="fa-solid fa-user-gear text-primary" aria-hidden="true" />
+          <span>{t('pages.users.heading')}</span>
+        </Card.Title>
         <Card.Text>{t('pages.users.description')}</Card.Text>
 
         <Form onSubmit={handleSubmit} className="mb-3">
@@ -137,7 +140,8 @@ function UsersPage() {
             </Col>
 
             <Col md={2}>
-              <Button type="submit" className="w-100">
+              <Button type="submit" className="w-100 d-inline-flex align-items-center justify-content-center">
+                <i className="fa-solid fa-magnifying-glass me-2" aria-hidden="true" />
                 {t('filters.search')}
               </Button>
             </Col>
@@ -179,6 +183,7 @@ function UsersPage() {
                       <td>{roleLabel(user.role)}</td>
                       <td>
                         <Button as={Link} to={`/users/${user.id}`} size="sm" variant="outline-secondary">
+                          <i className="fa-solid fa-eye me-2" aria-hidden="true" />
                           {t('pages.users.actions.view')}
                         </Button>
                       </td>

--- a/management-console/frontend/src/styles/index.css
+++ b/management-console/frontend/src/styles/index.css
@@ -2,3 +2,14 @@ body {
   margin: 0;
   font-family: Inter, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
+
+.ethicapp-logo-topbar {
+  display: inline-flex;
+  align-items: center;
+}
+
+.ethicapp-logo-topbar-img {
+  height: 42px;
+  max-width: 170px;
+  object-fit: contain;
+}


### PR DESCRIPTION
### Motivation
- Improve management-console UX by adding EthicApp branding in the topbar, visual iconography for key actions and headings, and a quick logout action for convenience.

### Description
- Render the EthicApp SVG logo in the top navbar and add compact topbar styles (`management-console/frontend/src/components/layout/ManagementLayout.jsx`, `management-console/frontend/src/assets/logos/ethicapp-logo.svg`, `management-console/frontend/src/styles/index.css`).
- Add a logout button in the topbar that redirects to `/logout` and an i18n key `nav.logout` in both `es_CL` and `en_US` (`management-console/frontend/src/i18n/locales/es_CL.js`, `management-console/frontend/src/i18n/locales/en_US.js`).
- Integrate Font Awesome icons via CDN in `index.html` and apply icons to navigation, page headings and action buttons across `UsersPage` and `UserShowPage` to improve affordance and visual hierarchy.

### Testing
- Built the frontend successfully with `cd management-console/frontend && npm run build`, which ran `vite build` and produced the distribution without errors (build succeeded).
- Attempted to add the `@fortawesome/fontawesome-free` package with `npm install @fortawesome/fontawesome-free --save` but the install failed with a `403 Forbidden` in this environment, so the CDN stylesheet was used instead; the build remained successful using the CDN-loaded icons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef75bf21a4832babb2d8a8417fa907)