### PR TITLE
feat(student): add Font Awesome icons to student UI actions

### DIFF
--- a/ethicapp-student/frontend/index.html
+++ b/ethicapp-student/frontend/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
+      integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
     <title>EthicApp Student</title>
   </head>
   <body>

--- a/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
+++ b/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
@@ -58,7 +58,10 @@ export default function JoinSessionCard({ disabled, onJoined }) {
               onChange={(event) => setJoinCode(event.target.value.toLowerCase())}
             />
             <button className="btn btn-primary" type="submit" disabled={joinBusy || disabled}>
-              {joinBusy ? 'Uniendo...' : 'Unirse'}
+              <span className="d-inline-flex align-items-center gap-2">
+                <i className={`fa-solid ${joinBusy ? 'fa-spinner fa-spin' : 'fa-right-to-bracket'}`} aria-hidden="true" />
+                <span>{joinBusy ? 'Uniendo...' : 'Unirse'}</span>
+              </span>
             </button>
           </div>
         </form>

--- a/ethicapp-student/frontend/src/components/SessionList.jsx
+++ b/ethicapp-student/frontend/src/components/SessionList.jsx
@@ -104,7 +104,10 @@ export default function SessionList({
                     onClick={() => onSessionSelect?.(joinedSession.id)}
                   >
                     <div className="card-body">
-                      <h3 className="h6 mb-1">{joinedSession.name ?? `Sesión #${joinedSession.id}`}</h3>
+                      <h3 className="h6 mb-1 d-flex align-items-center gap-2">
+                        <i className="fa-solid fa-eye text-primary" aria-hidden="true" />
+                        <span>{joinedSession.name ?? `Sesión #${joinedSession.id}`}</span>
+                      </h3>
 
                       <p className="mb-2 small text-secondary">{joinedSession.descr || 'Sin descripción'}</p>
 
@@ -133,7 +136,10 @@ export default function SessionList({
                   onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
                   aria-label="Página anterior"
                 >
-                  Anterior
+                  <span className="d-inline-flex align-items-center gap-2">
+                    <i className="fa-solid fa-chevron-left" aria-hidden="true" />
+                    <span>Anterior</span>
+                  </span>
                 </button>
               </li>
 
@@ -156,7 +162,10 @@ export default function SessionList({
                   onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
                   aria-label="Página siguiente"
                 >
-                  Siguiente
+                  <span className="d-inline-flex align-items-center gap-2">
+                    <span>Siguiente</span>
+                    <i className="fa-solid fa-chevron-right" aria-hidden="true" />
+                  </span>
                 </button>
               </li>
             </ul>

--- a/ethicapp-student/frontend/src/components/StudentTopbar.jsx
+++ b/ethicapp-student/frontend/src/components/StudentTopbar.jsx
@@ -18,7 +18,10 @@ export default function StudentTopbar({ loadingSession, userDisplayName, onLogou
             {loadingSession ? 'Cargando usuario...' : userDisplayName}
           </span>
           <button type="button" className="btn btn-outline-danger btn-sm" onClick={onLogout}>
-            Logout
+            <span className="d-inline-flex align-items-center gap-2">
+              <i className="fa-solid fa-right-from-bracket" aria-hidden="true" />
+              <span>Logout</span>
+            </span>
           </button>
         </div>
       </div>

--- a/ethicapp-student/frontend/src/pages/HomePage.jsx
+++ b/ethicapp-student/frontend/src/pages/HomePage.jsx
@@ -28,7 +28,10 @@ export default function HomePage() {
             aria-selected={activeTab === TABS.JOIN}
             onClick={() => setActiveTab(TABS.JOIN)}
           >
-            Ingresar a Sesión
+            <span className="d-inline-flex align-items-center gap-2">
+              <i className="fa-solid fa-right-to-bracket" aria-hidden="true" />
+              <span>Ingresar a Sesión</span>
+            </span>
           </button>
           <button
             type="button"
@@ -37,7 +40,10 @@ export default function HomePage() {
             aria-selected={activeTab === TABS.PREVIOUS}
             onClick={() => setActiveTab(TABS.PREVIOUS)}
           >
-            Sesiones Anteriores
+            <span className="d-inline-flex align-items-center gap-2">
+              <i className="fa-solid fa-clock-rotate-left" aria-hidden="true" />
+              <span>Sesiones Anteriores</span>
+            </span>
           </button>
         </div>
       </nav>

--- a/ethicapp-student/frontend/src/pages/NotFoundPage.jsx
+++ b/ethicapp-student/frontend/src/pages/NotFoundPage.jsx
@@ -6,7 +6,10 @@ export default function NotFoundPage() {
       <h1 className="h4">Página no encontrada</h1>
       <p className="text-muted">La ruta que intentaste abrir no existe en el módulo de estudiante.</p>
       <Link to="/" className="btn btn-primary btn-sm">
-        Ir al home
+        <span className="d-inline-flex align-items-center gap-2">
+          <i className="fa-solid fa-house" aria-hidden="true" />
+          <span>Ir al home</span>
+        </span>
       </Link>
     </section>
   );

--- a/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
+++ b/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
@@ -149,7 +149,10 @@ export default function SessionDetailPage() {
       <div className="d-flex align-items-center justify-content-between mb-3">
         <h1 className="h4 mb-0">Detalle de sesión</h1>
         <Link to="/" className="btn btn-outline-secondary btn-sm">
-          Volver al home
+          <span className="d-inline-flex align-items-center gap-2">
+            <i className="fa-solid fa-arrow-left" aria-hidden="true" />
+            <span>Volver al home</span>
+          </span>
         </Link>
       </div>
 


### PR DESCRIPTION
### Motivation
- Improve affordance and scanability of primary action buttons and navigation in the student frontend by adding visual icons to key controls.
- Provide a low-effort, non-invasive enhancement that works across views without changing existing app behavior or translations.

### Description
- Load Font Awesome via CDN by adding the stylesheet link to `ethicapp-student/frontend/index.html` so icons are available at runtime.
- Add icon+label compositions (using Font Awesome classes) to the following student UI elements: home tabs (Ingresar / Sesiones Anteriores), join-session submit button (with spinner state), session card heading (eye icon), pagination controls (previous/next chevrons), session detail back link, 404 home button, and topbar logout button.
- Implement the join-button loading spinner by switching the button content to an icon + text combination that shows `fa-spinner fa-spin` when `joinBusy` is true.
- Keep all existing Spanish labels and interaction logic unchanged and avoid introducing new JS dependencies in the code (icons referenced via CSS classes).

### Testing
- Attempted `npm install @fortawesome/fontawesome-svg-core @fortawesome/free-solid-svg-icons @fortawesome/react-fontawesome` in `ethicapp-student/frontend`, but the command failed with a `403 Forbidden` error due to registry/access policy in this environment (installation not possible here).
- Attempted `npm run build` in `ethicapp-student/frontend`, but the build failed in this environment because the `vite` binary is not available (`vite: not found`).
- No automated frontend tests or lints were executed successfully in this environment due to the package/engine limitations above; changes are limited to markup and JSX and should be verified by running the app locally and checking the visual appearance of affected buttons and spinner states.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8d6d15a8832ba341e69459c7fdc0)