### PR TITLE
Activity tabs icons, SemanticDifferential task component, and dev-only session metadata

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/ActivityTabsPanel.jsx
@@ -86,7 +86,12 @@ export default function ActivityTabsPanel({
               aria-selected={activeTab === tabEntry.id}
               onClick={() => setActiveTab(tabEntry.id)}
             >
-              {tabEntry.label}
+              <span className="d-inline-flex align-items-center gap-2">
+                {typeof tabEntry.iconClass === 'string' && tabEntry.iconClass.length > 0 ? (
+                  <i className={`fa-solid ${tabEntry.iconClass}`} aria-hidden="true" />
+                ) : null}
+                <span>{tabEntry.label}</span>
+              </span>
             </button>
           </li>
         ))}

--- a/ethicapp-student/frontend/src/components/session-detail/SessionMetadata.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/SessionMetadata.jsx
@@ -1,30 +1,60 @@
+import { useState } from 'react';
 import { formatSessionDate, sessionStatusLabel } from '../../utils/sessionFormat.js';
 
+const SHOW_DEV_METADATA = import.meta.env.DEV
+  && String(import.meta.env.VITE_SHOW_DEV_METADATA ?? 'false').toLowerCase() === 'true';
+
 export default function SessionMetadata({ selectedSession, locale, t, currentPhaseNumber, currentPhaseId }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!SHOW_DEV_METADATA) {
+    return null;
+  }
+
   return (
-    <>
-      <h2 className="h5 mb-2">{selectedSession.name ?? `${t('sessions.sessionFallbackName')} #${selectedSession.id}`}</h2>
-      <p className="text-secondary mb-3">{selectedSession.descr || t('sessionDetail.noDescription')}</p>
+    <section className="card border-0 shadow-sm mt-4" aria-label={t('sessionDetail.developerInfoTitle')}>
+      <div className="card-body">
+        <div className="d-flex justify-content-between align-items-center gap-2 flex-wrap">
+          <h2 className="h6 mb-0">{t('sessionDetail.developerInfoTitle')}</h2>
+          <button
+            type="button"
+            className="btn btn-outline-secondary btn-sm"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            aria-expanded={isExpanded}
+            aria-controls="developer-session-metadata"
+          >
+            <span className="d-inline-flex align-items-center gap-2">
+              <i className={`fa-solid ${isExpanded ? 'fa-chevron-up' : 'fa-chevron-down'}`} aria-hidden="true" />
+              <span>{isExpanded ? t('sessionDetail.hideDeveloperInfo') : t('sessionDetail.showDeveloperInfo')}</span>
+            </span>
+          </button>
+        </div>
 
-      <dl className="row mb-0">
-        <dt className="col-sm-3">{t('sessionDetail.status')}</dt>
-        <dd className="col-sm-9">{sessionStatusLabel(selectedSession.status, t)}</dd>
+        {isExpanded ? (
+          <>
+            <hr className="my-3" />
+            <dl id="developer-session-metadata" className="row mb-0">
+              <dt className="col-sm-3">{t('sessionDetail.status')}</dt>
+              <dd className="col-sm-9">{sessionStatusLabel(selectedSession.status, t)}</dd>
 
-        <dt className="col-sm-3">{t('sessionDetail.date')}</dt>
-        <dd className="col-sm-9">{formatSessionDate(selectedSession.time, locale, t)}</dd>
+              <dt className="col-sm-3">{t('sessionDetail.date')}</dt>
+              <dd className="col-sm-9">{formatSessionDate(selectedSession.time, locale, t)}</dd>
 
-        <dt className="col-sm-3">{t('sessionDetail.code')}</dt>
-        <dd className="col-sm-9">{selectedSession.code ?? t('sessionDetail.unavailable')}</dd>
+              <dt className="col-sm-3">{t('sessionDetail.code')}</dt>
+              <dd className="col-sm-9">{selectedSession.code ?? t('sessionDetail.unavailable')}</dd>
 
-        <dt className="col-sm-3">{t('sessionDetail.type')}</dt>
-        <dd className="col-sm-9">{selectedSession.type ?? t('sessionDetail.noType')}</dd>
+              <dt className="col-sm-3">{t('sessionDetail.type')}</dt>
+              <dd className="col-sm-9">{selectedSession.type ?? t('sessionDetail.noType')}</dd>
 
-        <dt className="col-sm-3">{t('sessionDetail.activePhaseNumber')}</dt>
-        <dd className="col-sm-9">{currentPhaseNumber ?? t('sessionDetail.unavailable')}</dd>
+              <dt className="col-sm-3">{t('sessionDetail.activePhaseNumber')}</dt>
+              <dd className="col-sm-9">{currentPhaseNumber ?? t('sessionDetail.unavailable')}</dd>
 
-        <dt className="col-sm-3">{t('sessionDetail.activePhaseId')}</dt>
-        <dd className="col-sm-9">{currentPhaseId ?? t('sessionDetail.unavailable')}</dd>
-      </dl>
-    </>
+              <dt className="col-sm-3">{t('sessionDetail.activePhaseId')}</dt>
+              <dd className="col-sm-9">{currentPhaseId ?? t('sessionDetail.unavailable')}</dd>
+            </dl>
+          </>
+        ) : null}
+      </div>
+    </section>
   );
 }

--- a/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import SemanticDifferentialTaskView from './SemanticDifferentialTaskView.jsx';
 
 function mapResponsesByTaskId(phase) {
   const responseList = Array.isArray(phase?.responses) ? phase.responses : [];
@@ -146,88 +147,25 @@ export default function SemanticDifferentialPhaseView({
 
       {tasks.map((task) => {
         const taskId = Number(task?.id);
-        const numValues = Number(task?.numValues);
         const disabled = isReadOnly || !isActivePhase;
         const selectedValue = getTaskValue(taskId);
         const justification = getTaskJustification(taskId);
         const taskFeedback = feedbackByTaskId[taskId] ?? null;
 
         return (
-          <article key={taskId}>
-            <p className="fw-semibold mb-2">{task.title}</p>
-            <div className="row align-items-center g-2 mb-3">
-              <div className="col-3 text-start">
-                <small className="text-muted">{task.leftPole}</small>
-              </div>
-              <div className="col-6 d-flex justify-content-center flex-nowrap gap-2">
-                {Array.from({ length: numValues }, (_, idx) => idx + 1).map((scaleValue) => {
-                  const radioId = `task-${taskId}-value-${scaleValue}`;
-
-                  return (
-                    <div key={radioId} className="form-check form-check-inline m-0 d-inline-flex align-items-center">
-                      <input
-                        id={radioId}
-                        type="radio"
-                        name={`task-${taskId}-scale`}
-                        className="form-check-input"
-                        checked={selectedValue === scaleValue}
-                        disabled={disabled}
-                        onChange={() => setTaskDraft(taskId, { value: scaleValue })}
-                      />
-                      <label htmlFor={radioId} className="form-check-label ms-1">
-                        {scaleValue}
-                      </label>
-                    </div>
-                  );
-                })}
-              </div>
-              <div className="col-3 text-end">
-                <small className="text-muted">{task.rightPole}</small>
-              </div>
-            </div>
-
-            {task.requiresJustification ? (
-              <div className="mb-3">
-                <label htmlFor={`task-${taskId}-justification`} className="form-label small text-muted mb-1">
-                  {t('sessionDetail.justificationLabel')}
-                </label>
-                <textarea
-                  id={`task-${taskId}-justification`}
-                  className="form-control"
-                  rows={3}
-                  value={justification}
-                  readOnly={disabled}
-                  onChange={(event) => setTaskDraft(taskId, { justification: event.target.value })}
-                  placeholder={t('sessionDetail.justificationPlaceholder')}
-                />
-              </div>
-            ) : null}
-
-            <div className="d-flex justify-content-end align-items-center gap-2">
-              {taskFeedback ? (
-                <div
-                  className={`alert alert-${taskFeedback.type} py-1 px-2 mb-0`}
-                  role="status"
-                  aria-live="polite"
-                >
-                  {taskFeedback.message}
-                </div>
-              ) : null}
-              <button
-                type="button"
-                className="btn btn-primary btn-sm"
-                disabled={disabled || submittingTaskId === taskId}
-                onClick={() => submitTask(task)}
-              >
-                <span className="d-inline-flex align-items-center gap-2">
-                  <i className="fa-solid fa-paper-plane" aria-hidden="true" />
-                  <span>{submittingTaskId === taskId ? t('sessionDetail.submittingResponse') : t('sessionDetail.submitResponse')}</span>
-                </span>
-              </button>
-            </div>
-
-            <hr className="my-3" />
-          </article>
+          <SemanticDifferentialTaskView
+            key={taskId}
+            task={task}
+            disabled={disabled}
+            selectedValue={selectedValue}
+            justification={justification}
+            taskFeedback={taskFeedback}
+            submitting={submittingTaskId === taskId}
+            onTaskValueChange={(value) => setTaskDraft(taskId, { value })}
+            onTaskJustificationChange={(nextJustification) => setTaskDraft(taskId, { justification: nextJustification })}
+            onTaskSubmit={() => submitTask(task)}
+            t={t}
+          />
         );
       })}
     </div>

--- a/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialTaskView.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialTaskView.jsx
@@ -1,0 +1,93 @@
+export default function SemanticDifferentialTaskView({
+  task,
+  disabled,
+  selectedValue,
+  justification,
+  taskFeedback,
+  submitting,
+  onTaskValueChange,
+  onTaskJustificationChange,
+  onTaskSubmit,
+  t
+}) {
+  const taskId = Number(task?.id);
+  const numValues = Number(task?.numValues);
+
+  return (
+    <article>
+      <p className="fw-semibold mb-2">{task.title}</p>
+      <div className="row align-items-center g-2 mb-3">
+        <div className="col-3 text-start">
+          <small className="text-muted">{task.leftPole}</small>
+        </div>
+        <div className="col-6 d-flex justify-content-center flex-nowrap gap-2">
+          {Array.from({ length: numValues }, (_, idx) => idx + 1).map((scaleValue) => {
+            const radioId = `task-${taskId}-value-${scaleValue}`;
+
+            return (
+              <div key={radioId} className="form-check form-check-inline m-0 d-inline-flex align-items-center">
+                <input
+                  id={radioId}
+                  type="radio"
+                  name={`task-${taskId}-scale`}
+                  className="form-check-input"
+                  checked={selectedValue === scaleValue}
+                  disabled={disabled}
+                  onChange={() => onTaskValueChange(scaleValue)}
+                />
+                <label htmlFor={radioId} className="form-check-label ms-1">
+                  {scaleValue}
+                </label>
+              </div>
+            );
+          })}
+        </div>
+        <div className="col-3 text-end">
+          <small className="text-muted">{task.rightPole}</small>
+        </div>
+      </div>
+
+      {task.requiresJustification ? (
+        <div className="mb-3">
+          <label htmlFor={`task-${taskId}-justification`} className="form-label small text-muted mb-1">
+            {t('sessionDetail.justificationLabel')}
+          </label>
+          <textarea
+            id={`task-${taskId}-justification`}
+            className="form-control"
+            rows={3}
+            value={justification}
+            readOnly={disabled}
+            onChange={(event) => onTaskJustificationChange(event.target.value)}
+            placeholder={t('sessionDetail.justificationPlaceholder')}
+          />
+        </div>
+      ) : null}
+
+      <div className="d-flex justify-content-end align-items-center gap-2">
+        {taskFeedback ? (
+          <div
+            className={`alert alert-${taskFeedback.type} py-1 px-2 mb-0`}
+            role="status"
+            aria-live="polite"
+          >
+            {taskFeedback.message}
+          </div>
+        ) : null}
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          disabled={disabled || submitting}
+          onClick={onTaskSubmit}
+        >
+          <span className="d-inline-flex align-items-center gap-2">
+            <i className="fa-solid fa-paper-plane" aria-hidden="true" />
+            <span>{submitting ? t('sessionDetail.submittingResponse') : t('sessionDetail.submitResponse')}</span>
+          </span>
+        </button>
+      </div>
+
+      <hr className="my-3" />
+    </article>
+  );
+}

--- a/ethicapp-student/frontend/src/i18n/locales/en_US.js
+++ b/ethicapp-student/frontend/src/i18n/locales/en_US.js
@@ -92,7 +92,10 @@ const enUS = {
     responseCooldown: 'Please wait before submitting this question again.',
     rankingTabPlaceholder: 'Ranking phase view is under implementation.',
     phaseTabPlaceholder: 'Phase content is under implementation.',
-    notFoundInAvailable: 'We could not find the requested session in your available sessions.'
+    notFoundInAvailable: 'We could not find the requested session in your available sessions.',
+    developerInfoTitle: 'Developer information',
+    showDeveloperInfo: 'Show information',
+    hideDeveloperInfo: 'Hide information'
   },
   notFound: {
     title: 'Page not found',

--- a/ethicapp-student/frontend/src/i18n/locales/es_CL.js
+++ b/ethicapp-student/frontend/src/i18n/locales/es_CL.js
@@ -92,7 +92,10 @@ const esCL = {
     responseCooldown: 'Espera antes de volver a enviar esta pregunta.',
     rankingTabPlaceholder: 'Vista de fase de ranking en implementación.',
     phaseTabPlaceholder: 'Contenido de la fase en implementación.',
-    notFoundInAvailable: 'No encontramos la sesión solicitada dentro de tus sesiones disponibles.'
+    notFoundInAvailable: 'No encontramos la sesión solicitada dentro de tus sesiones disponibles.',
+    developerInfoTitle: 'Información para desarrolladores',
+    showDeveloperInfo: 'Mostrar información',
+    hideDeveloperInfo: 'Ocultar información'
   },
   notFound: {
     title: 'Página no encontrada',

--- a/ethicapp-student/frontend/src/pages/ActivityPage.jsx
+++ b/ethicapp-student/frontend/src/pages/ActivityPage.jsx
@@ -284,18 +284,29 @@ export default function ActivityPage() {
     const entries = [];
 
     if (hasCaseTab) {
-      entries.push({ id: 'case', label: t('sessionDetail.caseTab') });
+      entries.push({
+        id: 'case',
+        label: t('sessionDetail.caseTab'),
+        iconClass: 'fa-book-open'
+      });
     }
+
+    const phaseIconClassByDesign = {
+      semantic_differential: 'fa-brain',
+      ranking: 'fa-puzzle-piece'
+    };
+    const phaseIconClass = phaseIconClassByDesign[designType] ?? 'fa-puzzle-piece';
 
     phaseTabs.forEach((phase) => {
       entries.push({
         id: `phase-${phase.id ?? phase.number}`,
-        label: `${t('sessionDetail.phaseN')} ${phase.number}`
+        label: `${t('sessionDetail.phaseN')} ${phase.number}`,
+        iconClass: phaseIconClass
       });
     });
 
     return entries;
-  }, [hasCaseTab, phaseTabs, t]);
+  }, [designType, hasCaseTab, phaseTabs, t]);
 
   useEffect(() => {
     if (tabEntries.length === 0) {
@@ -409,13 +420,8 @@ export default function ActivityPage() {
         selectedSession ? (
           <article className="card shadow-sm">
             <div className="card-body">
-              <SessionMetadata
-                selectedSession={selectedSession}
-                locale={locale}
-                t={t}
-                currentPhaseNumber={currentPhaseNumber}
-                currentPhaseId={currentPhaseId}
-              />
+              <h2 className="h5 mb-2">{selectedSession.name ?? `${t('sessions.sessionFallbackName')} #${selectedSession.id}`}</h2>
+              <p className="text-secondary mb-3">{selectedSession.descr || t('sessionDetail.noDescription')}</p>
 
               {localState.loadingDescriptor ? <p className="text-muted mt-3 mb-0">{t('sessionDetail.loadingDescriptor')}</p> : null}
 
@@ -472,6 +478,16 @@ export default function ActivityPage() {
             {t('sessionDetail.notFoundInAvailable')}
           </div>
         )
+      ) : null}
+
+      {selectedSession ? (
+        <SessionMetadata
+          selectedSession={selectedSession}
+          locale={locale}
+          t={t}
+          currentPhaseNumber={currentPhaseNumber}
+          currentPhaseId={currentPhaseId}
+        />
       ) : null}
     </section>
   );


### PR DESCRIPTION
### Motivation
- Improve UX of activity tabs by adding visual icons to help users scan case and phase tabs. 
- Increase maintainability of the semantic differential phase view by extracting per-question UI into a dedicated component. 
- Keep developer-only session metadata out of the regular student UI and expose it only in development for debugging.

### Description
- Render Font Awesome icons next to tab labels in `ActivityTabsPanel` and build `tabEntries` with `iconClass` in `ActivityPage` (case: `fa-book-open`, semantic differential: `fa-brain`, ranking/fallback: `fa-puzzle-piece`).
- Introduce `SemanticDifferentialTaskView` to encapsulate a single question's UI (scale radios, optional justification, submit button and feedback) and simplify `SemanticDifferentialPhaseView` to orchestrate drafts/submissions only.
- Move `SessionMetadata` out of the main card and make it a collapsible developer-only card shown at the bottom of the page when in Vite dev mode and `VITE_SHOW_DEV_METADATA=true`, defaulting collapsed with a toggle button.
- Add i18n keys for the developer info title and toggle labels in both `es_CL` and `en_US` locales.

### Testing
- Attempted local frontend build with `npm run build` in `ethicapp-student/frontend`, which failed because `vite` is not available in the execution environment (`vite: not found`).
- Verified component-level changes by running code inspection and ensuring runtime logic (draft handling, submit flow and feedback timers) was preserved after refactor; no automated unit tests were present for these components in this change set.
- Manual QA recommendations included in the PR body: run the frontend in dev with `VITE_SHOW_DEV_METADATA=true` and exercise session detail, tabs, task submit and developer metadata toggle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d81593bc832bbb60e1a9d1b1c7a5)