### PR TITLE
Semantic differential: normalize responses, per-task feedback & UI improvements; avoid repeated auto-select of phase tab

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
@@ -4,13 +4,23 @@ function mapResponsesByTaskId(phase) {
   const responseList = Array.isArray(phase?.responses) ? phase.responses : [];
 
   return responseList.reduce((acc, response) => {
-    const taskId = Number(response?.taskId);
+    const taskId = Number(response?.taskId ?? response?.questionId);
 
     if (!Number.isInteger(taskId) || taskId <= 0) {
       return acc;
     }
 
-    acc[taskId] = response;
+    const normalizedValue = Number(
+      response?.selection
+      ?? response?.value
+      ?? response?.responseValue
+      ?? response?.response_value
+    );
+
+    acc[taskId] = {
+      ...response,
+      normalizedValue: Number.isInteger(normalizedValue) ? normalizedValue : null
+    };
     return acc;
   }, {});
 }
@@ -25,7 +35,7 @@ export default function SemanticDifferentialPhaseView({
   const responsesByTask = useMemo(() => mapResponsesByTaskId(phase), [phase]);
   const [draftByTaskId, setDraftByTaskId] = useState({});
   const [submittingTaskId, setSubmittingTaskId] = useState(null);
-  const [feedback, setFeedback] = useState(null);
+  const [feedbackByTaskId, setFeedbackByTaskId] = useState({});
 
   const tasks = useMemo(() => {
     const phaseTasks = Array.isArray(phase?.tasks) ? phase.tasks : [];
@@ -48,8 +58,7 @@ export default function SemanticDifferentialPhaseView({
       return draftValue;
     }
 
-    const persistedValue = Number(responsesByTask[taskId]?.selection);
-    return Number.isInteger(persistedValue) ? persistedValue : null;
+    return Number.isInteger(responsesByTask[taskId]?.normalizedValue) ? responsesByTask[taskId].normalizedValue : null;
   };
 
   const getTaskJustification = (taskId) => {
@@ -67,14 +76,18 @@ export default function SemanticDifferentialPhaseView({
     const justification = getTaskJustification(taskId).trim();
 
     if (!Number.isInteger(value)) {
-      setFeedback({
-        type: 'danger',
-        message: t('sessionDetail.responseSelectScaleFirst')
-      });
+      setFeedbackByTaskId((prev) => ({
+        ...prev,
+        [taskId]: {
+          type: 'danger',
+          message: t('sessionDetail.responseSelectScaleFirst')
+        }
+      }));
       return;
     }
 
     setSubmittingTaskId(taskId);
+    setTaskDraft(taskId, { value, justification });
 
     const result = await onSubmitPhaseResponse({
       responseKey: taskId,
@@ -87,29 +100,25 @@ export default function SemanticDifferentialPhaseView({
 
     setSubmittingTaskId(null);
 
-    setFeedback({
-      type: result.ok ? 'success' : 'danger',
-      message: result.message
-    });
+    setFeedbackByTaskId((prev) => ({
+      ...prev,
+      [taskId]: {
+        type: result.ok ? 'success' : 'danger',
+        message: result.message
+      }
+    }));
 
     window.setTimeout(() => {
-      setFeedback(null);
+      setFeedbackByTaskId((prev) => {
+        const next = { ...prev };
+        delete next[taskId];
+        return next;
+      });
     }, 2600);
   };
 
   return (
     <div className="d-flex flex-column gap-3">
-      {feedback ? (
-        <div
-          className={`position-fixed top-0 end-0 mt-3 me-3 alert alert-${feedback.type} py-2 px-3 shadow-sm`}
-          role="status"
-          aria-live="polite"
-          style={{ zIndex: 1050 }}
-        >
-          {feedback.message}
-        </div>
-      ) : null}
-
       {!isActivePhase && !isReadOnly ? (
         <div className="alert alert-info py-2 mb-0" role="status">
           {t('sessionDetail.phaseReadOnlyWhileInactive')}
@@ -128,35 +137,40 @@ export default function SemanticDifferentialPhaseView({
         const disabled = isReadOnly || !isActivePhase;
         const selectedValue = getTaskValue(taskId);
         const justification = getTaskJustification(taskId);
+        const taskFeedback = feedbackByTaskId[taskId] ?? null;
 
         return (
           <article key={taskId}>
             <p className="fw-semibold mb-2">{task.title}</p>
-            <div className="d-flex justify-content-between align-items-center mb-2">
-              <small className="text-muted">{task.leftPole}</small>
-              <small className="text-muted">{task.rightPole}</small>
-            </div>
-            <div className="d-flex flex-wrap gap-2 mb-3">
-              {Array.from({ length: numValues }, (_, idx) => idx + 1).map((scaleValue) => {
-                const radioId = `task-${taskId}-value-${scaleValue}`;
+            <div className="row align-items-center g-2 mb-3">
+              <div className="col-3 text-start">
+                <small className="text-muted">{task.leftPole}</small>
+              </div>
+              <div className="col-6 d-flex justify-content-center flex-nowrap gap-2">
+                {Array.from({ length: numValues }, (_, idx) => idx + 1).map((scaleValue) => {
+                  const radioId = `task-${taskId}-value-${scaleValue}`;
 
-                return (
-                  <div key={radioId} className="form-check form-check-inline m-0">
-                    <input
-                      id={radioId}
-                      type="radio"
-                      name={`task-${taskId}-scale`}
-                      className="form-check-input"
-                      checked={selectedValue === scaleValue}
-                      disabled={disabled}
-                      onChange={() => setTaskDraft(taskId, { value: scaleValue })}
-                    />
-                    <label htmlFor={radioId} className="form-check-label">
-                      {scaleValue}
-                    </label>
-                  </div>
-                );
-              })}
+                  return (
+                    <div key={radioId} className="form-check form-check-inline m-0 d-inline-flex align-items-center">
+                      <input
+                        id={radioId}
+                        type="radio"
+                        name={`task-${taskId}-scale`}
+                        className="form-check-input"
+                        checked={selectedValue === scaleValue}
+                        disabled={disabled}
+                        onChange={() => setTaskDraft(taskId, { value: scaleValue })}
+                      />
+                      <label htmlFor={radioId} className="form-check-label ms-1">
+                        {scaleValue}
+                      </label>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="col-3 text-end">
+                <small className="text-muted">{task.rightPole}</small>
+              </div>
             </div>
 
             {task.requiresJustification ? (
@@ -176,14 +190,26 @@ export default function SemanticDifferentialPhaseView({
               </div>
             ) : null}
 
-            <div className="d-flex justify-content-end">
+            <div className="d-flex justify-content-end align-items-center gap-2">
+              {taskFeedback ? (
+                <div
+                  className={`alert alert-${taskFeedback.type} py-1 px-2 mb-0`}
+                  role="status"
+                  aria-live="polite"
+                >
+                  {taskFeedback.message}
+                </div>
+              ) : null}
               <button
                 type="button"
                 className="btn btn-primary btn-sm"
                 disabled={disabled || submittingTaskId === taskId}
                 onClick={() => submitTask(task)}
               >
-                {submittingTaskId === taskId ? t('sessionDetail.submittingResponse') : t('sessionDetail.submitResponse')}
+                <span className="d-inline-flex align-items-center gap-2">
+                  <i className="fa-solid fa-paper-plane" aria-hidden="true" />
+                  <span>{submittingTaskId === taskId ? t('sessionDetail.submittingResponse') : t('sessionDetail.submitResponse')}</span>
+                </span>
               </button>
             </div>
 

--- a/ethicapp-student/frontend/src/pages/ActivityPage.jsx
+++ b/ethicapp-student/frontend/src/pages/ActivityPage.jsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { useEffect, useMemo, useReducer, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { Link, useOutletContext, useParams } from 'react-router-dom';
 import { studentApi, legacyUserApi } from '../api/studentApi.js';
 import { useI18n } from '../app/providers.jsx';
@@ -23,6 +23,7 @@ export default function ActivityPage() {
   const { sessionId } = useParams();
   const [localState, dispatch] = useReducer(sessionDetailReducer, initialSessionDetailState);
   const [lastSubmittedAtByResponse, setLastSubmittedAtByResponse] = useState({});
+  const lastAutoSelectedPhaseIdRef = useRef(null);
   const {
     stateBySession,
     loadingBySession,
@@ -66,6 +67,10 @@ export default function ActivityPage() {
   const activityState = stateBySession[selectedSessionId] ?? null;
   const loadingActivityState = loadingBySession[selectedSessionId] ?? false;
   const activityStateError = errorBySession[selectedSessionId] ?? '';
+
+  useEffect(() => {
+    lastAutoSelectedPhaseIdRef.current = null;
+  }, [selectedSessionId]);
 
   useEffect(() => {
     if (!session.isAuthenticated || !selectedSession) {
@@ -312,6 +317,11 @@ export default function ActivityPage() {
       return;
     }
 
+    if (lastAutoSelectedPhaseIdRef.current === currentPhaseId) {
+      return;
+    }
+
+    lastAutoSelectedPhaseIdRef.current = currentPhaseId;
     const currentPhaseTabId = `phase-${currentPhaseId}`;
     if (localState.activeTab !== currentPhaseTabId) {
       dispatch({ type: 'ACTIVE_TAB_SET', payload: currentPhaseTabId });


### PR DESCRIPTION
### Motivation

- Accept varied response shapes from the API by normalizing task id and value fields so persisted answers are read reliably. 
- Replace a single global feedback banner with per-task feedback to avoid hiding task-specific messages and to improve UX. 
- Improve scale layout and submit button appearance for clearer alignment and affordance. 
- Prevent repeated auto-selection of the current phase tab which could cause unnecessary re-renders or focus jumps.

### Description

- Updated `mapResponsesByTaskId` to accept `response.taskId` or `response.questionId` and normalize numeric values from multiple possible fields into `normalizedValue` on the stored response object. 
- Replaced global `feedback` state with `feedbackByTaskId` to track and render feedback messages per task, and updated `submitTask` to set/clear per-task feedback and to persist draft on submit. 
- `getTaskValue` now uses the normalized persisted value (`normalizedValue`) instead of a hard `selection` field. 
- UI/layout changes in `SemanticDifferentialPhaseView.jsx`: reorganized the poles and radio buttons into a responsive row with columns, added radio label spacing, moved feedback inline near the task, and updated the submit button to include an icon and loading text. 
- Removed the global fixed top-right feedback alert. 
- In `ActivityPage.jsx` added `lastAutoSelectedPhaseIdRef` and logic to reset it when switching sessions and to guard the auto-select effect so the same `currentPhaseId` is not repeatedly auto-selected.

### Testing

- Ran the existing front-end automated test suite (unit/integration) after the changes and it passed. 
- Performed basic automated smoke checks for rendering the semantic differential tasks and submitting a response, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c93e8b80832b84872159e011d245)