### PR TITLE
Add read-only session UI and live current-phase state handling

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
@@ -21,7 +21,7 @@ function buildCaseViewerUrl(caseDocumentUrl) {
   return normalizedCaseDocumentUrl.includes('#') ? normalizedCaseDocumentUrl : `${normalizedCaseDocumentUrl}${hash}`;
 }
 
-export default function ActivityTabsPanel({ tabEntries, activeTab, setActiveTab, hasCaseTab, caseDocumentUrl, t }) {
+export default function ActivityTabsPanel({ tabEntries, activeTab, setActiveTab, hasCaseTab, caseDocumentUrl, readOnly = false, t }) {
   const caseViewerUrl = buildCaseViewerUrl(caseDocumentUrl);
 
   return (
@@ -35,6 +35,7 @@ export default function ActivityTabsPanel({ tabEntries, activeTab, setActiveTab,
               role="tab"
               aria-selected={activeTab === tabEntry.id}
               onClick={() => setActiveTab(tabEntry.id)}
+              disabled={readOnly}
             >
               {tabEntry.label}
             </button>
@@ -42,7 +43,11 @@ export default function ActivityTabsPanel({ tabEntries, activeTab, setActiveTab,
         ))}
       </ul>
 
-      <div className="border border-top-0 rounded-bottom p-3">
+      <div
+        className={`border border-top-0 rounded-bottom p-3 ${readOnly ? 'opacity-75' : ''}`}
+        style={readOnly ? { pointerEvents: 'none' } : undefined}
+        aria-disabled={readOnly}
+      >
         {activeTab === 'case' && hasCaseTab ? (
           <div className="d-flex flex-column gap-2">
             <iframe

--- a/ethicapp-student/frontend/src/context/StudentActivityStateContext.jsx
+++ b/ethicapp-student/frontend/src/context/StudentActivityStateContext.jsx
@@ -3,13 +3,38 @@ import axios from 'axios';
 import { useI18n } from '../app/providers.jsx';
 import { legacyUserApi } from '../api/studentApi.js';
 
-const StudentActivityStateContext = createContext(null);
+const defaultStudentActivityStateContext = {
+  stateBySession: {},
+  loadingBySession: {},
+  errorBySession: {},
+  loadFullState: async () => null,
+  loadCurrentPhaseState: async () => null
+};
+
+const StudentActivityStateContext = createContext(defaultStudentActivityStateContext);
 
 export function StudentActivityStateProvider({ children }) {
   const { t } = useI18n();
   const [stateBySession, setStateBySession] = useState({});
   const [loadingBySession, setLoadingBySession] = useState({});
   const [errorBySession, setErrorBySession] = useState({});
+
+  const mergePhaseIntoSessionState = useCallback((previousState, phase) => {
+    if (!phase || typeof phase !== 'object') {
+      return previousState ?? null;
+    }
+
+    const previousPhases = Array.isArray(previousState?.phases) ? previousState.phases : [];
+    const nextPhases = previousPhases.filter((existingPhase) => existingPhase?.id !== phase.id);
+
+    nextPhases.push(phase);
+    nextPhases.sort((leftPhase, rightPhase) => Number(leftPhase?.number ?? 0) - Number(rightPhase?.number ?? 0));
+
+    return {
+      ...(previousState ?? {}),
+      phases: nextPhases
+    };
+  }, []);
 
   const loadFullState = useCallback(async ({ sessionId, userId, invalidate = false }) => {
     const parsedSessionId = Number(sessionId);
@@ -54,14 +79,48 @@ export function StudentActivityStateProvider({ children }) {
     }
   }, [t]);
 
+  const loadCurrentPhaseState = useCallback(async ({ sessionId, invalidate = false }) => {
+    const parsedSessionId = Number(sessionId);
+
+    if (!Number.isInteger(parsedSessionId) || parsedSessionId <= 0) {
+      throw new Error(t('errors.invalidSessionId'));
+    }
+
+    setErrorBySession((prev) => ({ ...prev, [parsedSessionId]: '' }));
+
+    try {
+      const { data } = await legacyUserApi.get(`/activities/${parsedSessionId}/current_phase_state`, {
+        params: {
+          invalidate
+        }
+      });
+      const currentPhaseState = data?.phase ?? null;
+
+      setStateBySession((prev) => ({
+        ...prev,
+        [parsedSessionId]: mergePhaseIntoSessionState(prev[parsedSessionId], currentPhaseState)
+      }));
+
+      return currentPhaseState;
+    } catch (error) {
+      const message = axios.isAxiosError(error)
+        ? (error.response?.data?.error ?? t('errors.currentPhaseStateFallback'))
+        : t('errors.currentPhaseStateFallback');
+
+      setErrorBySession((prev) => ({ ...prev, [parsedSessionId]: message }));
+      throw error;
+    }
+  }, [mergePhaseIntoSessionState, t]);
+
   const value = useMemo(
     () => ({
       stateBySession,
       loadingBySession,
       errorBySession,
-      loadFullState
+      loadFullState,
+      loadCurrentPhaseState
     }),
-    [errorBySession, loadFullState, loadingBySession, stateBySession]
+    [errorBySession, loadCurrentPhaseState, loadFullState, loadingBySession, stateBySession]
   );
 
   return <StudentActivityStateContext.Provider value={value}>{children}</StudentActivityStateContext.Provider>;
@@ -70,8 +129,8 @@ export function StudentActivityStateProvider({ children }) {
 export function useStudentActivityState() {
   const context = useContext(StudentActivityStateContext);
 
-  if (!context) {
-    throw new Error('useStudentActivityState must be used within StudentActivityStateProvider');
+  if (context === defaultStudentActivityStateContext && import.meta.env?.DEV) {
+    console.warn('useStudentActivityState is running without StudentActivityStateProvider. Using fallback context.');
   }
 
   return context;

--- a/ethicapp-student/frontend/src/i18n/locales/en_US.js
+++ b/ethicapp-student/frontend/src/i18n/locales/en_US.js
@@ -71,6 +71,7 @@ const enUS = {
     waitingTitle: 'Please wait while the activity starts',
     waitingDescription: 'Stay tuned to your teacher instructions',
     loadingActivityState: 'Loading full activity state...',
+    activityFinished: 'This activity has finished',
     loadingCaseDocument: 'Loading case document...',
     caseLoadErrorFallback: 'Unable to load case document',
     activityPhasesLabel: 'Activity phases',
@@ -90,7 +91,8 @@ const enUS = {
   errors: {
     invalidSessionId: 'Invalid sessionId',
     invalidUserId: 'Invalid userId',
-    fullStateFallback: 'Unable to load full activity state'
+    fullStateFallback: 'Unable to load full activity state',
+    currentPhaseStateFallback: 'Unable to load the initial state of the current phase'
   }
 };
 

--- a/ethicapp-student/frontend/src/i18n/locales/es_CL.js
+++ b/ethicapp-student/frontend/src/i18n/locales/es_CL.js
@@ -71,6 +71,7 @@ const esCL = {
     waitingTitle: 'Por favor espera mientras la actividad se inicia',
     waitingDescription: 'Mantente atento a las indicaciones del profesor',
     loadingActivityState: 'Cargando estado completo de la actividad...',
+    activityFinished: 'Esta actividad ha finalizado',
     loadingCaseDocument: 'Cargando documento del caso...',
     caseLoadErrorFallback: 'No se pudo cargar el documento del caso',
     activityPhasesLabel: 'Fases de la actividad',
@@ -90,7 +91,8 @@ const esCL = {
   errors: {
     invalidSessionId: 'sessionId inválido',
     invalidUserId: 'userId inválido',
-    fullStateFallback: 'No se pudo cargar el estado completo de la actividad'
+    fullStateFallback: 'No se pudo cargar el estado completo de la actividad',
+    currentPhaseStateFallback: 'No se pudo cargar el estado inicial de la fase actual'
   }
 };
 

--- a/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
+++ b/ethicapp-student/frontend/src/pages/SessionDetailPage.jsx
@@ -20,7 +20,7 @@ export default function SessionDetailPage() {
   const { session, sessionRefreshKey } = useOutletContext();
   const { sessionId } = useParams();
   const [localState, dispatch] = useReducer(sessionDetailReducer, initialSessionDetailState);
-  const { stateBySession, loadingBySession, errorBySession, loadFullState } = useStudentActivityState();
+  const { stateBySession, loadingBySession, errorBySession, loadFullState, loadCurrentPhaseState } = useStudentActivityState();
 
   useEffect(() => {
     if (!session.isAuthenticated) {
@@ -99,6 +99,7 @@ export default function SessionDetailPage() {
 
   const shouldShowWaitingScreen = activityStatusCode === SESSION_STATUS.initiated;
   const shouldLoadActivityData = activityStatusCode >= SESSION_STATUS.inProgress;
+  const isSessionFinished = activityStatusCode === SESSION_STATUS.finished;
 
   useEffect(() => {
     if (!session.isAuthenticated || !selectedSession || !session.uid || !shouldLoadActivityData) {
@@ -185,6 +186,9 @@ export default function SessionDetailPage() {
       });
 
       dispatch({ type: 'ACTIVITY_FORCE_IN_PROGRESS' });
+      loadCurrentPhaseState({ sessionId: activeSessionId }).catch(() => {
+        // Errors are already reflected in the context state.
+      });
     };
 
     const handleShareResponse = (payload) => {
@@ -199,6 +203,8 @@ export default function SessionDetailPage() {
         sessionId: activeSessionId,
         payload
       });
+
+      dispatch({ type: 'ACTIVITY_FORCE_FINISHED' });
     };
 
     const handleChatMessage = (payload) => {
@@ -241,7 +247,7 @@ export default function SessionDetailPage() {
       socket.off('onEndSession', handleEndSession);
       socket.off('onChatMessage', handleChatMessage);
     };
-  }, [selectedSession, session.isAuthenticated]);
+  }, [loadCurrentPhaseState, selectedSession, session.isAuthenticated]);
 
   const phaseTabs = useMemo(() => {
     return Array.isArray(activityState?.phases) ? activityState.phases : [];
@@ -343,14 +349,22 @@ export default function SessionDetailPage() {
               ) : null}
 
               {!shouldShowWaitingScreen && !loadingActivityState && !activityStateError && tabEntries.length > 0 ? (
-                <ActivityTabsPanel
-                  tabEntries={tabEntries}
-                  activeTab={localState.activeTab}
-                  setActiveTab={(nextTab) => dispatch({ type: 'ACTIVE_TAB_SET', payload: nextTab })}
-                  hasCaseTab={hasCaseTab}
-                  caseDocumentUrl={localState.caseDocumentUrl}
-                  t={t}
-                />
+                <>
+                  {isSessionFinished ? (
+                    <div className="alert alert-warning mt-3 mb-0" role="alert">
+                      {t('sessionDetail.activityFinished')}
+                    </div>
+                  ) : null}
+                  <ActivityTabsPanel
+                    tabEntries={tabEntries}
+                    activeTab={localState.activeTab}
+                    setActiveTab={(nextTab) => dispatch({ type: 'ACTIVE_TAB_SET', payload: nextTab })}
+                    hasCaseTab={hasCaseTab}
+                    caseDocumentUrl={localState.caseDocumentUrl}
+                    readOnly={isSessionFinished}
+                    t={t}
+                  />
+                </>
               ) : null}
             </div>
           </article>

--- a/ethicapp-student/frontend/src/pages/session-detail/sessionDetailState.js
+++ b/ethicapp-student/frontend/src/pages/session-detail/sessionDetailState.js
@@ -133,6 +133,14 @@ export function sessionDetailReducer(state, action) {
         }
       };
     }
+    case 'ACTIVITY_FORCE_FINISHED':
+      return {
+        ...state,
+        activityDescriptor: {
+          ...(state.activityDescriptor ?? {}),
+          status: SESSION_STATUS.finished
+        }
+      };
     case 'ACTIVE_TAB_SET':
       return {
         ...state,


### PR DESCRIPTION
### Motivation
- Disable interaction with session tabs when an activity has finished and provide a UI hint that the activity is completed.
- Ensure the client can fetch and merge the current phase state on phase transitions received via websocket to keep local session state up to date.
- Improve resilience of the student activity context by providing a safe default context and clearer developer warnings when the provider is missing.

### Description
- Added a `readOnly` prop to `ActivityTabsPanel` to disable tab buttons, apply reduced opacity, set `pointerEvents: none`, and expose `aria-disabled` when the session is finished.
- Introduced `loadCurrentPhaseState` and `mergePhaseIntoSessionState` in `StudentActivityStateContext` to fetch the current phase state and merge it into the existing session state phases array, and added a non-null default context value and a dev-time warning in `useStudentActivityState`.
- Hooked `loadCurrentPhaseState` into `SessionDetailPage` websocket handling so `onPhaseTransition` fetches the current phase; `onEndSession` now dispatches `ACTIVITY_FORCE_FINISHED` and the page sets `readOnly` and shows an `activityFinished` alert when appropriate.
- Added reducer case `ACTIVITY_FORCE_FINISHED` in `sessionDetailState` to set the activity status to `finished`.
- Added new i18n keys `sessionDetail.activityFinished` and `errors.currentPhaseStateFallback` to `en_US` and `es_CL` locales.

### Testing
- Ran the frontend test suite with `npm run test` and all tests passed.
- Built the frontend with `npm run build` and the build completed successfully.
- Ran linter checks with `npm run lint` with no new warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f001c915b4832ba8eb8e13bcdc17a6)