### PR TITLE
Persist semantic-differential task drafts per phase and normalize response fields

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import RankingPhaseView from './phases/RankingPhaseView.jsx';
 import SemanticDifferentialPhaseView from './phases/SemanticDifferentialPhaseView.jsx';
 
@@ -38,6 +38,7 @@ export default function ActivityTabsPanel({
   onSubmitPhaseResponse,
   t
 }) {
+  const [semanticDraftByPhaseId, setSemanticDraftByPhaseId] = useState({});
   const caseViewerUrl = buildCaseViewerUrl(caseDocumentUrl);
 
   const activePhase = useMemo(() => {
@@ -54,6 +55,24 @@ export default function ActivityTabsPanel({
   }, [activeTab, phases]);
 
   const isActivePhase = Number(activePhase?.id) === Number(currentPhaseId);
+  const activePhaseId = Number(activePhase?.id);
+
+  const setSemanticTaskDraft = (phaseId, taskId, partialUpdate) => {
+    if (!Number.isInteger(phaseId) || phaseId <= 0) {
+      return;
+    }
+
+    setSemanticDraftByPhaseId((prev) => ({
+      ...prev,
+      [phaseId]: {
+        ...(prev[phaseId] ?? {}),
+        [taskId]: {
+          ...((prev[phaseId] ?? {})[taskId] ?? {}),
+          ...partialUpdate
+        }
+      }
+    }));
+  };
 
   return (
     <section className="mt-4" aria-label={t('sessionDetail.activityPhasesLabel')}>
@@ -100,6 +119,8 @@ export default function ActivityTabsPanel({
         {activeTab !== 'case' && activePhase && designType === 'semantic_differential' ? (
           <SemanticDifferentialPhaseView
             phase={activePhase}
+            draftByTaskId={semanticDraftByPhaseId[activePhaseId] ?? {}}
+            onTaskDraftChange={(taskId, partialUpdate) => setSemanticTaskDraft(activePhaseId, taskId, partialUpdate)}
             isReadOnly={isSessionFinished}
             isActivePhase={isActivePhase}
             onSubmitPhaseResponse={onSubmitPhaseResponse}

--- a/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
@@ -4,7 +4,13 @@ function mapResponsesByTaskId(phase) {
   const responseList = Array.isArray(phase?.responses) ? phase.responses : [];
 
   return responseList.reduce((acc, response) => {
-    const taskId = Number(response?.taskId ?? response?.questionId);
+    const taskId = Number(
+      response?.taskId
+      ?? response?.task_id
+      ?? response?.questionId
+      ?? response?.question_id
+      ?? response?.did
+    );
 
     if (!Number.isInteger(taskId) || taskId <= 0) {
       return acc;
@@ -12,14 +18,21 @@ function mapResponsesByTaskId(phase) {
 
     const normalizedValue = Number(
       response?.selection
+      ?? response?.sel
       ?? response?.value
       ?? response?.responseValue
       ?? response?.response_value
     );
 
+    const normalizedJustification = response?.justification
+      ?? response?.comment
+      ?? response?.description
+      ?? '';
+
     acc[taskId] = {
       ...response,
-      normalizedValue: Number.isInteger(normalizedValue) ? normalizedValue : null
+      normalizedValue: Number.isInteger(normalizedValue) ? normalizedValue : null,
+      normalizedJustification: typeof normalizedJustification === 'string' ? normalizedJustification : ''
     };
     return acc;
   }, {});
@@ -27,13 +40,15 @@ function mapResponsesByTaskId(phase) {
 
 export default function SemanticDifferentialPhaseView({
   phase,
+  draftByTaskId,
+  onTaskDraftChange,
   isReadOnly,
   isActivePhase,
   onSubmitPhaseResponse,
   t
 }) {
   const responsesByTask = useMemo(() => mapResponsesByTaskId(phase), [phase]);
-  const [draftByTaskId, setDraftByTaskId] = useState({});
+  const safeDraftByTaskId = draftByTaskId ?? {};
   const [submittingTaskId, setSubmittingTaskId] = useState(null);
   const [feedbackByTaskId, setFeedbackByTaskId] = useState({});
 
@@ -43,17 +58,15 @@ export default function SemanticDifferentialPhaseView({
   }, [phase]);
 
   const setTaskDraft = (taskId, partialUpdate) => {
-    setDraftByTaskId((prev) => ({
-      ...prev,
-      [taskId]: {
-        ...(prev[taskId] ?? {}),
-        ...partialUpdate
-      }
-    }));
+    if (typeof onTaskDraftChange !== 'function') {
+      return;
+    }
+
+    onTaskDraftChange(taskId, partialUpdate);
   };
 
   const getTaskValue = (taskId) => {
-    const draftValue = draftByTaskId[taskId]?.value;
+    const draftValue = safeDraftByTaskId[taskId]?.value;
     if (Number.isInteger(draftValue)) {
       return draftValue;
     }
@@ -62,11 +75,11 @@ export default function SemanticDifferentialPhaseView({
   };
 
   const getTaskJustification = (taskId) => {
-    if (typeof draftByTaskId[taskId]?.justification === 'string') {
-      return draftByTaskId[taskId].justification;
+    if (typeof safeDraftByTaskId[taskId]?.justification === 'string') {
+      return safeDraftByTaskId[taskId].justification;
     }
 
-    const persistedJustification = responsesByTask[taskId]?.justification;
+    const persistedJustification = responsesByTask[taskId]?.normalizedJustification;
     return typeof persistedJustification === 'string' ? persistedJustification : '';
   };
 

--- a/ethicapp-student/frontend/src/pages/ActivityPage.jsx
+++ b/ethicapp-student/frontend/src/pages/ActivityPage.jsx
@@ -443,7 +443,7 @@ export default function ActivityPage() {
                 </div>
               ) : null}
 
-              {!shouldShowWaitingScreen && !loadingActivityState && !activityStateError && tabEntries.length > 0 ? (
+              {!shouldShowWaitingScreen && !activityStateError && tabEntries.length > 0 ? (
                 <>
                   {isSessionFinished ? (
                     <div className="alert alert-warning mt-3 mb-0" role="alert">


### PR DESCRIPTION
### Motivation
- Keep semantic-differential task drafts isolated per phase so users don't lose input when switching tabs.
- Normalize response payloads to tolerate different API field names for robustness when reading persisted responses.

### Description
- Added local state `semanticDraftByPhaseId` and helper `setSemanticTaskDraft` in `ActivityTabsPanel.jsx` to store draft values keyed by phase id and passed them to the semantic-differential view via `draftByTaskId` and `onTaskDraftChange` props.
- Updated `SemanticDifferentialPhaseView.jsx` to accept `draftByTaskId` and `onTaskDraftChange`, to use external drafts instead of internal-only state, and to call the provided change handler via `setTaskDraft`.
- Enhanced `mapResponsesByTaskId` to support multiple possible response field names (`taskId`, `task_id`, `questionId`, `question_id`, `did`) and multiple selection/value names (`selection`, `sel`, `value`, `responseValue`, `response_value`) and to normalize justifications into `normalizedJustification`.
- Relaxed conditional rendering in `ActivityPage.jsx` to render `ActivityTabsPanel` even while `loadingActivityState` may be true by removing the `!loadingActivityState` check.

### Testing
- Ran frontend unit tests and component tests; all tests passed.
- Ran linting (`eslint`) and a local dev build; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ccf16b20832bb226102c020d75c2)