### PR TITLE
Fix activity list filtering in teacher Activities view

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/activity.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/activity.controller.js
@@ -116,15 +116,28 @@ export function ActivityController($scope, $http,
             return;
         }
 
+        const normalizeStatus = (status) => {
+            const parsedStatus = Number(status);
+            return Number.isNaN(parsedStatus) ? status : parsedStatus;
+        };
+
         try {
-            vm.activities.archived = ActivityCatalogService.
-                getActivities().filter(activity => { return activity.archived; });
-            vm.activities.ongoing = ActivityCatalogService.
-                getActivities().filter(activity => { return !activity.archived &&
-                    activity.status == statusCodes.in_progress; });
-            vm.activities.finished = ActivityCatalogService.
-                getActivities().filter(activity => { return !activity.archived &&
-                    activity.status == statusCodes.finished; });
+            vm.activities.archived = activities.filter((activity) => {
+                return activity.archived;
+            });
+
+            vm.activities.ongoing = activities.filter((activity) => {
+                const activityStatus = normalizeStatus(activity.status);
+                return !activity.archived &&
+                    (activityStatus === statusCodes.initiated ||
+                     activityStatus === statusCodes.in_progress);
+            });
+
+            vm.activities.finished = activities.filter((activity) => {
+                const activityStatus = normalizeStatus(activity.status);
+                return !activity.archived &&
+                    activityStatus === statusCodes.finished;
+            });
         } catch (error) {
             console.error("[ActivityController::updateActivities] An error ocurred.");
         }

--- a/ethicapp/frontend/assets/js/services/activity-catalog.service.js
+++ b/ethicapp/frontend/assets/js/services/activity-catalog.service.js
@@ -8,15 +8,20 @@ let ActivityCatalogService = ($http) => {
         },
         
         async getActivityBySessionId(sessionId, retry = true) {
+            const normalizedSessionId = Number(sessionId);
             // Search locally
-            const activity = service.activities.find(activity => activity.session === sessionId);
+            const activity = service.activities.find((activityItem) => {
+                return Number(activityItem.sessionId) === normalizedSessionId;
+            });
 
             // If the activity was not found, and retrying is requested, reload and
             // then find again.
             if (!activity && retry) {
                 try {
                     await service.loadActivities();
-                    return service.activities.find(activity => activity.session === sessionId) || null;
+                    return service.activities.find((activityItem) => {
+                        return Number(activityItem.sessionId) === normalizedSessionId;
+                    }) || null;
                 } catch (error) {
                     console.error(`Error fetching activity by sessionId: ${sessionId}`, error);
                     throw new Error("Error fetching activity by session ID");


### PR DESCRIPTION
### Motivation
- Teachers saw the empty-state message in the Current tab despite activities existing because the UI/service flow filtered or looked up activities inconsistently and did not tolerate numeric/string differences in status or session ids.

### Description
- Updated `ActivityController.updateActivities()` to use the local `activities` snapshot, normalize `activity.status` to a number when possible, and treat both `initiated` and `in_progress` as current/ongoing states.
- Changed finished/archived filtering to be type-safe and explicit to avoid hiding valid activities.
- Fixed `ActivityCatalogService.getActivityBySessionId()` to search by the backend payload field `sessionId` (rather than `session`) and normalize the session id numerically for robust matching.
- Files changed: `ethicapp/frontend/assets/js/controllers/teacher/activity.controller.js` and `ethicapp/frontend/assets/js/services/activity-catalog.service.js`.

### Testing
- Ran lint on the modified files with `npx eslint ethicapp/frontend/assets/js/controllers/teacher/activity.controller.js ethicapp/frontend/assets/js/services/activity-catalog.service.js`, which reported `24 problems (19 errors, 5 warnings)` and exited non-zero due to legacy lint issues; this change is focused on functional correctness and did not attempt broad style refactors.
- No other automated tests were present/run for these legacy frontend files in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9678bf68832bbc8872f491e8c960)