### PR TITLE
Emit teacher dashboard socket notifications for student response submissions

### DIFF
--- a/ethicapp/backend/controllers/activities/activities-student.js
+++ b/ethicapp/backend/controllers/activities/activities-student.js
@@ -5,6 +5,7 @@ import { requireOwnershipOrRole, requireRole } from "../../helpers/auth-helper.j
 import * as StudentActivityStatusHelper from "../../helpers/student-activity-state-helper.js";
 import * as config from "../../config/config.js";
 import * as rpg2 from "../../db/rest-pg-2.js";
+import { teacherNotifications } from "../../config/socket.config.js";
 import { getDesignTypeBySessionId } from "./activities-common.js";
 
 const router = express.Router();
@@ -166,13 +167,15 @@ router.post("/activities/:id/response", async (req, res) => {
             return res.status(400).json({ error: `Unsupported design type: ${designType}` });
         }
 
-        await handler({
+        const notificationData = await handler({
             sessionId,
             phaseId,
             userId,
             questionId: Number(questionId),
             payload:    req.body,
         });
+
+        emitResponseSubmittedNotification(sessionId, phaseId, notificationData);
 
         return res.status(201).json({
             status:  "ok",
@@ -244,6 +247,14 @@ async function submitSemanticDifferentialResponse({ phaseId, userId, questionId,
             rpg2.param("plain", justification),
         ],
     });
+
+    return {
+        type: "semantic_differential",
+        uid:  userId,
+        did:  questionId,
+        sel:  value,
+        comment: justification,
+    };
 }
 
 async function submitRankingResponse({ phaseId, userId, questionId, payload }) {
@@ -302,6 +313,31 @@ async function submitRankingResponse({ phaseId, userId, questionId, payload }) {
             rpg2.param("plain", phaseId),
         ],
     });
+
+    return {
+        type: "ranking",
+        uid:  userId,
+        items: [
+            {
+                actorid: itemId,
+                orden: order,
+                description: justification,
+            },
+        ],
+    };
+}
+
+function emitResponseSubmittedNotification(sessionId, phaseId, responsePayload) {
+    if (!teacherNotifications?.responseSubmitted) {
+        console.warn("Teacher socket notification service is not initialized.");
+        return;
+    }
+
+    teacherNotifications.responseSubmitted(
+        sessionId,
+        phaseId,
+        responsePayload
+    );
 }
 
 async function getCurrentPhaseIdForSession(sessionId) {


### PR DESCRIPTION
### Motivation
- The teacher activity dashboard depends on `onResponseSubmitted` websocket events to merge incoming student responses into the teacher-side in-memory state. 
- The new student endpoint `POST /activities/:id/response` persisted responses but did not emit notifications, so the dashboard did not update in real time. 
- The change aims to notify the teacher socket namespace after a successful response write using payloads compatible with existing frontend merge handlers.

### Description
- Imported `teacherNotifications` from `ethicapp/backend/config/socket.config.js` into `ethicapp/backend/controllers/activities/activities-student.js` and call it after a successful submission. 
- Updated response handlers so they return a normalized notification payload instead of returning nothing; `semantic_differential` returns `{ type, uid, did, sel, comment }` and `ranking` returns `{ type, uid, items: [{ actorid, orden, description }] }`. 
- Added `emitResponseSubmittedNotification(sessionId, phaseId, responsePayload)` which guards if the socket notifier is not initialized and calls `teacherNotifications.responseSubmitted(...)` when available. 
- Changes are limited to `ethicapp/backend/controllers/activities/activities-student.js` and preserve persistence behavior if sockets are unavailable.

### Testing
- Ran `node --check ethicapp/backend/controllers/activities/activities-student.js`, which succeeded. 
- Executed `npm run lint-js`; the command ran but the repository contains many pre-existing lint errors and the lint step failed for unrelated files (no new lint scope regressions introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e59e8844832baa26cdc5a44e4df8)