### PR TITLE
Fix semantic differential phase state reset after submitting responses

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import RankingPhaseView from './phases/RankingPhaseView.jsx';
 import SemanticDifferentialPhaseView from './phases/SemanticDifferentialPhaseView.jsx';
 
@@ -38,6 +38,7 @@ export default function ActivityTabsPanel({
   onSubmitPhaseResponse,
   t
 }) {
+  const [semanticDraftByPhaseId, setSemanticDraftByPhaseId] = useState({});
   const caseViewerUrl = buildCaseViewerUrl(caseDocumentUrl);
 
   const activePhase = useMemo(() => {
@@ -54,6 +55,24 @@ export default function ActivityTabsPanel({
   }, [activeTab, phases]);
 
   const isActivePhase = Number(activePhase?.id) === Number(currentPhaseId);
+  const activePhaseId = Number(activePhase?.id);
+
+  const setSemanticTaskDraft = (phaseId, taskId, partialUpdate) => {
+    if (!Number.isInteger(phaseId) || phaseId <= 0) {
+      return;
+    }
+
+    setSemanticDraftByPhaseId((prev) => ({
+      ...prev,
+      [phaseId]: {
+        ...(prev[phaseId] ?? {}),
+        [taskId]: {
+          ...((prev[phaseId] ?? {})[taskId] ?? {}),
+          ...partialUpdate
+        }
+      }
+    }));
+  };
 
   return (
     <section className="mt-4" aria-label={t('sessionDetail.activityPhasesLabel')}>
@@ -100,6 +119,8 @@ export default function ActivityTabsPanel({
         {activeTab !== 'case' && activePhase && designType === 'semantic_differential' ? (
           <SemanticDifferentialPhaseView
             phase={activePhase}
+            draftByTaskId={semanticDraftByPhaseId[activePhaseId] ?? {}}
+            onTaskDraftChange={(taskId, partialUpdate) => setSemanticTaskDraft(activePhaseId, taskId, partialUpdate)}
             isReadOnly={isSessionFinished}
             isActivePhase={isActivePhase}
             onSubmitPhaseResponse={onSubmitPhaseResponse}

--- a/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
@@ -4,7 +4,13 @@ function mapResponsesByTaskId(phase) {
   const responseList = Array.isArray(phase?.responses) ? phase.responses : [];
 
   return responseList.reduce((acc, response) => {
-    const taskId = Number(response?.taskId ?? response?.questionId);
+    const taskId = Number(
+      response?.taskId
+      ?? response?.task_id
+      ?? response?.questionId
+      ?? response?.question_id
+      ?? response?.did
+    );
 
     if (!Number.isInteger(taskId) || taskId <= 0) {
       return acc;
@@ -12,14 +18,21 @@ function mapResponsesByTaskId(phase) {
 
     const normalizedValue = Number(
       response?.selection
+      ?? response?.sel
       ?? response?.value
       ?? response?.responseValue
       ?? response?.response_value
     );
 
+    const normalizedJustification = response?.justification
+      ?? response?.comment
+      ?? response?.description
+      ?? '';
+
     acc[taskId] = {
       ...response,
-      normalizedValue: Number.isInteger(normalizedValue) ? normalizedValue : null
+      normalizedValue: Number.isInteger(normalizedValue) ? normalizedValue : null,
+      normalizedJustification: typeof normalizedJustification === 'string' ? normalizedJustification : ''
     };
     return acc;
   }, {});
@@ -27,13 +40,15 @@ function mapResponsesByTaskId(phase) {
 
 export default function SemanticDifferentialPhaseView({
   phase,
+  draftByTaskId,
+  onTaskDraftChange,
   isReadOnly,
   isActivePhase,
   onSubmitPhaseResponse,
   t
 }) {
   const responsesByTask = useMemo(() => mapResponsesByTaskId(phase), [phase]);
-  const [draftByTaskId, setDraftByTaskId] = useState({});
+  const safeDraftByTaskId = draftByTaskId ?? {};
   const [submittingTaskId, setSubmittingTaskId] = useState(null);
   const [feedbackByTaskId, setFeedbackByTaskId] = useState({});
 
@@ -43,17 +58,15 @@ export default function SemanticDifferentialPhaseView({
   }, [phase]);
 
   const setTaskDraft = (taskId, partialUpdate) => {
-    setDraftByTaskId((prev) => ({
-      ...prev,
-      [taskId]: {
-        ...(prev[taskId] ?? {}),
-        ...partialUpdate
-      }
-    }));
+    if (typeof onTaskDraftChange !== 'function') {
+      return;
+    }
+
+    onTaskDraftChange(taskId, partialUpdate);
   };
 
   const getTaskValue = (taskId) => {
-    const draftValue = draftByTaskId[taskId]?.value;
+    const draftValue = safeDraftByTaskId[taskId]?.value;
     if (Number.isInteger(draftValue)) {
       return draftValue;
     }
@@ -62,11 +75,11 @@ export default function SemanticDifferentialPhaseView({
   };
 
   const getTaskJustification = (taskId) => {
-    if (typeof draftByTaskId[taskId]?.justification === 'string') {
-      return draftByTaskId[taskId].justification;
+    if (typeof safeDraftByTaskId[taskId]?.justification === 'string') {
+      return safeDraftByTaskId[taskId].justification;
     }
 
-    const persistedJustification = responsesByTask[taskId]?.justification;
+    const persistedJustification = responsesByTask[taskId]?.normalizedJustification;
     return typeof persistedJustification === 'string' ? persistedJustification : '';
   };
 


### PR DESCRIPTION
### Motivation
- Submitting a semantic differential response triggered a UI reset because draft input state lived inside `SemanticDifferentialPhaseView` and was lost if the view was unmounted/remounted after a state refresh.
- Persisted responses from the backend used several field-name variants, causing read-only phases to sometimes not show the saved selection or justification. 
- The change aims to keep user-entered drafts visible across refreshes and ensure persisted responses are mapped reliably.

### Description
- Move semantic-differential draft storage to `ActivityTabsPanel` (scoped by `phaseId` and `taskId`) and pass drafts into `SemanticDifferentialPhaseView` via `draftByTaskId` and `onTaskDraftChange` props to avoid losing local UI state on remount. (`ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx`)
- Enhance response normalization in `mapResponsesByTaskId` to accept backend variants for task id and value names (`taskId/task_id/questionId/question_id/did` and `selection/sel/value/responseValue/response_value`) and normalize justification fields (`justification/comment/description`). (`ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx`)
- Use a safe `draftByTaskId` fallback inside `SemanticDifferentialPhaseView`, and delegate draft updates to the parent component via `onTaskDraftChange` so submitted values and justifications persist after `onSubmitPhaseResponse` refreshes.

### Testing
- Ran repository lint check with `npm run lint-js`; the check failed due to many pre-existing repository-wide lint errors unrelated to the changed files. (status: failed)
- Attempted to build the student frontend with `npm run build` in `ethicapp-student/frontend`; the build failed in this environment because `vite` is not installed (`vite: not found`). (status: failed due to environment)
- Manual verification steps recommended: open a semantic differential phase, enter a value and justification, submit and verify the selection and text remain visible after the refresh, and check read-only phases render persisted selections/justifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ccf16b20832bb226102c020d75c2)