### PR TITLE
Fix student full_state response caching for semantic differential reloads

### DIFF
--- a/ethicapp/backend/helpers/student-activity-state-helper.js
+++ b/ethicapp/backend/helpers/student-activity-state-helper.js
@@ -651,7 +651,16 @@ export async function getCachedStudentActivityResponses(designType, sessionId, u
             const cachedData = await redisClient.get(cacheKey);
             if (cachedData) {
                 console.debug(`Cache hit for responses: sessionId=${sessionId}, userId=${userId}`);
-                const responsesByPhase = JSON.parse(cachedData);
+                const cachedResponses = JSON.parse(cachedData);
+                const responsesByPhase = Array.isArray(cachedResponses)
+                    ? cachedResponses.reduce((acc, phase) => {
+                        const phaseNumber = Number(phase?.number);
+                        if (Number.isInteger(phaseNumber) && phaseNumber > 0) {
+                            acc[phaseNumber] = Array.isArray(phase?.responses) ? phase.responses : [];
+                        }
+                        return acc;
+                    }, {})
+                    : cachedResponses;
 
                 // Attach cached responses to the corresponding phases
                 phases.forEach(phase => {
@@ -664,9 +673,13 @@ export async function getCachedStudentActivityResponses(designType, sessionId, u
 
         // Cache miss or invalidation: Fetch responses from the database
         console.debug(`Cache miss for responses: sessionId=${sessionId}, userId=${userId}`);
-        const responsesByPhase = await studentActivityResponseGetters[designType](sessionId, userId, phases);
+        const phasesWithResponses = await getStudentActivityResponses(designType, sessionId, userId, phases);
+        const responsesByPhase = phasesWithResponses.reduce((acc, phase) => {
+            acc[phase.number] = Array.isArray(phase.responses) ? phase.responses : [];
+            return acc;
+        }, {});
 
-        // Cache the result
+        // Cache the normalized map of phaseNumber -> responses
         await redisClient.set(cacheKey, JSON.stringify(responsesByPhase), 'EX', 300); // Expiration: 5 minutes
 
         // Attach responses to the corresponding phases


### PR DESCRIPTION
### Motivation
- Refreshing the student ActivityPage could clear previously submitted semantic differential answers because cached responses were stored in a different shape (array of phases) than the code later expected (map keyed by phase number).

### Description
- Normalize cached responses in `getCachedStudentActivityResponses` so the cache always stores a map `{ [phaseNumber]: responses[] }` and attach those responses back to `phase.responses` before returning.
- On cache miss the helper now calls `getStudentActivityResponses(...)`, reduces the returned phases into the normalized phaseNumber->responses map and caches that normalized map.
- Add backward-compatible parsing for legacy cached payloads that may still be arrays so older keys are tolerated and converted to the new map shape without changing any external API.

### Testing
- Ran a syntax check with `node --check ethicapp/backend/helpers/student-activity-state-helper.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d433049c832bbb852be25fee3f09)