### PR TITLE
Redirect to session when student re-enters a previously joined code

### DIFF
--- a/ethicapp-student/backend/routes/student.routes.js
+++ b/ethicapp-student/backend/routes/student.routes.js
@@ -103,6 +103,26 @@ router.post('/sessions/join', async (req, res, next) => {
     });
 
   try {
+    const existingMembership = await query(
+      `
+        SELECT s.id AS sesid
+        FROM sesusers AS su
+        JOIN sessions AS s
+          ON s.id = su.sesid
+        WHERE su.uid = $1
+          AND s.code = $2
+        LIMIT 1
+      `,
+      [uid, code]
+    );
+
+    if (existingMembership.rowCount > 0) {
+      return res.status(200).json({
+        sesid: existingMembership.rows[0].sesid,
+        alreadyJoined: true
+      });
+    }
+
     const result = await query(
       `
         INSERT INTO sesusers(uid, sesid, device)
@@ -140,7 +160,8 @@ router.post('/sessions/join', async (req, res, next) => {
     }
 
     return res.status(201).json({
-      sesid: result.rows[0].sesid
+      sesid: result.rows[0].sesid,
+      alreadyJoined: false
     });
   } catch (error) {
     return next(error);

--- a/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
+++ b/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
@@ -20,14 +20,22 @@ export default function JoinSessionCard({ disabled, onJoined }) {
     setJoinFeedback(null);
 
     try {
-      await studentApi.post('sessions/join', {
+      const { data } = await studentApi.post('sessions/join', {
         code: normalizedCode,
         device: 'web'
       });
 
-      setJoinFeedback({ type: 'success', message: 'Te uniste a la sesión correctamente.' });
+      const alreadyJoined = Boolean(data?.alreadyJoined);
+      const sessionId = Number(data?.sesid);
+
+      setJoinFeedback({
+        type: 'success',
+        message: alreadyJoined
+          ? 'Ya habías ingresado a esta sesión. Redirigiendo...'
+          : 'Te uniste a la sesión correctamente. Redirigiendo...'
+      });
       setJoinCode('');
-      onJoined();
+      onJoined(sessionId, { alreadyJoined });
     } catch (error) {
       const message = axios.isAxiosError(error)
         ? (error.response?.data?.error ?? 'No fue posible unirse a la sesión')

--- a/ethicapp-student/frontend/src/pages/HomePage.jsx
+++ b/ethicapp-student/frontend/src/pages/HomePage.jsx
@@ -17,6 +17,14 @@ export default function HomePage() {
     navigate(`/sessions/${sessionId}`);
   };
 
+  const handleSessionJoined = (sessionId) => {
+    onSessionJoined();
+
+    if (Number.isInteger(sessionId) && sessionId > 0) {
+      navigate(`/sessions/${sessionId}`);
+    }
+  };
+
   return (
     <div className="d-flex flex-column gap-4">
       <nav>
@@ -51,7 +59,7 @@ export default function HomePage() {
       {activeTab === TABS.JOIN ? (
         <div className="row g-4">
           <section className="col-12">
-            <JoinSessionCard disabled={loadingSession} onJoined={onSessionJoined} />
+            <JoinSessionCard disabled={loadingSession} onJoined={handleSessionJoined} />
           </section>
 
           <section className="col-12">


### PR DESCRIPTION
### Motivation
- When a student submits a session code they already joined, the UI showed a generic error instead of recognizing previous membership and routing them to the session page. 
- Improve UX by detecting existing membership and navigating directly to the session detail when appropriate.

### Description
- Updated backend `POST /sessions/join` in `ethicapp-student/backend/routes/student.routes.js` to check for an existing `sesusers` record for the authenticated `uid` and session `code`, returning `200` with `{ sesid, alreadyJoined: true }` if found. 
- Preserved the insert flow for new joins and now return `{ sesid, alreadyJoined: false }` on success (previously returned only `sesid`).
- Updated frontend `JoinSessionCard` (`ethicapp-student/frontend/src/components/JoinSessionCard.jsx`) to read `sesid` and `alreadyJoined` from the API response and invoke the callback with `onJoined(sessionId, { alreadyJoined })` while showing an appropriate redirecting message. 
- Updated `HomePage` (`ethicapp-student/frontend/src/pages/HomePage.jsx`) to handle the `onJoined` callback by refreshing sessions (`onSessionJoined()`) and navigating to `/sessions/:sessionId` when a valid `sesid` is returned.

### Testing
- Attempted automated frontend build with `npm run build` (from `ethicapp-student/`), which failed in this environment due to missing frontend dev dependency (`vite: not found`).
- No other automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9bc93a18832ba6c2ba678c9e6a03)