### PR TITLE
feat(ethicapp-student): add auth-backend-style i18n for frontend and backend

### DIFF
--- a/ethicapp-student/backend/app.js
+++ b/ethicapp-student/backend/app.js
@@ -4,6 +4,8 @@ import express from 'express';
 import session from 'express-session';
 
 import studentRoutes from './routes/student.routes.js';
+import studentMessages from './i18n/messages/student-messages.js';
+import { translateMessage } from './i18n/locale.js';
 import { exposeLegacySession, hydrateLegacySession, requireLegacyAuth } from './middleware/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -65,7 +67,7 @@ app.use((err, req, res, next) => {
     return next(err);
   }
 
-  return res.status(500).json({ error: 'Internal server error' });
+  return res.status(500).json({ error: translateMessage(req, 'internalServerError', studentMessages) });
 });
 
 export default app;

--- a/ethicapp-student/backend/i18n/locale.js
+++ b/ethicapp-student/backend/i18n/locale.js
@@ -1,0 +1,39 @@
+const DEFAULT_LOCALE = 'en_US';
+
+function normalizePreferredLocale(locale) {
+  const normalizedLocale = String(locale || '').trim().toLowerCase().replace('-', '_');
+
+  if (normalizedLocale.startsWith('es_') || normalizedLocale === 'es') {
+    return 'es_CL';
+  }
+
+  return 'en_US';
+}
+
+function inferPreferredLocaleFromRequest(req) {
+  const bodyLocale = (req.body?.preferred_locale || '').trim();
+
+  if (bodyLocale) {
+    return normalizePreferredLocale(bodyLocale);
+  }
+
+  const acceptLanguageHeader = String(req.headers['accept-language'] || '');
+  const languageCandidates = acceptLanguageHeader
+    .split(',')
+    .map((entry) => entry.split(';')[0].trim())
+    .filter(Boolean);
+
+  return normalizePreferredLocale(languageCandidates[0] || DEFAULT_LOCALE);
+}
+
+function translateMessage(req, key, catalog) {
+  const locale = inferPreferredLocaleFromRequest(req);
+  return catalog[locale]?.[key] || catalog[DEFAULT_LOCALE]?.[key] || key;
+}
+
+export {
+  DEFAULT_LOCALE,
+  normalizePreferredLocale,
+  inferPreferredLocaleFromRequest,
+  translateMessage
+};

--- a/ethicapp-student/backend/i18n/messages/student-messages.js
+++ b/ethicapp-student/backend/i18n/messages/student-messages.js
@@ -1,0 +1,18 @@
+const studentMessages = {
+  en_US: {
+    unauthenticated: 'User not authenticated',
+    unauthorizedStudent: 'User does not have student permissions',
+    sessionCodeRequired: 'Session code is required',
+    joinSessionUnavailable: 'Unable to join the session using the provided code',
+    internalServerError: 'Internal server error'
+  },
+  es_CL: {
+    unauthenticated: 'Usuario no autenticado',
+    unauthorizedStudent: 'Usuario sin permisos de estudiante',
+    sessionCodeRequired: 'Código de sesión requerido',
+    joinSessionUnavailable: 'No fue posible unirse a la sesión con el código entregado',
+    internalServerError: 'Error interno del servidor'
+  }
+};
+
+export default studentMessages;

--- a/ethicapp-student/backend/routes/student.routes.js
+++ b/ethicapp-student/backend/routes/student.routes.js
@@ -1,19 +1,25 @@
 import { Router } from 'express';
 import { query } from '../config/database.js';
+import studentMessages from '../i18n/messages/student-messages.js';
+import { translateMessage } from '../i18n/locale.js';
 
 const router = Router();
+
+function t(req, key) {
+  return translateMessage(req, key, studentMessages);
+}
 
 function ensureStudentSession(req, res) {
   const uid = Number(req.session?.uid);
   const role = req.session?.role;
 
   if (!Number.isInteger(uid) || uid <= 0) {
-    res.status(401).json({ error: 'Usuario no autenticado' });
+    res.status(401).json({ error: t(req, 'unauthenticated') });
     return null;
   }
 
   if (role !== 'A') {
-    res.status(403).json({ error: 'Usuario sin permisos de estudiante' });
+    res.status(403).json({ error: t(req, 'unauthorizedStudent') });
     return null;
   }
 
@@ -93,14 +99,14 @@ router.post('/sessions/join', async (req, res, next) => {
   const { device } = req.body;
 
   if (!code) {
-    return res.status(400).json({ error: 'Código de sesión requerido' });
+    return res.status(400).json({ error: t(req, 'sessionCodeRequired') });
   }
 
   console.log('[join] payload', {
     uid,
     code,
     device: device ?? null
-    });
+  });
 
   try {
     const existingMembership = await query(
@@ -155,7 +161,7 @@ router.post('/sessions/join', async (req, res, next) => {
     if (result.rowCount === 0) {
       console.log('[join] no row inserted', { uid, code, device: device ?? null });
       return res.status(404).json({
-        error: 'No fue posible unirse a la sesión con el código entregado'
+        error: t(req, 'joinSessionUnavailable')
       });
     }
 

--- a/ethicapp-student/frontend/src/App.jsx
+++ b/ethicapp-student/frontend/src/App.jsx
@@ -1,14 +1,17 @@
 import { RouterProvider } from 'react-router-dom';
+import { AppProviders } from './app/providers.jsx';
 import router from './router';
 import { StudentUserProvider } from './context/StudentUserContext.jsx';
 import { StudentActivityStateProvider } from './context/StudentActivityStateContext.jsx';
 
 export default function App() {
   return (
-    <StudentUserProvider>
-      <StudentActivityStateProvider>
-        <RouterProvider router={router} />
-      </StudentActivityStateProvider>
-    </StudentUserProvider>
+    <AppProviders>
+      <StudentUserProvider>
+        <StudentActivityStateProvider>
+          <RouterProvider router={router} />
+        </StudentActivityStateProvider>
+      </StudentUserProvider>
+    </AppProviders>
   );
 }

--- a/ethicapp-student/frontend/src/app/providers.jsx
+++ b/ethicapp-student/frontend/src/app/providers.jsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useMemo } from 'react';
+import translations from '../i18n/translations.js';
+import { DEFAULT_LOCALE, detectPreferredLocale } from '../i18n/languages.js';
+
+const I18nContext = createContext({
+  locale: DEFAULT_LOCALE,
+  t: (key) => key
+});
+
+function getByPath(dictionary, dottedPath) {
+  return dottedPath
+    .split('.')
+    .reduce((value, segment) => (value && value[segment] !== undefined ? value[segment] : undefined), dictionary);
+}
+
+export function AppProviders({ children }) {
+  const locale = detectPreferredLocale();
+
+  const contextValue = useMemo(() => {
+    const localeDictionary = translations[locale] || translations[DEFAULT_LOCALE] || {};
+
+    function t(key) {
+      const localizedText = getByPath(localeDictionary, key);
+      return localizedText ?? key;
+    }
+
+    return { locale, t };
+  }, [locale]);
+
+  return <I18nContext.Provider value={contextValue}>{children}</I18nContext.Provider>;
+}
+
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
+++ b/ethicapp-student/frontend/src/components/JoinSessionCard.jsx
@@ -1,8 +1,10 @@
 import axios from 'axios';
 import { useState } from 'react';
 import { studentApi } from '../api/studentApi.js';
+import { useI18n } from '../app/providers.jsx';
 
 export default function JoinSessionCard({ disabled, onJoined }) {
+  const { t } = useI18n();
   const [joinCode, setJoinCode] = useState('');
   const [joinBusy, setJoinBusy] = useState(false);
   const [joinFeedback, setJoinFeedback] = useState(null);
@@ -12,7 +14,7 @@ export default function JoinSessionCard({ disabled, onJoined }) {
 
     const normalizedCode = joinCode.trim();
     if (!normalizedCode) {
-      setJoinFeedback({ type: 'danger', message: 'Ingresa un código de sesión válido.' });
+      setJoinFeedback({ type: 'danger', message: t('joinSession.invalidCode') });
       return;
     }
 
@@ -30,16 +32,14 @@ export default function JoinSessionCard({ disabled, onJoined }) {
 
       setJoinFeedback({
         type: 'success',
-        message: alreadyJoined
-          ? 'Ya habías ingresado a esta sesión. Redirigiendo...'
-          : 'Te uniste a la sesión correctamente. Redirigiendo...'
+        message: alreadyJoined ? t('joinSession.alreadyJoined') : t('joinSession.joinedSuccess')
       });
       setJoinCode('');
       onJoined(sessionId, { alreadyJoined });
     } catch (error) {
       const message = axios.isAxiosError(error)
-        ? (error.response?.data?.error ?? 'No fue posible unirse a la sesión')
-        : 'No fue posible unirse a la sesión';
+        ? (error.response?.data?.error ?? t('joinSession.joinErrorFallback'))
+        : t('joinSession.joinErrorFallback');
 
       setJoinFeedback({ type: 'danger', message });
     } finally {
@@ -50,25 +50,23 @@ export default function JoinSessionCard({ disabled, onJoined }) {
   return (
     <div className="card shadow-sm h-100">
       <div className="card-body d-flex flex-column">
-        <h2 className="h5 mb-2">Unirse a una sesión</h2>
-        <p className="text-muted small mb-3">
-          Ingresa el código compartido por tu profesor. El formulario es compatible con móvil y escritorio.
-        </p>
+        <h2 className="h5 mb-2">{t('joinSession.title')}</h2>
+        <p className="text-muted small mb-3">{t('joinSession.description')}</p>
 
         <form className="mt-auto" onSubmit={handleJoinSession}>
           <div className="input-group input-group-lg">
             <input
               type="text"
               className="form-control"
-              placeholder="Ej: k0010d"
-              aria-label="Código de sesión"
+              placeholder={t('joinSession.placeholder')}
+              aria-label={t('joinSession.ariaSessionCode')}
               value={joinCode}
               onChange={(event) => setJoinCode(event.target.value.toLowerCase())}
             />
             <button className="btn btn-primary" type="submit" disabled={joinBusy || disabled}>
               <span className="d-inline-flex align-items-center gap-2">
                 <i className={`fa-solid ${joinBusy ? 'fa-spinner fa-spin' : 'fa-right-to-bracket'}`} aria-hidden="true" />
-                <span>{joinBusy ? 'Uniendo...' : 'Unirse'}</span>
+                <span>{joinBusy ? t('joinSession.joiningAction') : t('joinSession.joinAction')}</span>
               </span>
             </button>
           </div>

--- a/ethicapp-student/frontend/src/components/SessionList.jsx
+++ b/ethicapp-student/frontend/src/components/SessionList.jsx
@@ -1,21 +1,25 @@
 import axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { studentApi } from '../api/studentApi.js';
+import { useI18n } from '../app/providers.jsx';
 import { formatSessionDate, sessionStatusLabel } from '../utils/sessionFormat.js';
 
 export default function SessionList({
   isAuthenticated,
   refreshKey,
   onSessionSelect,
-  title = 'Mis sesiones',
+  title,
   limit,
   enablePagination = false,
   pageSize = 10
 }) {
+  const { locale, t } = useI18n();
   const [joinedSessions, setJoinedSessions] = useState([]);
   const [loadingSessions, setLoadingSessions] = useState(true);
   const [sessionsError, setSessionsError] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
+
+  const resolvedTitle = title || t('sessions.mySessions');
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -36,14 +40,14 @@ export default function SessionList({
       })
       .catch((error) => {
         const message = axios.isAxiosError(error)
-          ? (error.response?.data?.error ?? 'No se pudieron cargar las sesiones')
-          : 'No se pudieron cargar las sesiones';
+          ? (error.response?.data?.error ?? t('sessions.loadErrorFallback'))
+          : t('sessions.loadErrorFallback');
 
         setSessionsError(message);
         setJoinedSessions([]);
         setLoadingSessions(false);
       });
-  }, [isAuthenticated, refreshKey]);
+  }, [isAuthenticated, refreshKey, t]);
 
   useEffect(() => {
     setCurrentPage(1);
@@ -81,11 +85,11 @@ export default function SessionList({
   return (
     <div className="card h-100 shadow-sm">
       <div className="card-body">
-        <h2 className="h5 mb-3">{title}</h2>
+        <h2 className="h5 mb-3">{resolvedTitle}</h2>
 
-        {!isAuthenticated && <p className="text-muted mb-0">Inicia sesión para ver tus sesiones previas.</p>}
+        {!isAuthenticated && <p className="text-muted mb-0">{t('sessions.loginToView')}</p>}
 
-        {isAuthenticated && loadingSessions ? <p className="text-muted mb-0">Cargando sesiones...</p> : null}
+        {isAuthenticated && loadingSessions ? <p className="text-muted mb-0">{t('sessions.loadingSessions')}</p> : null}
 
         {sessionsError ? (
           <div className="alert alert-danger py-2 mb-0" role="alert">
@@ -106,15 +110,15 @@ export default function SessionList({
                     <div className="card-body">
                       <h3 className="h6 mb-1 d-flex align-items-center gap-2">
                         <i className="fa-solid fa-eye text-primary" aria-hidden="true" />
-                        <span>{joinedSession.name ?? `Sesión #${joinedSession.id}`}</span>
+                        <span>{joinedSession.name ?? `${t('sessions.sessionFallbackName')} #${joinedSession.id}`}</span>
                       </h3>
 
-                      <p className="mb-2 small text-secondary">{joinedSession.descr || 'Sin descripción'}</p>
+                      <p className="mb-2 small text-secondary">{joinedSession.descr || t('sessions.noDescription')}</p>
 
                       <div className="small text-muted d-flex flex-wrap gap-2">
-                        <span>Estado: {sessionStatusLabel(joinedSession.status)}</span>
-                        <span>Fecha: {formatSessionDate(joinedSession.time)}</span>
-                        <span>Código: {joinedSession.code}</span>
+                        <span>{t('sessions.statusLabel')}: {sessionStatusLabel(joinedSession.status, t)}</span>
+                        <span>{t('sessions.dateLabel')}: {formatSessionDate(joinedSession.time, locale, t)}</span>
+                        <span>{t('sessions.codeLabel')}: {joinedSession.code}</span>
                       </div>
                     </div>
                   </button>
@@ -122,23 +126,23 @@ export default function SessionList({
               ))}
             </div>
           ) : (
-            <p className="text-muted mb-0">Aún no te has unido a ninguna sesión.</p>
+            <p className="text-muted mb-0">{t('sessions.empty')}</p>
           )
         ) : null}
 
         {!loadingSessions && isAuthenticated && !sessionsError && enablePagination && totalPages > 1 ? (
-          <nav aria-label="Paginación de sesiones" className="mt-4 d-flex justify-content-end">
+          <nav aria-label={t('sessions.paginationLabel')} className="mt-4 d-flex justify-content-end">
             <ul className="pagination pagination-sm mb-0">
               <li className={`page-item ${safePage === 1 ? 'disabled' : ''}`}>
                 <button
                   type="button"
                   className="page-link"
                   onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
-                  aria-label="Página anterior"
+                  aria-label={t('sessions.previousPage')}
                 >
                   <span className="d-inline-flex align-items-center gap-2">
                     <i className="fa-solid fa-chevron-left" aria-hidden="true" />
-                    <span>Anterior</span>
+                    <span>{t('sessions.previous')}</span>
                   </span>
                 </button>
               </li>
@@ -160,10 +164,10 @@ export default function SessionList({
                   type="button"
                   className="page-link"
                   onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
-                  aria-label="Página siguiente"
+                  aria-label={t('sessions.nextPage')}
                 >
                   <span className="d-inline-flex align-items-center gap-2">
-                    <span>Siguiente</span>
+                    <span>{t('sessions.next')}</span>
                     <i className="fa-solid fa-chevron-right" aria-hidden="true" />
                   </span>
                 </button>

--- a/ethicapp-student/frontend/src/components/StudentTopbar.jsx
+++ b/ethicapp-student/frontend/src/components/StudentTopbar.jsx
@@ -1,26 +1,29 @@
 import logo from '../assets/logos/ethicapp-logo.svg';
+import { useI18n } from '../app/providers.jsx';
 
 export default function StudentTopbar({ loadingSession, userDisplayName, onLogout }) {
+  const { t } = useI18n();
+
   return (
     <header className="navbar navbar-expand-lg bg-white border-bottom sticky-top shadow-sm">
       <div className="container-fluid container-lg py-1">
         <span className="navbar-brand mb-0">
-          <a href="https://www.ethicapp.info" target="_blank" className="ethicapp-logo-topbar">
+          <a href="https://www.ethicapp.info" target="_blank" className="ethicapp-logo-topbar" rel="noreferrer">
             <img
               src={logo}
-              alt="EthicApp"
+              alt={t('common.appName')}
               className="ethicapp-logo-topbar-img"
             />
           </a>
         </span>
         <div className="d-flex align-items-center gap-2 ms-auto">
           <span className="small text-secondary text-truncate" style={{ maxWidth: '180px' }}>
-            {loadingSession ? 'Cargando usuario...' : userDisplayName}
+            {loadingSession ? t('common.loadingUser') : userDisplayName}
           </span>
           <button type="button" className="btn btn-outline-danger btn-sm" onClick={onLogout}>
             <span className="d-inline-flex align-items-center gap-2">
               <i className="fa-solid fa-right-from-bracket" aria-hidden="true" />
-              <span>Logout</span>
+              <span>{t('common.logout')}</span>
             </span>
           </button>
         </div>

--- a/ethicapp-student/frontend/src/context/StudentActivityStateContext.jsx
+++ b/ethicapp-student/frontend/src/context/StudentActivityStateContext.jsx
@@ -1,10 +1,12 @@
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import axios from 'axios';
+import { useI18n } from '../app/providers.jsx';
 import { legacyUserApi } from '../api/studentApi.js';
 
 const StudentActivityStateContext = createContext(null);
 
 export function StudentActivityStateProvider({ children }) {
+  const { t } = useI18n();
   const [stateBySession, setStateBySession] = useState({});
   const [loadingBySession, setLoadingBySession] = useState({});
   const [errorBySession, setErrorBySession] = useState({});
@@ -14,11 +16,11 @@ export function StudentActivityStateProvider({ children }) {
     const parsedUserId = Number(userId);
 
     if (!Number.isInteger(parsedSessionId) || parsedSessionId <= 0) {
-      throw new Error('sessionId inválido');
+      throw new Error(t('errors.invalidSessionId'));
     }
 
     if (!Number.isInteger(parsedUserId) || parsedUserId <= 0) {
-      throw new Error('userId inválido');
+      throw new Error(t('errors.invalidUserId'));
     }
 
     setLoadingBySession((prev) => ({ ...prev, [parsedSessionId]: true }));
@@ -42,15 +44,15 @@ export function StudentActivityStateProvider({ children }) {
       return fullState;
     } catch (error) {
       const message = axios.isAxiosError(error)
-        ? (error.response?.data?.error ?? 'No se pudo cargar el estado completo de la actividad')
-        : 'No se pudo cargar el estado completo de la actividad';
+        ? (error.response?.data?.error ?? t('errors.fullStateFallback'))
+        : t('errors.fullStateFallback');
 
       setStateBySession((prev) => ({ ...prev, [parsedSessionId]: null }));
       setErrorBySession((prev) => ({ ...prev, [parsedSessionId]: message }));
       setLoadingBySession((prev) => ({ ...prev, [parsedSessionId]: false }));
       throw error;
     }
-  }, []);
+  }, [t]);
 
   const value = useMemo(
     () => ({
@@ -69,7 +71,7 @@ export function useStudentActivityState() {
   const context = useContext(StudentActivityStateContext);
 
   if (!context) {
-    throw new Error('useStudentActivityState debe usarse dentro de StudentActivityStateProvider');
+    throw new Error('useStudentActivityState must be used within StudentActivityStateProvider');
   }
 
   return context;

--- a/ethicapp-student/frontend/src/i18n/languages.js
+++ b/ethicapp-student/frontend/src/i18n/languages.js
@@ -1,0 +1,44 @@
+export const SUPPORTED_LOCALES = {
+  ES_CL: 'es_CL',
+  EN_US: 'en_US'
+};
+
+export const DEFAULT_LOCALE = SUPPORTED_LOCALES.EN_US;
+
+function normalizeLocale(locale) {
+  return String(locale || '').trim().toLowerCase().replace('-', '_');
+}
+
+function resolveSupportedLocale(candidateLocale) {
+  const normalizedLocale = normalizeLocale(candidateLocale);
+
+  if (!normalizedLocale) {
+    return null;
+  }
+
+  if (normalizedLocale.startsWith('es')) {
+    return SUPPORTED_LOCALES.ES_CL;
+  }
+
+  return SUPPORTED_LOCALES.EN_US;
+}
+
+export function detectPreferredLocale() {
+  const localeCandidates = [
+    ...(typeof navigator !== 'undefined' && Array.isArray(navigator.languages)
+      ? navigator.languages
+      : []),
+    typeof navigator !== 'undefined' ? navigator.language : null,
+    typeof navigator !== 'undefined' ? navigator.userLanguage : null
+  ];
+
+  for (const localeCandidate of localeCandidates) {
+    const locale = resolveSupportedLocale(localeCandidate);
+
+    if (locale) {
+      return locale;
+    }
+  }
+
+  return DEFAULT_LOCALE;
+}

--- a/ethicapp-student/frontend/src/i18n/locales/en_US.js
+++ b/ethicapp-student/frontend/src/i18n/locales/en_US.js
@@ -1,0 +1,87 @@
+const enUS = {
+  common: {
+    appName: 'EthicApp',
+    studentLabel: 'Student',
+    logout: 'Logout',
+    loadingUser: 'Loading user...'
+  },
+  navigation: {
+    sessionsNavigation: 'Sessions navigation',
+    joinSession: 'Join session',
+    previousSessions: 'Previous sessions'
+  },
+  home: {
+    recentSessions: 'Recent sessions',
+    previousSessions: 'Previous sessions'
+  },
+  joinSession: {
+    title: 'Join a session',
+    description: 'Enter the code shared by your teacher. The form works on mobile and desktop.',
+    placeholder: 'Example: k0010d',
+    ariaSessionCode: 'Session code',
+    joinAction: 'Join',
+    joiningAction: 'Joining...',
+    invalidCode: 'Enter a valid session code.',
+    joinErrorFallback: 'Unable to join the session',
+    alreadyJoined: 'You already joined this session. Redirecting...',
+    joinedSuccess: 'You joined the session successfully. Redirecting...'
+  },
+  sessions: {
+    mySessions: 'My sessions',
+    loginToView: 'Sign in to view your previous sessions.',
+    loadingSessions: 'Loading sessions...',
+    loadErrorFallback: 'Unable to load sessions',
+    sessionFallbackName: 'Session',
+    noDescription: 'No description',
+    statusLabel: 'Status',
+    dateLabel: 'Date',
+    codeLabel: 'Code',
+    empty: 'You have not joined any sessions yet.',
+    paginationLabel: 'Session pagination',
+    previousPage: 'Previous page',
+    nextPage: 'Next page',
+    previous: 'Previous',
+    next: 'Next',
+    noDate: 'No date',
+    noStatus: 'No status',
+    status: {
+      setup: 'Setup',
+      active: 'Active',
+      closed: 'Closed',
+      archived: 'Archived'
+    }
+  },
+  sessionDetail: {
+    title: 'Session detail',
+    backHome: 'Back home',
+    loginToView: 'Sign in to review the selected session.',
+    loadingDetail: 'Loading detail...',
+    loadErrorFallback: 'Unable to load session data',
+    noDescription: 'No description',
+    status: 'Status',
+    date: 'Date',
+    code: 'Code',
+    type: 'Type',
+    activePhaseNumber: 'Active phase #',
+    activePhaseId: 'Active phase ID',
+    unavailable: 'Unavailable',
+    noType: 'No type',
+    loadingActivityState: 'Loading full activity state...',
+    activityPhasesLabel: 'Activity phases',
+    phasesTitle: 'Phases',
+    phaseN: 'Phase',
+    notFoundInAvailable: 'We could not find the requested session in your available sessions.'
+  },
+  notFound: {
+    title: 'Page not found',
+    description: 'The route you tried to open does not exist in the student module.',
+    backHome: 'Go home'
+  },
+  errors: {
+    invalidSessionId: 'Invalid sessionId',
+    invalidUserId: 'Invalid userId',
+    fullStateFallback: 'Unable to load full activity state'
+  }
+};
+
+export default enUS;

--- a/ethicapp-student/frontend/src/i18n/locales/es_CL.js
+++ b/ethicapp-student/frontend/src/i18n/locales/es_CL.js
@@ -1,0 +1,87 @@
+const esCL = {
+  common: {
+    appName: 'EthicApp',
+    studentLabel: 'Estudiante',
+    logout: 'Cerrar sesión',
+    loadingUser: 'Cargando usuario...'
+  },
+  navigation: {
+    sessionsNavigation: 'Navegación de sesiones',
+    joinSession: 'Ingresar a sesión',
+    previousSessions: 'Sesiones anteriores'
+  },
+  home: {
+    recentSessions: 'Sesiones recientes',
+    previousSessions: 'Sesiones anteriores'
+  },
+  joinSession: {
+    title: 'Unirse a una sesión',
+    description: 'Ingresa el código compartido por tu profesor. El formulario es compatible con móvil y escritorio.',
+    placeholder: 'Ej: k0010d',
+    ariaSessionCode: 'Código de sesión',
+    joinAction: 'Unirse',
+    joiningAction: 'Uniendo...',
+    invalidCode: 'Ingresa un código de sesión válido.',
+    joinErrorFallback: 'No fue posible unirse a la sesión',
+    alreadyJoined: 'Ya habías ingresado a esta sesión. Redirigiendo...',
+    joinedSuccess: 'Te uniste a la sesión correctamente. Redirigiendo...'
+  },
+  sessions: {
+    mySessions: 'Mis sesiones',
+    loginToView: 'Inicia sesión para ver tus sesiones previas.',
+    loadingSessions: 'Cargando sesiones...',
+    loadErrorFallback: 'No se pudieron cargar las sesiones',
+    sessionFallbackName: 'Sesión',
+    noDescription: 'Sin descripción',
+    statusLabel: 'Estado',
+    dateLabel: 'Fecha',
+    codeLabel: 'Código',
+    empty: 'Aún no te has unido a ninguna sesión.',
+    paginationLabel: 'Paginación de sesiones',
+    previousPage: 'Página anterior',
+    nextPage: 'Página siguiente',
+    previous: 'Anterior',
+    next: 'Siguiente',
+    noDate: 'Sin fecha',
+    noStatus: 'Sin estado',
+    status: {
+      setup: 'Configuración',
+      active: 'Activa',
+      closed: 'Cerrada',
+      archived: 'Archivada'
+    }
+  },
+  sessionDetail: {
+    title: 'Detalle de sesión',
+    backHome: 'Volver al home',
+    loginToView: 'Inicia sesión para revisar la sesión seleccionada.',
+    loadingDetail: 'Cargando detalle...',
+    loadErrorFallback: 'No se pudieron cargar los datos de la sesión',
+    noDescription: 'Sin descripción',
+    status: 'Estado',
+    date: 'Fecha',
+    code: 'Código',
+    type: 'Tipo',
+    activePhaseNumber: 'Fase activa #',
+    activePhaseId: 'Fase activa ID',
+    unavailable: 'No disponible',
+    noType: 'Sin tipo',
+    loadingActivityState: 'Cargando estado completo de la actividad...',
+    activityPhasesLabel: 'Fases de la actividad',
+    phasesTitle: 'Fases',
+    phaseN: 'Fase',
+    notFoundInAvailable: 'No encontramos la sesión solicitada dentro de tus sesiones disponibles.'
+  },
+  notFound: {
+    title: 'Página no encontrada',
+    description: 'La ruta que intentaste abrir no existe en el módulo de estudiante.',
+    backHome: 'Ir al home'
+  },
+  errors: {
+    invalidSessionId: 'sessionId inválido',
+    invalidUserId: 'userId inválido',
+    fullStateFallback: 'No se pudo cargar el estado completo de la actividad'
+  }
+};
+
+export default esCL;

--- a/ethicapp-student/frontend/src/i18n/translations.js
+++ b/ethicapp-student/frontend/src/i18n/translations.js
@@ -1,0 +1,10 @@
+import enUS from './locales/en_US.js';
+import esCL from './locales/es_CL.js';
+import { SUPPORTED_LOCALES } from './languages.js';
+
+const translations = {
+  [SUPPORTED_LOCALES.EN_US]: enUS,
+  [SUPPORTED_LOCALES.ES_CL]: esCL
+};
+
+export default translations;

--- a/ethicapp-student/frontend/src/layouts/StudentLayout.jsx
+++ b/ethicapp-student/frontend/src/layouts/StudentLayout.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Outlet } from 'react-router-dom';
+import { useI18n } from '../app/providers.jsx';
 import { studentApi } from '../api/studentApi.js';
 import StudentTopbar from '../components/StudentTopbar.jsx';
 import { useStudentUser } from '../context/StudentUserContext.jsx';
@@ -11,6 +12,7 @@ const SESSION_PLACEHOLDER = {
 };
 
 export default function StudentLayout() {
+  const { t } = useI18n();
   const [session, setSession] = useState(SESSION_PLACEHOLDER);
   const [loadingSession, setLoadingSession] = useState(true);
   const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
@@ -18,7 +20,7 @@ export default function StudentLayout() {
 
   const userDisplayName = useMemo(() => {
     if (!session.isAuthenticated) {
-      return 'Estudiante';
+      return t('common.studentLabel');
     }
 
     const fullName = [user.firstname, user.lastname].filter(Boolean).join(' ').trim();
@@ -31,8 +33,8 @@ export default function StudentLayout() {
       return user.name;
     }
 
-    return `Usuario #${session.uid}`;
-  }, [session, user]);
+    return `${t('common.studentLabel')} #${session.uid}`;
+  }, [session, t, user]);
 
   useEffect(() => {
     studentApi

--- a/ethicapp-student/frontend/src/pages/HomePage.jsx
+++ b/ethicapp-student/frontend/src/pages/HomePage.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useOutletContext } from 'react-router-dom';
+import { useI18n } from '../app/providers.jsx';
 import JoinSessionCard from '../components/JoinSessionCard.jsx';
 import SessionList from '../components/SessionList.jsx';
 
@@ -9,6 +10,7 @@ const TABS = {
 };
 
 export default function HomePage() {
+  const { t } = useI18n();
   const navigate = useNavigate();
   const { loadingSession, session, sessionRefreshKey, onSessionJoined } = useOutletContext();
   const [activeTab, setActiveTab] = useState(TABS.JOIN);
@@ -28,7 +30,7 @@ export default function HomePage() {
   return (
     <div className="d-flex flex-column gap-4">
       <nav>
-        <div className="nav nav-tabs" role="tablist" aria-label="Navegación de sesiones">
+        <div className="nav nav-tabs" role="tablist" aria-label={t('navigation.sessionsNavigation')}>
           <button
             type="button"
             className={`nav-link ${activeTab === TABS.JOIN ? 'active' : ''}`}
@@ -38,7 +40,7 @@ export default function HomePage() {
           >
             <span className="d-inline-flex align-items-center gap-2">
               <i className="fa-solid fa-right-to-bracket" aria-hidden="true" />
-              <span>Ingresar a Sesión</span>
+              <span>{t('navigation.joinSession')}</span>
             </span>
           </button>
           <button
@@ -50,7 +52,7 @@ export default function HomePage() {
           >
             <span className="d-inline-flex align-items-center gap-2">
               <i className="fa-solid fa-clock-rotate-left" aria-hidden="true" />
-              <span>Sesiones Anteriores</span>
+              <span>{t('navigation.previousSessions')}</span>
             </span>
           </button>
         </div>
@@ -64,7 +66,7 @@ export default function HomePage() {
 
           <section className="col-12">
             <SessionList
-              title="Sesiones recientes"
+              title={t('home.recentSessions')}
               isAuthenticated={session.isAuthenticated}
               refreshKey={sessionRefreshKey}
               onSessionSelect={handleSessionSelect}
@@ -75,7 +77,7 @@ export default function HomePage() {
       ) : (
         <section>
           <SessionList
-            title="Sesiones anteriores"
+            title={t('home.previousSessions')}
             isAuthenticated={session.isAuthenticated}
             refreshKey={sessionRefreshKey}
             onSessionSelect={handleSessionSelect}

--- a/ethicapp-student/frontend/src/pages/NotFoundPage.jsx
+++ b/ethicapp-student/frontend/src/pages/NotFoundPage.jsx
@@ -1,14 +1,17 @@
 import { Link } from 'react-router-dom';
+import { useI18n } from '../app/providers.jsx';
 
 export default function NotFoundPage() {
+  const { t } = useI18n();
+
   return (
     <section className="text-center py-5">
-      <h1 className="h4">Página no encontrada</h1>
-      <p className="text-muted">La ruta que intentaste abrir no existe en el módulo de estudiante.</p>
+      <h1 className="h4">{t('notFound.title')}</h1>
+      <p className="text-muted">{t('notFound.description')}</p>
       <Link to="/" className="btn btn-primary btn-sm">
         <span className="d-inline-flex align-items-center gap-2">
           <i className="fa-solid fa-house" aria-hidden="true" />
-          <span>Ir al home</span>
+          <span>{t('notFound.backHome')}</span>
         </span>
       </Link>
     </section>

--- a/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
+++ b/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
@@ -2,11 +2,13 @@ import axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useOutletContext, useParams } from 'react-router-dom';
 import { studentApi } from '../api/studentApi.js';
+import { useI18n } from '../app/providers.jsx';
 import { useStudentActivityState } from '../context/StudentActivityStateContext.jsx';
 import { getStudentSocket } from '../services/studentSocket.js';
 import { formatSessionDate, sessionStatusLabel } from '../utils/sessionFormat.js';
 
 export default function SessionDetailPage() {
+  const { locale, t } = useI18n();
   const { session, sessionRefreshKey } = useOutletContext();
   const { sessionId } = useParams();
   const [joinedSessions, setJoinedSessions] = useState([]);
@@ -33,14 +35,14 @@ export default function SessionDetailPage() {
       })
       .catch((error) => {
         const message = axios.isAxiosError(error)
-          ? (error.response?.data?.error ?? 'No se pudieron cargar los datos de la sesión')
-          : 'No se pudieron cargar los datos de la sesión';
+          ? (error.response?.data?.error ?? t('sessionDetail.loadErrorFallback'))
+          : t('sessionDetail.loadErrorFallback');
 
         setSessionsError(message);
         setJoinedSessions([]);
         setLoadingSessions(false);
       });
-  }, [session.isAuthenticated, sessionRefreshKey]);
+  }, [session.isAuthenticated, sessionRefreshKey, t]);
 
   const selectedSession = useMemo(() => {
     const parsedSessionId = Number(sessionId);
@@ -61,7 +63,7 @@ export default function SessionDetailPage() {
       sessionId: selectedSession.id,
       userId: session.uid
     }).catch(() => {
-      // El error ya queda reflejado en el contexto.
+      // The error is already reflected in the context state.
     });
   }, [loadFullState, selectedSession, session.isAuthenticated, session.uid]);
 
@@ -147,18 +149,18 @@ export default function SessionDetailPage() {
   return (
     <section className="mx-auto" style={{ maxWidth: '860px' }}>
       <div className="d-flex align-items-center justify-content-between mb-3">
-        <h1 className="h4 mb-0">Detalle de sesión</h1>
+        <h1 className="h4 mb-0">{t('sessionDetail.title')}</h1>
         <Link to="/" className="btn btn-outline-secondary btn-sm">
           <span className="d-inline-flex align-items-center gap-2">
             <i className="fa-solid fa-arrow-left" aria-hidden="true" />
-            <span>Volver al home</span>
+            <span>{t('sessionDetail.backHome')}</span>
           </span>
         </Link>
       </div>
 
-      {!session.isAuthenticated ? <p className="text-muted">Inicia sesión para revisar la sesión seleccionada.</p> : null}
+      {!session.isAuthenticated ? <p className="text-muted">{t('sessionDetail.loginToView')}</p> : null}
 
-      {loadingSessions ? <p className="text-muted">Cargando detalle...</p> : null}
+      {loadingSessions ? <p className="text-muted">{t('sessionDetail.loadingDetail')}</p> : null}
 
       {sessionsError ? (
         <div className="alert alert-danger" role="alert">
@@ -170,30 +172,30 @@ export default function SessionDetailPage() {
         selectedSession ? (
           <article className="card shadow-sm">
             <div className="card-body">
-              <h2 className="h5 mb-2">{selectedSession.name ?? `Sesión #${selectedSession.id}`}</h2>
-              <p className="text-secondary mb-3">{selectedSession.descr || 'Sin descripción'}</p>
+              <h2 className="h5 mb-2">{selectedSession.name ?? `${t('sessions.sessionFallbackName')} #${selectedSession.id}`}</h2>
+              <p className="text-secondary mb-3">{selectedSession.descr || t('sessionDetail.noDescription')}</p>
 
               <dl className="row mb-0">
-                <dt className="col-sm-3">Estado</dt>
-                <dd className="col-sm-9">{sessionStatusLabel(selectedSession.status)}</dd>
+                <dt className="col-sm-3">{t('sessionDetail.status')}</dt>
+                <dd className="col-sm-9">{sessionStatusLabel(selectedSession.status, t)}</dd>
 
-                <dt className="col-sm-3">Fecha</dt>
-                <dd className="col-sm-9">{formatSessionDate(selectedSession.time)}</dd>
+                <dt className="col-sm-3">{t('sessionDetail.date')}</dt>
+                <dd className="col-sm-9">{formatSessionDate(selectedSession.time, locale, t)}</dd>
 
-                <dt className="col-sm-3">Código</dt>
-                <dd className="col-sm-9">{selectedSession.code ?? 'No disponible'}</dd>
+                <dt className="col-sm-3">{t('sessionDetail.code')}</dt>
+                <dd className="col-sm-9">{selectedSession.code ?? t('sessionDetail.unavailable')}</dd>
 
-                <dt className="col-sm-3">Tipo</dt>
-                <dd className="col-sm-9">{selectedSession.type ?? 'Sin tipo'}</dd>
+                <dt className="col-sm-3">{t('sessionDetail.type')}</dt>
+                <dd className="col-sm-9">{selectedSession.type ?? t('sessionDetail.noType')}</dd>
 
-                <dt className="col-sm-3">Fase activa #</dt>
-                <dd className="col-sm-9">{currentPhaseNumber ?? 'No disponible'}</dd>
+                <dt className="col-sm-3">{t('sessionDetail.activePhaseNumber')}</dt>
+                <dd className="col-sm-9">{currentPhaseNumber ?? t('sessionDetail.unavailable')}</dd>
 
-                <dt className="col-sm-3">Fase activa ID</dt>
-                <dd className="col-sm-9">{currentPhaseId ?? 'No disponible'}</dd>
+                <dt className="col-sm-3">{t('sessionDetail.activePhaseId')}</dt>
+                <dd className="col-sm-9">{currentPhaseId ?? t('sessionDetail.unavailable')}</dd>
               </dl>
 
-              {loadingActivityState ? <p className="text-muted mt-3 mb-0">Cargando estado completo de la actividad...</p> : null}
+              {loadingActivityState ? <p className="text-muted mt-3 mb-0">{t('sessionDetail.loadingActivityState')}</p> : null}
 
               {activityStateError ? (
                 <div className="alert alert-warning mt-3 mb-0" role="alert">
@@ -202,8 +204,8 @@ export default function SessionDetailPage() {
               ) : null}
 
               {!loadingActivityState && !activityStateError && phaseTabs.length > 0 ? (
-                <section className="mt-4" aria-label="Fases de la actividad">
-                  <h3 className="h6 mb-2">Fases</h3>
+                <section className="mt-4" aria-label={t('sessionDetail.activityPhasesLabel')}>
+                  <h3 className="h6 mb-2">{t('sessionDetail.phasesTitle')}</h3>
                   <div className="d-flex gap-2 flex-wrap">
                     {phaseTabs.map((phase) => {
                       const isCurrent = Number(phase.number) === Number(currentPhaseNumber);
@@ -212,7 +214,7 @@ export default function SessionDetailPage() {
                           key={phase.id ?? phase.number}
                           className={`phase-pill ${isCurrent ? 'phase-pill--current' : 'phase-pill--inactive'}`}
                         >
-                          Fase {phase.number}
+                          {t('sessionDetail.phaseN')} {phase.number}
                         </span>
                       );
                     })}
@@ -223,7 +225,7 @@ export default function SessionDetailPage() {
           </article>
         ) : (
           <div className="alert alert-warning mb-0" role="alert">
-            No encontramos la sesión solicitada dentro de tus sesiones disponibles.
+            {t('sessionDetail.notFoundInAvailable')}
           </div>
         )
       ) : null}

--- a/ethicapp-student/frontend/src/utils/sessionFormat.js
+++ b/ethicapp-student/frontend/src/utils/sessionFormat.js
@@ -1,27 +1,28 @@
-export function formatSessionDate(value) {
+export function formatSessionDate(value, locale, t) {
   if (!value) {
-    return 'Sin fecha';
+    return t('sessions.noDate');
   }
 
   const date = new Date(value);
 
   if (Number.isNaN(date.getTime())) {
-    return 'Sin fecha';
+    return t('sessions.noDate');
   }
 
-  return new Intl.DateTimeFormat('es-CL', {
+  const dateLocale = locale === 'es_CL' ? 'es-CL' : 'en-US';
+
+  return new Intl.DateTimeFormat(dateLocale, {
     dateStyle: 'medium',
     timeStyle: 'short'
   }).format(date);
 }
 
-export function sessionStatusLabel(status) {
-  const labels = {
-    setup: 'Configuración',
-    active: 'Activa',
-    closed: 'Cerrada',
-    archived: 'Archivada'
-  };
+export function sessionStatusLabel(status, t) {
+  if (!status) {
+    return t('sessions.noStatus');
+  }
 
-  return labels[status] ?? status ?? 'Sin estado';
+  const key = `sessions.status.${status}`;
+  const translatedStatus = t(key);
+  return translatedStatus === key ? status : translatedStatus;
 }


### PR DESCRIPTION
### Motivation
- Provide locale-aware user messages for the student module following the same architecture and canonical locale policy used in `auth-backend` (`es_*` => `es_CL`, otherwise `en_US`).
- Replace hardcoded user-facing strings (mostly Spanish) in both backend and frontend so messages can be served in the correct locale.

### Description
- Backend: added `backend/i18n/locale.js` (normalize/infer/translate helpers) and `backend/i18n/messages/student-messages.js` (catalogs for `en_US` and `es_CL`), switched `routes/student.routes.js` to use `t(req, key)` and localized the global 500 handler in `app.js` to use the catalog.
- Frontend: added a lightweight provider `frontend/src/app/providers.jsx`, locale detection `frontend/src/i18n/languages.js`, translations registration `frontend/src/i18n/translations.js`, and locale catalogs under `frontend/src/i18n/locales/{en_US,es_CL}.js` and wrapped the app with `AppProviders` in `App.jsx`.
- UI changes: replaced hardcoded strings in components/pages (JoinSessionCard, SessionList, StudentTopbar, HomePage, NotFoundPage, SessionDetailPage) to use `t(...)` and made the session formatting utilities locale-aware (`formatSessionDate`, `sessionStatusLabel`).
- Small adjustments: localized error/fallback messages in `StudentActivityStateContext`, normalized some English-only internal messages, and preserved safe fallbacks when translation keys are missing.

### Testing
- Built frontend: ran `npm run build` from `ethicapp-student/frontend` and the build completed successfully.
- Static syntax checks: ran `node --check backend/app.js && node --check backend/routes/student.routes.js && node --check backend/i18n/locale.js` and all checked files passed without syntax errors.
- No automated unit tests exist for this change set; verification consisted of the successful frontend build and backend syntax checks listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc128de08832b8cc26fb288c0477b)