### PR TITLE
Show phase instructions in SD and ranking phase description templates

### DIFF
--- a/ethicapp/frontend/assets/locales/en.json
+++ b/ethicapp/frontend/assets/locales/en.json
@@ -100,6 +100,7 @@
 	"finished": "Finished",
 	"forgot_pass": "Forgot Password?",
 	"gender": "Gender",
+	"phase_instructions_title": "Instructions",
 	"generalInst": "General instructions",
 	"generate": "Generate",
 	"generateCode": "Generate code",

--- a/ethicapp/frontend/assets/locales/es.json
+++ b/ethicapp/frontend/assets/locales/es.json
@@ -88,6 +88,7 @@
 	"teamWork": "Grupal",
 	"description": "Descripción",
 	"dashboard": "Dashboard",
+	"phase_instructions_title": "Instrucciones",
 	"generalInst": "Instrucciones Generales",
 	"individual": "Individual",
 	"delete": "Eliminar",

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/ranking-phase-description.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/ranking-phase-description.template.html
@@ -20,7 +20,11 @@
             {{ ctrl.phaseDetails.prevPhasesResponse.join(', ') }}
         </p>
     </div>
-    <hr>    
+    <div ng-if="ctrl.phaseDetails.instructions && ctrl.phaseDetails.instructions.trim().length > 0">
+        <h4>{{ 'phase_instructions_title' | translate }}</h4>
+        <p style="white-space: pre-line;">{{ ctrl.phaseDetails.instructions }}</p>
+    </div>
+    <hr>
     <h4>{{ 'actors_label' | translate }}</h4>
     <table class="table table-striped">
         <thead>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-phase-description.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-phase-description.template.html
@@ -8,6 +8,10 @@
         <li ng-if="ctrl.phaseMode === 'team'"><strong>{{ 'group_size_label' | translate }}:</strong> {{ ctrl.phaseDetails.stdntAmount }}</li>
         <li ng-if="$ctrl.phaseDetails.prevPhasesResponse.length > 0"><strong>{{ 'previous_phases_label' | translate }}:</strong> {{ ctrl.phaseDetails.prevPhasesResponse.join(', ') }}</li>
     </ul>
+    <div ng-if="ctrl.phaseDetails.instructions && ctrl.phaseDetails.instructions.trim().length > 0">
+        <h4>{{ 'phase_instructions_title' | translate }}</h4>
+        <p style="white-space: pre-line;">{{ ctrl.phaseDetails.instructions }}</p>
+    </div>
     <hr>
     <h4>{{ 'questions_title_text' | translate }}</h4>
     <table class="table table-striped">


### PR DESCRIPTION
### Motivation
- Phases in the design schema can include an optional `instructions` field, but the teacher phase-description fragments for semantic differential and ranking did not render that text. The change exposes phase instructions in the UI when present.

### Description
- Added a conditional Instructions section to `ethicapp/frontend/assets/static/views/teacher/fragments/sd-phase-description.template.html` that displays `ctrl.phaseDetails.instructions` when non-empty and preserves line breaks via `style="white-space: pre-line;"`.
- Added the same conditional Instructions section to `ethicapp/frontend/assets/static/views/teacher/fragments/ranking-phase-description.template.html`.
- Reused the existing translation key `phase_instructions_title` in the templates and added the key to legacy locale catalogs at `ethicapp/frontend/assets/locales/es.json` and `ethicapp/frontend/assets/locales/en.json` with values `"Instrucciones"` and `"Instructions"` respectively.

### Testing
- Validated JSON syntax for the modified locale files using `python -m json.tool ethicapp/frontend/assets/locales/es.json` and `python -m json.tool ethicapp/frontend/assets/locales/en.json`, both checks succeeded.
- No other automated frontend tests were executed for these template changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef87763eb0832ba8f30f7cbeaa48ef)