### PR TITLE
Notify teachers on student responses; improve socket logging and frontend merge/UX robustness

### DIFF
--- a/ethicapp/backend/config/socket.config.js
+++ b/ethicapp/backend/config/socket.config.js
@@ -12,17 +12,20 @@ const initializeSockets = (server) => {
         throw new Error("Server instance is required to initialize sockets.");
     }
 
+    console.info("[socket.config] Initializing Socket.IO namespaces.");
     const io = new SocketIO(server);
 
     // Teacher namespace
-    const teacherSocket = io.of('/teacher');
-    teacherSocket.on('connection', (socket) => teacherSocketInit(socket, teacherSocket));
+    const teacherSocket = io.of("/teacher");
+    teacherSocket.on("connection", (socket) => teacherSocketInit(socket, teacherSocket));
     teacherNotifications = toTeacherNotifications(teacherSocket);
+    console.info("[socket.config] Teacher namespace '/teacher' initialized.");
 
     // Student namespace
-    const studentSocket = io.of('/student');
-    studentSocket.on('connection', (socket) => studentSocketInit(socket, studentSocket));
+    const studentSocket = io.of("/student");
+    studentSocket.on("connection", (socket) => studentSocketInit(socket, studentSocket));
     studentNotifications = toStudentsNotifications(studentSocket);
+    console.info("[socket.config] Student namespace '/student' initialized.");
 
     ioInstance = io;
 

--- a/ethicapp/backend/controllers/activities/activities-student.js
+++ b/ethicapp/backend/controllers/activities/activities-student.js
@@ -5,6 +5,7 @@ import { requireOwnershipOrRole, requireRole } from "../../helpers/auth-helper.j
 import * as StudentActivityStatusHelper from "../../helpers/student-activity-state-helper.js";
 import * as config from "../../config/config.js";
 import * as rpg2 from "../../db/rest-pg-2.js";
+import { teacherNotifications } from "../../config/socket.config.js";
 import { getDesignTypeBySessionId } from "./activities-common.js";
 
 const router = express.Router();
@@ -166,13 +167,15 @@ router.post("/activities/:id/response", async (req, res) => {
             return res.status(400).json({ error: `Unsupported design type: ${designType}` });
         }
 
-        await handler({
+        const notificationData = await handler({
             sessionId,
             phaseId,
             userId,
             questionId: Number(questionId),
             payload:    req.body,
         });
+
+        emitResponseSubmittedNotification(sessionId, phaseId, notificationData);
 
         return res.status(201).json({
             status:  "ok",
@@ -244,6 +247,14 @@ async function submitSemanticDifferentialResponse({ phaseId, userId, questionId,
             rpg2.param("plain", justification),
         ],
     });
+
+    return {
+        type: "semantic_differential",
+        uid:  userId,
+        did:  questionId,
+        sel:  value,
+        comment: justification,
+    };
 }
 
 async function submitRankingResponse({ phaseId, userId, questionId, payload }) {
@@ -302,6 +313,31 @@ async function submitRankingResponse({ phaseId, userId, questionId, payload }) {
             rpg2.param("plain", phaseId),
         ],
     });
+
+    return {
+        type: "ranking",
+        uid:  userId,
+        items: [
+            {
+                actorid: itemId,
+                orden: order,
+                description: justification,
+            },
+        ],
+    };
+}
+
+function emitResponseSubmittedNotification(sessionId, phaseId, responsePayload) {
+    if (!teacherNotifications?.responseSubmitted) {
+        console.warn("Teacher socket notification service is not initialized.");
+        return;
+    }
+
+    teacherNotifications.responseSubmitted(
+        sessionId,
+        phaseId,
+        responsePayload
+    );
 }
 
 async function getCurrentPhaseIdForSession(sessionId) {

--- a/ethicapp/frontend/assets/js/directives/individual-phase-table.directive.js
+++ b/ethicapp/frontend/assets/js/directives/individual-phase-table.directive.js
@@ -46,12 +46,16 @@ let individualPhaseTableDirective = function() {
                     !iptCtrl.phaseData.state ||
                     !iptCtrl.phaseData.descriptor) {
                     console.error("Invalid phase data structure provided.");
+                    iptCtrl.sortedResponses = [];
+                    iptCtrl.totalChatMessages = 0;
                     return;
                 }
 
-                if (iptCtrl.phaseData.state.length === 0 ||
-                    iptCtrl.phaseData.descriptor.questions.length === 0) {
-                    console.warn("No responses or questions available. Initialization skipped.");
+                const questions = iptCtrl.phaseData.descriptor.questions || [];
+                if (questions.length === 0) {
+                    console.warn("No questions available for this phase.");
+                    iptCtrl.sortedResponses = [];
+                    iptCtrl.totalChatMessages = 0;
                     return;
                 }
 
@@ -61,6 +65,8 @@ let individualPhaseTableDirective = function() {
 
                 iptCtrl.phaseData.state = processedData;
                 iptCtrl.sortedResponses = [...processedData];
+                iptCtrl.totalChatMessages = processedData.reduce((acc, response) =>
+                    acc + Number(response.chatCount || 0), 0);
             };
 
             // Lifecycle hook: Called when the directive is initialized

--- a/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
@@ -50,6 +50,18 @@ let sdPhaseDataJoiner = (phaseDescriptor, responses, users,
         return acc;
     }, {});
 
+    // Ensure responders that are not currently present in the connected users
+    // list are still visible in the dashboard.
+    responses.forEach((response) => {
+        const uid = Number(response.uid);
+        if (!usersMap[uid]) {
+            usersMap[uid] = {
+                userId: uid,
+                userName: `User ${uid}`
+            };
+        }
+    });
+
     // Ensure all questions have default values for all users
     questions.forEach(question => {
         const questionNumber = question.number;
@@ -130,6 +142,19 @@ let rankingPhaseDataJoiner = (phaseDescriptor, responses, users,
         return acc;
     }, {});
 
+    // Ensure responders that are not currently present in the connected users
+    // list are still visible in the dashboard.
+    responses.forEach((response) => {
+        const uid = Number(response.uid);
+        if (!usersMap[uid]) {
+            usersMap[uid] = {
+                uid,
+                userName: `User ${uid}`,
+                chatCount: 0
+            };
+        }
+    });
+
     // If no existingData is provided, build the structure from scratch
     if (!existingData) {
         // Assign responses and chat statistics for each user
@@ -175,7 +200,7 @@ let rankingPhaseDataJoiner = (phaseDescriptor, responses, users,
         } else {
             const existingUser = existingDataMap[user.uid];
             // Update ranked items and actor IDs
-            phaseResponses
+            responses
                 .filter(response => response.uid === user.uid)
                 .forEach(response => {
                     existingUser[`r${response.orden}`] = response.description || null;

--- a/ethicapp/frontend/assets/js/services/activity-state.service.js
+++ b/ethicapp/frontend/assets/js/services/activity-state.service.js
@@ -7,32 +7,63 @@ let ActivityStateService = function($http, TeacherSocketService) {
         listeners: {}, // Subscribed listeners
         rankingResponseMerger: async function(sessionId, response, responses) {
             const phases = await service.getInstancedPhases(sessionId, false);
-            const phaseNumber = phases.find((phase) => phase.id === Number(response.phaseId))?.number;
+            const phaseNumber = phases.find((phase) =>
+                Number(phase.id) === Number(response.phaseId)
+            )?.number;
 
-            const phaseResponses = responses.find(
+            if (phaseNumber === undefined || phaseNumber === null) {
+                console.warn(`[ActivityStateService] Could not resolve phaseNumber for ranking response in session ${sessionId}.`, {
+                    phaseId: response.phaseId,
+                    phases,
+                });
+                return;
+            }
+
+            let phaseResponses = responses.find(
                 (prs) => Number(prs.phase_number) === Number(phaseNumber)
             );
 
-            const existingResponse = phaseResponses?.items.find(resp => resp.uid === response.uid);
-        
-            if (existingResponse) {
-                existingResponse.items = response.items;
-            } else {
-                const { type, ...responseWithoutType } = response;
-                if (!phaseResponses) {
-                    responses.push({
-                        phase_number: phaseNumber,
-                        responses: [responseWithoutType]
+            if (!phaseResponses) {
+                phaseResponses = {
+                    phase_number: phaseNumber,
+                    responses: [],
+                };
+                responses.push(phaseResponses);
+            }
+
+            const responseItems = Array.isArray(response.items) ? response.items : [];
+            responseItems.forEach((item) => {
+                const existingResponse = phaseResponses.responses.find(resp =>
+                    Number(resp.uid) === Number(response.uid) &&
+                    Number(resp.actorid) === Number(item.actorid)
+                );
+
+                if (existingResponse) {
+                    existingResponse.orden = item.orden;
+                    existingResponse.description = item.description;
+                } else {
+                    phaseResponses.responses.push({
+                        uid: response.uid,
+                        actorid: item.actorid,
+                        orden: item.orden,
+                        description: item.description,
                     });
                 }
-                else {
-                    phaseResponses.items.push(responseWithoutType);
-                }
-            }
+            });
         },
         semanticDifferentialResponseMerger: async function(sessionId, response, responses) {
             const phases = await service.getInstancedPhases(sessionId, false);
-            const phaseNumber = phases.find((phase) => phase.id === Number(response.phaseId))?.number;
+            const phaseNumber = phases.find((phase) =>
+                Number(phase.id) === Number(response.phaseId)
+            )?.number;
+
+            if (phaseNumber === undefined || phaseNumber === null) {
+                console.warn(`[ActivityStateService] Could not resolve phaseNumber for semantic_differential response in session ${sessionId}.`, {
+                    phaseId: response.phaseId,
+                    phases,
+                });
+                return;
+            }
 
             const phaseResponses = responses.find(
                 (prs) => Number(prs.phase_number) === Number(phaseNumber)
@@ -133,31 +164,36 @@ let ActivityStateService = function($http, TeacherSocketService) {
             subscriptions.push(
                 TeacherSocketService.fromEvent('onResponseSubmitted').subscribe({
                     next: async (data) => {
-                        const handler = await service.responseMergeHandlers[data.type];
-                        
-                        if (!handler) {
-                            const msg = "No handler available for the incoming response data";
-                            console.error(msg);
-                            throw new Error(msg);                           
+                        try {
+                            console.debug(`[ActivityStateService] onResponseSubmitted received for session ${sessionId}:`, data);
+                            const handler = service.responseMergeHandlers[data.type];
+                            
+                            if (!handler) {
+                                const msg = `[ActivityStateService] No handler available for incoming response type '${data.type}'`;
+                                console.error(msg, data);
+                                return;
+                            }
+
+                            // If this is the first response, fetch the responses, including the
+                            // one that just arrived. That is, have the API conform the appropriate data
+                            // structure to accommodate the next responses that arrive.
+                            if (!service.activityStates[sessionId].responses) {
+                                // load activity responses
+                                await service.getResponses(sessionId, true);
+                            }
+
+                            await handler(sessionId, data, service.activityStates[sessionId].responses);
+
+                            console.debug(`Response submitted for session ${sessionId}:`, 
+                                JSON.stringify(data));
+                            console.debug(`About to notify listeners ${JSON.stringify(data)}:`);
+        
+                            service.notifyListeners("onResponseSubmitted", { 
+                                response: data
+                            });
+                        } catch (error) {
+                            console.error(`[ActivityStateService] Failed to process onResponseSubmitted for session ${sessionId}:`, error);
                         }
-
-                        // If this is the first response, fetch the responses, including the
-                        // one that just arrived. That is, have the API conform the appropriate data
-                        // structure to accommodate the next responses that arrive.
-                        if (!service.activityStates[sessionId].responses) {
-                            // load activity responses
-                            await service.getResponses(sessionId, true);
-                        }
-
-                        await handler(sessionId, data, service.activityStates[sessionId].responses);
-
-                        console.debug(`Response submitted for session ${sessionId}:`, 
-                            JSON.stringify(data));
-                        console.debug(`About to notify listeners ${JSON.stringify(data)}:`);
-    
-                        service.notifyListeners("onResponseSubmitted", { 
-                            response: data
-                        });
                     },
                     error: (err) => console.error(`Websocket error for responseSubmitted in session ${sessionId}:`, err),
                 })                

--- a/ethicapp/frontend/assets/js/services/socket.service.js
+++ b/ethicapp/frontend/assets/js/services/socket.service.js
@@ -4,6 +4,23 @@ import { Observable } from 'rxjs';
 const SocketService = function(namespace) {
     const url = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}/${namespace}`;
     const socket = io(url);
+    const socketTag = `[SocketService:${namespace}]`;
+
+    socket.on("connect", () => {
+        console.debug(`${socketTag} connected`, { socketId: socket.id, url });
+    });
+
+    socket.on("disconnect", (reason) => {
+        console.debug(`${socketTag} disconnected`, { reason });
+    });
+
+    socket.on("connect_error", (error) => {
+        console.error(`${socketTag} connection error`, error);
+    });
+
+    socket.onAny((eventName, payload) => {
+        console.debug(`${socketTag} incoming event`, { eventName, payload });
+    });
 
     return {
         // Listen to generic events
@@ -16,7 +33,10 @@ const SocketService = function(namespace) {
         // Listen to generic events using RxJS Observable
         fromEvent: (eventName) => {
             return new Observable((observer) => {
-                const handler = (data) => observer.next(data);
+                const handler = (data) => {
+                    console.debug(`${socketTag} fromEvent`, { eventName, data });
+                    observer.next(data);
+                };
 
                 socket.on(eventName, handler);
 

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/ranking-individual-results-table.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/ranking-individual-results-table.template.html
@@ -1,5 +1,5 @@
-<p ng-if="iptCtrl.sortedResponses.length == 0">No responses currently available, waiting for participants to submit them.</p>
-<table class="table table-striped table-sortable" ng-if="iptCtrl.sortedResponses.length > 0">
+<p ng-if="!iptCtrl.sortedResponses || iptCtrl.sortedResponses.length == 0">No responses currently available, waiting for participants to submit them.</p>
+<table class="table table-striped table-sortable" ng-if="iptCtrl.sortedResponses && iptCtrl.sortedResponses.length > 0">
     <thead>
         <tr>
             <th sortable-column="responseCluster" reverse="reverse" on-sort="sortBy(field)">
@@ -30,9 +30,9 @@
         <tr>
             <td colspan="{{ iptCtrl.phaseData.descriptor.questions.length + 3 }}">
                 <div class="summary-text">
-                    <strong>{{ 'participants_label' | translate }}:</strong> {{ sortedResponses.length }} <br>
+                    <strong>{{ 'participants_label' | translate }}:</strong> {{ iptCtrl.sortedResponses.length }} <br>
                     <span class="badge badge-danger">
-                        <i class="fa fa-comments"></i> {{ totalChatMessages }} {{ 'chat_messages_label' | translate }}
+                        <i class="fa fa-comments"></i> {{ iptCtrl.totalChatMessages }} {{ 'chat_messages_label' | translate }}
                     </span>
                     <i class="fa-solid fa-sticky-note text-warning"></i> {{ 'comment_note_legend' | translate }}. <span class="text-danger">*</span> {{ 'justification_required_caption' | translate }}.
                 </div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-individual-results-table.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-individual-results-table.template.html
@@ -1,5 +1,5 @@
-<p ng-if="iptCtrl.phaseData.state.length == 0">{{ 'waiting_for_responses_text' | translate }}</p>
-<table class="table table-striped" ng-if="iptCtrl.phaseData.state.length > 0">
+<p ng-if="!iptCtrl.sortedResponses || iptCtrl.sortedResponses.length == 0">{{ 'waiting_for_responses_text' | translate }}</p>
+<table class="table table-striped" ng-if="iptCtrl.sortedResponses && iptCtrl.sortedResponses.length > 0">
     <thead>
         <tr>
             <th>{{ 'participant_column_header' | translate }}</th>
@@ -10,7 +10,7 @@
         </tr>
     </thead>
     <tbody>
-        <tr ng-repeat="response in iptCtrl.phaseData.state track by response.userId">
+        <tr ng-repeat="response in iptCtrl.sortedResponses track by response.userId">
             <td>{{ response.userName }}</td>
             <td ng-repeat="question in iptCtrl.phaseData.descriptor.questions">
                 {{ response['r' + question.number] || ('no_response' | translate) }}
@@ -25,7 +25,7 @@
         <tr>
             <td colspan="{{ iptCtrl.phaseData.descriptor.questions.length + 1 }}">
                 <div class="summary-text small">
-                    <strong>{{ 'participants_label' | translate }}:</strong> {{ iptCtrl.phaseData.state.length > 0 ? iptCtrl.phaseData.state.length : 0 }} <br>
+                    <strong>{{ 'participants_label' | translate }}:</strong> {{ iptCtrl.sortedResponses.length > 0 ? iptCtrl.sortedResponses.length : 0 }} <br>
                     <strong>A:</strong> {{ 'average_label' | translate }}. 
                     <strong>CV:</strong> {{ 'coefficient_of_variation_label' | translate }}.<br>
                     <i class="fa fa-comments"></i> {{ 'chat_messages_label' | translate }}. 


### PR DESCRIPTION
### Motivation
- Ensure teachers receive real-time notifications when students submit responses and make socket namespaces more observable during startup. 
- Improve robustness of frontend data merging so ranking/semantic responses are merged correctly and offline responders remain visible in dashboards. 
- Harden UI components to avoid crashes when phase data or responses are missing and surface helpful debugging information for socket events. 

### Description
- Backend: initializeSocket now logs namespace initialization and `activities-student` handlers now return structured response payloads and call a new `emitResponseSubmittedNotification` which forwards the payload via `teacherNotifications.responseSubmitted`. 
- Backend: `socket.config.js` adds console info logs and consistent string quoting for namespaces. 
- Frontend: `SocketService` now emits connection, disconnection and connection error debug logs and logs every incoming event, and `fromEvent` handlers log event data before pushing to observers. 
- Frontend: `ActivityStateService` fixes phase resolution and response merging for ranking and semantic differential types with additional safeguards and logging, and the dashboard joiners ensure responders not present in the users list are included so they appear on teacher dashboards. 
- Frontend: individual-phase directive initializes safe defaults (`sortedResponses`, `totalChatMessages`) and computes `totalChatMessages`, and templates updated to guard access to `iptCtrl.sortedResponses` and to reference `iptCtrl`-scoped totals. 

### Testing
- Ran frontend build and smoke-checked the teacher dashboard UI via `npm run build` and the app served without build errors (succeeded). 
- Ran backend test suite and integration smoke tests via `npm test` to validate activity submission flows and socket initialization (succeeded). 
- Executed linting and basic runtime checks to confirm no runtime exceptions from the new logging and merge logic (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e59e8844832baa26cdc5a44e4df8)