### PR TITLE
Student: handle onPhaseTransition/onEndSession — merge phase state and read-only finished UI

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
@@ -21,7 +21,7 @@ function buildCaseViewerUrl(caseDocumentUrl) {
   return normalizedCaseDocumentUrl.includes('#') ? normalizedCaseDocumentUrl : `${normalizedCaseDocumentUrl}${hash}`;
 }
 
-export default function ActivityTabsPanel({ tabEntries, activeTab, setActiveTab, hasCaseTab, caseDocumentUrl, t }) {
+export default function ActivityTabsPanel({ tabEntries, activeTab, setActiveTab, hasCaseTab, caseDocumentUrl, readOnly = false, t }) {
   const caseViewerUrl = buildCaseViewerUrl(caseDocumentUrl);
 
   return (
@@ -35,6 +35,7 @@ export default function ActivityTabsPanel({ tabEntries, activeTab, setActiveTab,
               role="tab"
               aria-selected={activeTab === tabEntry.id}
               onClick={() => setActiveTab(tabEntry.id)}
+              disabled={readOnly}
             >
               {tabEntry.label}
             </button>
@@ -42,7 +43,11 @@ export default function ActivityTabsPanel({ tabEntries, activeTab, setActiveTab,
         ))}
       </ul>
 
-      <div className="border border-top-0 rounded-bottom p-3">
+      <div
+        className={`border border-top-0 rounded-bottom p-3 ${readOnly ? 'opacity-75' : ''}`}
+        style={readOnly ? { pointerEvents: 'none' } : undefined}
+        aria-disabled={readOnly}
+      >
         {activeTab === 'case' && hasCaseTab ? (
           <div className="d-flex flex-column gap-2">
             <iframe

--- a/ethicapp-student/frontend/src/context/StudentActivityStateContext.jsx
+++ b/ethicapp-student/frontend/src/context/StudentActivityStateContext.jsx
@@ -11,6 +11,23 @@ export function StudentActivityStateProvider({ children }) {
   const [loadingBySession, setLoadingBySession] = useState({});
   const [errorBySession, setErrorBySession] = useState({});
 
+  const mergePhaseIntoSessionState = useCallback((previousState, phase) => {
+    if (!phase || typeof phase !== 'object') {
+      return previousState ?? null;
+    }
+
+    const previousPhases = Array.isArray(previousState?.phases) ? previousState.phases : [];
+    const nextPhases = previousPhases.filter((existingPhase) => existingPhase?.id !== phase.id);
+
+    nextPhases.push(phase);
+    nextPhases.sort((leftPhase, rightPhase) => Number(leftPhase?.number ?? 0) - Number(rightPhase?.number ?? 0));
+
+    return {
+      ...(previousState ?? {}),
+      phases: nextPhases
+    };
+  }, []);
+
   const loadFullState = useCallback(async ({ sessionId, userId, invalidate = false }) => {
     const parsedSessionId = Number(sessionId);
     const parsedUserId = Number(userId);
@@ -54,14 +71,48 @@ export function StudentActivityStateProvider({ children }) {
     }
   }, [t]);
 
+  const loadCurrentPhaseState = useCallback(async ({ sessionId, invalidate = false }) => {
+    const parsedSessionId = Number(sessionId);
+
+    if (!Number.isInteger(parsedSessionId) || parsedSessionId <= 0) {
+      throw new Error(t('errors.invalidSessionId'));
+    }
+
+    setErrorBySession((prev) => ({ ...prev, [parsedSessionId]: '' }));
+
+    try {
+      const { data } = await legacyUserApi.get(`/activities/${parsedSessionId}/current_phase_state`, {
+        params: {
+          invalidate
+        }
+      });
+      const currentPhaseState = data?.phase ?? null;
+
+      setStateBySession((prev) => ({
+        ...prev,
+        [parsedSessionId]: mergePhaseIntoSessionState(prev[parsedSessionId], currentPhaseState)
+      }));
+
+      return currentPhaseState;
+    } catch (error) {
+      const message = axios.isAxiosError(error)
+        ? (error.response?.data?.error ?? t('errors.currentPhaseStateFallback'))
+        : t('errors.currentPhaseStateFallback');
+
+      setErrorBySession((prev) => ({ ...prev, [parsedSessionId]: message }));
+      throw error;
+    }
+  }, [mergePhaseIntoSessionState, t]);
+
   const value = useMemo(
     () => ({
       stateBySession,
       loadingBySession,
       errorBySession,
-      loadFullState
+      loadFullState,
+      loadCurrentPhaseState
     }),
-    [errorBySession, loadFullState, loadingBySession, stateBySession]
+    [errorBySession, loadCurrentPhaseState, loadFullState, loadingBySession, stateBySession]
   );
 
   return <StudentActivityStateContext.Provider value={value}>{children}</StudentActivityStateContext.Provider>;

--- a/ethicapp-student/frontend/src/i18n/locales/en_US.js
+++ b/ethicapp-student/frontend/src/i18n/locales/en_US.js
@@ -71,6 +71,7 @@ const enUS = {
     waitingTitle: 'Please wait while the activity starts',
     waitingDescription: 'Stay tuned to your teacher instructions',
     loadingActivityState: 'Loading full activity state...',
+    activityFinished: 'This activity has finished',
     loadingCaseDocument: 'Loading case document...',
     caseLoadErrorFallback: 'Unable to load case document',
     activityPhasesLabel: 'Activity phases',
@@ -90,7 +91,8 @@ const enUS = {
   errors: {
     invalidSessionId: 'Invalid sessionId',
     invalidUserId: 'Invalid userId',
-    fullStateFallback: 'Unable to load full activity state'
+    fullStateFallback: 'Unable to load full activity state',
+    currentPhaseStateFallback: 'Unable to load the initial state of the current phase'
   }
 };
 

--- a/ethicapp-student/frontend/src/i18n/locales/es_CL.js
+++ b/ethicapp-student/frontend/src/i18n/locales/es_CL.js
@@ -71,6 +71,7 @@ const esCL = {
     waitingTitle: 'Por favor espera mientras la actividad se inicia',
     waitingDescription: 'Mantente atento a las indicaciones del profesor',
     loadingActivityState: 'Cargando estado completo de la actividad...',
+    activityFinished: 'Esta actividad ha finalizado',
     loadingCaseDocument: 'Cargando documento del caso...',
     caseLoadErrorFallback: 'No se pudo cargar el documento del caso',
     activityPhasesLabel: 'Fases de la actividad',
@@ -90,7 +91,8 @@ const esCL = {
   errors: {
     invalidSessionId: 'sessionId inválido',
     invalidUserId: 'userId inválido',
-    fullStateFallback: 'No se pudo cargar el estado completo de la actividad'
+    fullStateFallback: 'No se pudo cargar el estado completo de la actividad',
+    currentPhaseStateFallback: 'No se pudo cargar el estado inicial de la fase actual'
   }
 };
 

--- a/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
+++ b/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
@@ -20,7 +20,7 @@ export default function SessionDetailPage() {
   const { session, sessionRefreshKey } = useOutletContext();
   const { sessionId } = useParams();
   const [localState, dispatch] = useReducer(sessionDetailReducer, initialSessionDetailState);
-  const { stateBySession, loadingBySession, errorBySession, loadFullState } = useStudentActivityState();
+  const { stateBySession, loadingBySession, errorBySession, loadFullState, loadCurrentPhaseState } = useStudentActivityState();
 
   useEffect(() => {
     if (!session.isAuthenticated) {
@@ -99,6 +99,7 @@ export default function SessionDetailPage() {
 
   const shouldShowWaitingScreen = activityStatusCode === SESSION_STATUS.initiated;
   const shouldLoadActivityData = activityStatusCode >= SESSION_STATUS.inProgress;
+  const isSessionFinished = activityStatusCode === SESSION_STATUS.finished;
 
   useEffect(() => {
     if (!session.isAuthenticated || !selectedSession || !session.uid || !shouldLoadActivityData) {
@@ -185,6 +186,9 @@ export default function SessionDetailPage() {
       });
 
       dispatch({ type: 'ACTIVITY_FORCE_IN_PROGRESS' });
+      loadCurrentPhaseState({ sessionId: activeSessionId }).catch(() => {
+        // Errors are already reflected in the context state.
+      });
     };
 
     const handleShareResponse = (payload) => {
@@ -199,6 +203,8 @@ export default function SessionDetailPage() {
         sessionId: activeSessionId,
         payload
       });
+
+      dispatch({ type: 'ACTIVITY_FORCE_FINISHED' });
     };
 
     const handleChatMessage = (payload) => {
@@ -241,7 +247,7 @@ export default function SessionDetailPage() {
       socket.off('onEndSession', handleEndSession);
       socket.off('onChatMessage', handleChatMessage);
     };
-  }, [selectedSession, session.isAuthenticated]);
+  }, [loadCurrentPhaseState, selectedSession, session.isAuthenticated]);
 
   const phaseTabs = useMemo(() => {
     return Array.isArray(activityState?.phases) ? activityState.phases : [];
@@ -343,14 +349,22 @@ export default function SessionDetailPage() {
               ) : null}
 
               {!shouldShowWaitingScreen && !loadingActivityState && !activityStateError && tabEntries.length > 0 ? (
-                <ActivityTabsPanel
-                  tabEntries={tabEntries}
-                  activeTab={localState.activeTab}
-                  setActiveTab={(nextTab) => dispatch({ type: 'ACTIVE_TAB_SET', payload: nextTab })}
-                  hasCaseTab={hasCaseTab}
-                  caseDocumentUrl={localState.caseDocumentUrl}
-                  t={t}
-                />
+                <>
+                  {isSessionFinished ? (
+                    <div className="alert alert-warning mt-3 mb-0" role="alert">
+                      {t('sessionDetail.activityFinished')}
+                    </div>
+                  ) : null}
+                  <ActivityTabsPanel
+                    tabEntries={tabEntries}
+                    activeTab={localState.activeTab}
+                    setActiveTab={(nextTab) => dispatch({ type: 'ACTIVE_TAB_SET', payload: nextTab })}
+                    hasCaseTab={hasCaseTab}
+                    caseDocumentUrl={localState.caseDocumentUrl}
+                    readOnly={isSessionFinished}
+                    t={t}
+                  />
+                </>
               ) : null}
             </div>
           </article>

--- a/ethicapp-student/frontend/src/pages/session-detail/sessionDetailState.js
+++ b/ethicapp-student/frontend/src/pages/session-detail/sessionDetailState.js
@@ -133,6 +133,14 @@ export function sessionDetailReducer(state, action) {
         }
       };
     }
+    case 'ACTIVITY_FORCE_FINISHED':
+      return {
+        ...state,
+        activityDescriptor: {
+          ...(state.activityDescriptor ?? {}),
+          status: SESSION_STATUS.finished
+        }
+      };
     case 'ACTIVE_TAB_SET':
       return {
         ...state,


### PR DESCRIPTION
### Motivation
- Ensure websocket `onPhaseTransition` causes the student client to fetch the initial state for the new phase from `GET /activities/:session_id/current_phase_state` and append it to the accumulated phases so tabs reflect the new phase. 
- Ensure websocket `onEndSession` (or an activity descriptor with status `finished`) renders the student UI as read-only and shows a clear finished notice.

### Description
- Added `loadCurrentPhaseState` and `mergePhaseIntoSessionState` to `ethicapp-student/frontend/src/context/StudentActivityStateContext.jsx` to call `/activities/:session_id/current_phase_state` and merge/replace the received phase into `stateBySession[sessionId].phases` (keeps phases ordered by `number`).
- Updated `ethicapp-student/frontend/src/pages/SessionDetailPage.jsx` websocket handlers so `onPhaseTransition` dispatches `ACTIVITY_FORCE_IN_PROGRESS` and calls `loadCurrentPhaseState`, and `onEndSession` dispatches `ACTIVITY_FORCE_FINISHED` to mark the descriptor finished locally.
- Added `ACTIVITY_FORCE_FINISHED` reducer handling in `ethicapp-student/frontend/src/pages/session-detail/sessionDetailState.js` to set the descriptor status to `finished` (SESSION_STATUS 3).
- Modified `ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx` to accept a `readOnly` prop which disables tab buttons and makes the tab panel non-interactive (`pointer-events: none`, `aria-disabled` and visual opacity change), and added i18n keys in `es_CL` and `en_US` for the finished message and error fallback when loading current phase state.

### Testing
- Attempted an automated build with `npm --prefix ethicapp-student/frontend run build`, which failed in this environment due to missing tooling (`vite: not found`), so the frontend build could not be validated here.
- No additional automated tests were available or executed in this environment; runtime behavior should be validated in an environment with frontend dependencies installed and the backend websocket/events available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f001c915b4832ba8eb8e13bcdc17a6)