### PR TITLE
Use /users/profile for student context and allow role A for profile GET

### DIFF
--- a/ethicapp-student/frontend/src/context/StudentUserContext.jsx
+++ b/ethicapp-student/frontend/src/context/StudentUserContext.jsx
@@ -19,7 +19,7 @@ function StudentUserProvider({ children }) {
     setLoadingUser(true);
 
     try {
-      const { data } = await legacyUserApi.get('/users/myinfo');
+      const { data } = await legacyUserApi.get('/users/profile');
       const userData = data?.data ?? USER_PLACEHOLDER;
       setUser({
         id: userData.id ?? null,

--- a/ethicapp/backend/controllers/users/user-profile.js
+++ b/ethicapp/backend/controllers/users/user-profile.js
@@ -63,7 +63,7 @@ const buildAvatarPaths = (uid) => {
 };
 
 router.get("/users/profile", async (req, res) => {
-    if (!requireRole(req, res, "P")) return;
+    if (!requireRole(req, res, ["P", "A"])) return;
 
     try {
         res.set("Cache-Control", "no-store, no-cache, must-revalidate, private");


### PR DESCRIPTION
### Motivation
- The student frontend was fetching user information from the retired endpoint `GET /users/myinfo`, so it must consume `GET /users/profile` instead.
- The legacy backend restricted `GET /users/profile` to role `P`, preventing students (`A`) from retrieving their own profile, so read access must allow role `A` as well.

### Description
- Updated `ethicapp-student/frontend/src/context/StudentUserContext.jsx` to request user data from `GET /users/profile` instead of `GET /users/myinfo`.
- Updated `ethicapp/backend/controllers/users/user-profile.js` to authorize the `GET /users/profile` handler for both roles by using `requireRole(req, res, ["P", "A"])`.
- Left write endpoints (`POST /users/profile` and `POST /users/profile/avatar`) unchanged and still restricted to role `P` to avoid widening write permissions.

### Testing
- Ran a code diff review with `git diff` to verify the two modified files and their changes, which matched the intended edits (succeeded).
- Attempted frontend build with `npm --prefix ethicapp-student/frontend run build`, which failed in this environment because `vite` was not available (`vite: not found`).
- Attempted to install frontend deps with `npm --prefix ethicapp-student/frontend install`, but installation did not complete within the environment session constraints (no successful build verification possible here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc784f7b0832b8943b69a88431466)