### PR TITLE
Notify teacher sockets on student responses and harden socket/response merging

### DIFF
--- a/ethicapp/backend/config/socket.config.js
+++ b/ethicapp/backend/config/socket.config.js
@@ -12,17 +12,20 @@ const initializeSockets = (server) => {
         throw new Error("Server instance is required to initialize sockets.");
     }
 
+    console.info("[socket.config] Initializing Socket.IO namespaces.");
     const io = new SocketIO(server);
 
     // Teacher namespace
-    const teacherSocket = io.of('/teacher');
-    teacherSocket.on('connection', (socket) => teacherSocketInit(socket, teacherSocket));
+    const teacherSocket = io.of("/teacher");
+    teacherSocket.on("connection", (socket) => teacherSocketInit(socket, teacherSocket));
     teacherNotifications = toTeacherNotifications(teacherSocket);
+    console.info("[socket.config] Teacher namespace '/teacher' initialized.");
 
     // Student namespace
-    const studentSocket = io.of('/student');
-    studentSocket.on('connection', (socket) => studentSocketInit(socket, studentSocket));
+    const studentSocket = io.of("/student");
+    studentSocket.on("connection", (socket) => studentSocketInit(socket, studentSocket));
     studentNotifications = toStudentsNotifications(studentSocket);
+    console.info("[socket.config] Student namespace '/student' initialized.");
 
     ioInstance = io;
 

--- a/ethicapp/backend/controllers/activities/activities-student.js
+++ b/ethicapp/backend/controllers/activities/activities-student.js
@@ -5,6 +5,7 @@ import { requireOwnershipOrRole, requireRole } from "../../helpers/auth-helper.j
 import * as StudentActivityStatusHelper from "../../helpers/student-activity-state-helper.js";
 import * as config from "../../config/config.js";
 import * as rpg2 from "../../db/rest-pg-2.js";
+import { teacherNotifications } from "../../config/socket.config.js";
 import { getDesignTypeBySessionId } from "./activities-common.js";
 
 const router = express.Router();
@@ -166,13 +167,15 @@ router.post("/activities/:id/response", async (req, res) => {
             return res.status(400).json({ error: `Unsupported design type: ${designType}` });
         }
 
-        await handler({
+        const notificationData = await handler({
             sessionId,
             phaseId,
             userId,
             questionId: Number(questionId),
             payload:    req.body,
         });
+
+        emitResponseSubmittedNotification(sessionId, phaseId, notificationData);
 
         return res.status(201).json({
             status:  "ok",
@@ -244,6 +247,14 @@ async function submitSemanticDifferentialResponse({ phaseId, userId, questionId,
             rpg2.param("plain", justification),
         ],
     });
+
+    return {
+        type: "semantic_differential",
+        uid:  userId,
+        did:  questionId,
+        sel:  value,
+        comment: justification,
+    };
 }
 
 async function submitRankingResponse({ phaseId, userId, questionId, payload }) {
@@ -302,6 +313,31 @@ async function submitRankingResponse({ phaseId, userId, questionId, payload }) {
             rpg2.param("plain", phaseId),
         ],
     });
+
+    return {
+        type: "ranking",
+        uid:  userId,
+        items: [
+            {
+                actorid: itemId,
+                orden: order,
+                description: justification,
+            },
+        ],
+    };
+}
+
+function emitResponseSubmittedNotification(sessionId, phaseId, responsePayload) {
+    if (!teacherNotifications?.responseSubmitted) {
+        console.warn("Teacher socket notification service is not initialized.");
+        return;
+    }
+
+    teacherNotifications.responseSubmitted(
+        sessionId,
+        phaseId,
+        responsePayload
+    );
 }
 
 async function getCurrentPhaseIdForSession(sessionId) {

--- a/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
@@ -175,7 +175,7 @@ let rankingPhaseDataJoiner = (phaseDescriptor, responses, users,
         } else {
             const existingUser = existingDataMap[user.uid];
             // Update ranked items and actor IDs
-            phaseResponses
+            responses
                 .filter(response => response.uid === user.uid)
                 .forEach(response => {
                     existingUser[`r${response.orden}`] = response.description || null;

--- a/ethicapp/frontend/assets/js/services/activity-state.service.js
+++ b/ethicapp/frontend/assets/js/services/activity-state.service.js
@@ -9,26 +9,37 @@ let ActivityStateService = function($http, TeacherSocketService) {
             const phases = await service.getInstancedPhases(sessionId, false);
             const phaseNumber = phases.find((phase) => phase.id === Number(response.phaseId))?.number;
 
-            const phaseResponses = responses.find(
+            let phaseResponses = responses.find(
                 (prs) => Number(prs.phase_number) === Number(phaseNumber)
             );
 
-            const existingResponse = phaseResponses?.items.find(resp => resp.uid === response.uid);
-        
-            if (existingResponse) {
-                existingResponse.items = response.items;
-            } else {
-                const { type, ...responseWithoutType } = response;
-                if (!phaseResponses) {
-                    responses.push({
-                        phase_number: phaseNumber,
-                        responses: [responseWithoutType]
+            if (!phaseResponses) {
+                phaseResponses = {
+                    phase_number: phaseNumber,
+                    responses: [],
+                };
+                responses.push(phaseResponses);
+            }
+
+            const responseItems = Array.isArray(response.items) ? response.items : [];
+            responseItems.forEach((item) => {
+                const existingResponse = phaseResponses.responses.find(resp =>
+                    Number(resp.uid) === Number(response.uid) &&
+                    Number(resp.actorid) === Number(item.actorid)
+                );
+
+                if (existingResponse) {
+                    existingResponse.orden = item.orden;
+                    existingResponse.description = item.description;
+                } else {
+                    phaseResponses.responses.push({
+                        uid: response.uid,
+                        actorid: item.actorid,
+                        orden: item.orden,
+                        description: item.description,
                     });
                 }
-                else {
-                    phaseResponses.items.push(responseWithoutType);
-                }
-            }
+            });
         },
         semanticDifferentialResponseMerger: async function(sessionId, response, responses) {
             const phases = await service.getInstancedPhases(sessionId, false);
@@ -133,31 +144,36 @@ let ActivityStateService = function($http, TeacherSocketService) {
             subscriptions.push(
                 TeacherSocketService.fromEvent('onResponseSubmitted').subscribe({
                     next: async (data) => {
-                        const handler = await service.responseMergeHandlers[data.type];
-                        
-                        if (!handler) {
-                            const msg = "No handler available for the incoming response data";
-                            console.error(msg);
-                            throw new Error(msg);                           
+                        try {
+                            console.debug(`[ActivityStateService] onResponseSubmitted received for session ${sessionId}:`, data);
+                            const handler = service.responseMergeHandlers[data.type];
+                            
+                            if (!handler) {
+                                const msg = `[ActivityStateService] No handler available for incoming response type '${data.type}'`;
+                                console.error(msg, data);
+                                return;
+                            }
+
+                            // If this is the first response, fetch the responses, including the
+                            // one that just arrived. That is, have the API conform the appropriate data
+                            // structure to accommodate the next responses that arrive.
+                            if (!service.activityStates[sessionId].responses) {
+                                // load activity responses
+                                await service.getResponses(sessionId, true);
+                            }
+
+                            await handler(sessionId, data, service.activityStates[sessionId].responses);
+
+                            console.debug(`Response submitted for session ${sessionId}:`, 
+                                JSON.stringify(data));
+                            console.debug(`About to notify listeners ${JSON.stringify(data)}:`);
+        
+                            service.notifyListeners("onResponseSubmitted", { 
+                                response: data
+                            });
+                        } catch (error) {
+                            console.error(`[ActivityStateService] Failed to process onResponseSubmitted for session ${sessionId}:`, error);
                         }
-
-                        // If this is the first response, fetch the responses, including the
-                        // one that just arrived. That is, have the API conform the appropriate data
-                        // structure to accommodate the next responses that arrive.
-                        if (!service.activityStates[sessionId].responses) {
-                            // load activity responses
-                            await service.getResponses(sessionId, true);
-                        }
-
-                        await handler(sessionId, data, service.activityStates[sessionId].responses);
-
-                        console.debug(`Response submitted for session ${sessionId}:`, 
-                            JSON.stringify(data));
-                        console.debug(`About to notify listeners ${JSON.stringify(data)}:`);
-    
-                        service.notifyListeners("onResponseSubmitted", { 
-                            response: data
-                        });
                     },
                     error: (err) => console.error(`Websocket error for responseSubmitted in session ${sessionId}:`, err),
                 })                

--- a/ethicapp/frontend/assets/js/services/socket.service.js
+++ b/ethicapp/frontend/assets/js/services/socket.service.js
@@ -4,6 +4,23 @@ import { Observable } from 'rxjs';
 const SocketService = function(namespace) {
     const url = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}/${namespace}`;
     const socket = io(url);
+    const socketTag = `[SocketService:${namespace}]`;
+
+    socket.on("connect", () => {
+        console.debug(`${socketTag} connected`, { socketId: socket.id, url });
+    });
+
+    socket.on("disconnect", (reason) => {
+        console.debug(`${socketTag} disconnected`, { reason });
+    });
+
+    socket.on("connect_error", (error) => {
+        console.error(`${socketTag} connection error`, error);
+    });
+
+    socket.onAny((eventName, payload) => {
+        console.debug(`${socketTag} incoming event`, { eventName, payload });
+    });
 
     return {
         // Listen to generic events
@@ -16,7 +33,10 @@ const SocketService = function(namespace) {
         // Listen to generic events using RxJS Observable
         fromEvent: (eventName) => {
             return new Observable((observer) => {
-                const handler = (data) => observer.next(data);
+                const handler = (data) => {
+                    console.debug(`${socketTag} fromEvent`, { eventName, data });
+                    observer.next(data);
+                };
 
                 socket.on(eventName, handler);
 


### PR DESCRIPTION
### Motivation
- Ensure teachers are notified in real time when students submit responses and make socket behavior more observable for debugging. 
- Fix response merging bugs for ranking/semantic-differential activities so front-end state stays consistent.

### Description
- Backend: import `teacherNotifications` from `config/socket.config.js`, have response handlers return a normalized payload, and call a new `emitResponseSubmittedNotification(sessionId, phaseId, responsePayload)` function that uses `teacherNotifications.responseSubmitted` to notify teachers. 
- Backend: add console info logs in `initializeSockets` for namespace initialization in `config/socket.config.js`.
- Frontend: fix data-joiner variable usage in `dashboard-data-joiners.js` to use the correct `responses` collection when merging ranking responses. 
- Frontend: update `ActivityStateService` merging logic in `activity-state.service.js` to handle ranking responses containing `items` arrays, correctly update per-item entries, and add robust handling/guarding when initial responses are missing. 
- Frontend: strengthen socket observability in `socket.service.js` by adding `connect`/`disconnect`/`connect_error`/`onAny` debug logs and log events delivered through `fromEvent`.

### Testing
- Ran the project's automated frontend and backend test suites (local `npm test` flows and existing unit/integration tests); the test run completed without reported regressions. 
- Manually exercised socket flows during local development to confirm `onResponseSubmitted` handlers run and listeners receive updates (no errors observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e59e8844832baa26cdc5a44e4df8)