### PR TITLE
feat(teacher-dashboard): SD individual response detail modal

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
@@ -20,6 +20,47 @@ export function DashboardController($scope, $routeParams, $http,
         vm.selectedTab = index; // Update the selected tab index
     };
 
+    vm.openIndividualResponseModal = function(response, phaseData) {
+        if (!response || !phaseData || vm.designObj?.type !== "semantic_differential") {
+            return;
+        }
+
+        $uibModal.open({
+            animation: true,
+            size: "lg",
+            backdrop: "static",
+            templateUrl: "/assets/static/views/teacher/fragments/sd-individual-response-modal.template.html",
+            controllerAs: "$ctrl",
+            controller: ["$uibModalInstance", "data", function($uibModalInstance, data) {
+                const $ctrl = this;
+
+                $ctrl.response = data.response;
+                $ctrl.phaseData = data.phaseData;
+                $ctrl.questions = data.phaseData?.descriptor?.questions || [];
+
+                $ctrl.buildScaleOptions = function(question) {
+                    const range = Number(question?.range) || 0;
+                    return Array.from({ length: range }, (_, i) => i + 1);
+                };
+
+                $ctrl.getResponseValue = function(question) {
+                    return $ctrl.response?.[`r${question.number}`] || null;
+                };
+
+                $ctrl.getResponseComment = function(question) {
+                    return $ctrl.response?.[`commentR${question.number}`] || "";
+                };
+
+                $ctrl.close = function() {
+                    $uibModalInstance.dismiss("close");
+                };
+            }],
+            resolve: {
+                data: () => ({ response, phaseData }),
+            },
+        });
+    };
+
     vm.init = async function () {
         let id = $routeParams.id;
 

--- a/ethicapp/frontend/assets/js/directives/individual-phase-table.directive.js
+++ b/ethicapp/frontend/assets/js/directives/individual-phase-table.directive.js
@@ -5,7 +5,8 @@ let individualPhaseTableDirective = function() {
         restrict: 'E',
         scope: {
             phaseData: '<',
-            designType: '<'
+            designType: '<',
+            onSelectResponse: '&?'
         },
         bindToController: true, // Bind the scope properties to the controller
         controllerAs: 'iptCtrl', // Alias for the controller
@@ -101,6 +102,19 @@ let individualPhaseTableDirective = function() {
                     return `/assets/static/views/teacher/fragments/default-template.html`;
                 }
                 return template;
+            };
+
+            iptCtrl.onResponseRowClick = function(response) {
+                if (iptCtrl.designType !== 'semantic_differential') {
+                    return;
+                }
+
+                if (typeof iptCtrl.onSelectResponse === 'function') {
+                    iptCtrl.onSelectResponse({
+                        response,
+                        phaseData: iptCtrl.phaseData,
+                    });
+                }
             };
         },
         template: `

--- a/ethicapp/frontend/assets/js/directives/phase-state.directive.js
+++ b/ethicapp/frontend/assets/js/directives/phase-state.directive.js
@@ -3,7 +3,8 @@ let phaseStateDirective = function() {
         restrict: 'E',
         scope: {
             designType: '<',
-            phaseData: '<'
+            phaseData: '<',
+            onSelectResponse: '&?'
         },
         bindToController: true,
         controllerAs: 'ctrl',

--- a/ethicapp/frontend/assets/static/views/teacher/activity.view.html
+++ b/ethicapp/frontend/assets/static/views/teacher/activity.view.html
@@ -67,7 +67,11 @@
                                      ng-if="dc.dashboardPhaseData.length > 0"
                                      ng-repeat="phase in dc.dashboardPhaseData track by $index">
                                     <phase-description phase-number="phase.descriptor.number" design-object="dc.designObj"></phase-description>
-                                    <phase-state phase-data="phase" design-type="dc.designObj.type"></phase-state>
+                                    <phase-state
+                                        phase-data="phase"
+                                        design-type="dc.designObj.type"
+                                        on-select-response="dc.openIndividualResponseModal(response, phaseData)">
+                                    </phase-state>
                                 </div>
                             </div>
                         </div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/phase-state.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/phase-state.template.html
@@ -1,7 +1,10 @@
 <div>
     <h4>{{ "responses_title_text" | translate }}</h4>
     <div ng-if="ctrl.phaseData.descriptor.mode !== 'team'">
-        <individual-phase-table phase-data="ctrl.phaseData" design-type="ctrl.designType">
+        <individual-phase-table
+            phase-data="ctrl.phaseData"
+            design-type="ctrl.designType"
+            on-select-response="ctrl.onSelectResponse({ response: response, phaseData: phaseData })">
         </individual-phase-table>
     </div>
     <div ng-if="ctrl.phaseData.descriptor.mode === 'team'">

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-individual-response-modal.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-individual-response-modal.template.html
@@ -1,0 +1,58 @@
+<div class="modal-header">
+    <button type="button" class="close" ng-click="$ctrl.close()" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <h4 class="modal-title">
+        {{ 'answerOf' | translate }} {{ $ctrl.response.userName }}
+    </h4>
+</div>
+
+<div class="modal-body" ng-if="$ctrl.questions.length > 0">
+    <div class="panel panel-default" ng-repeat="question in $ctrl.questions track by question.number">
+        <div class="panel-heading">
+            <strong>{{ 'item_label' | translate }} {{ $index + 1 }}</strong>
+        </div>
+        <div class="panel-body">
+            <p>
+                <strong>{{ 'question_text_label' | translate }}:</strong>
+                {{ question.text || question.question || ('no_response' | translate) }}
+            </p>
+
+            <div class="row" style="margin-top: .75em; margin-bottom: .75em;">
+                <div class="col-sm-3 text-right">
+                    <strong>{{ question.leftPole || ('left_pole_label' | translate) }}</strong>
+                </div>
+                <div class="col-sm-6 text-center">
+                    <label class="radio-inline"
+                           ng-repeat="option in $ctrl.buildScaleOptions(question) track by option"
+                           style="margin-right: .5em; margin-left: .5em;">
+                        <input type="radio"
+                               disabled
+                               ng-checked="$ctrl.getResponseValue(question) == option">
+                        {{ option }}
+                    </label>
+                </div>
+                <div class="col-sm-3 text-left">
+                    <strong>{{ question.rightPole || ('right_pole_label' | translate) }}</strong>
+                </div>
+            </div>
+
+            <div class="form-group" ng-if="question.justify">
+                <label>{{ 'comment' | translate }}</label>
+                <textarea class="form-control"
+                          rows="3"
+                          readonly>{{ $ctrl.getResponseComment(question) || ('no_response' | translate) }}</textarea>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal-body" ng-if="$ctrl.questions.length === 0">
+    <p>{{ 'no_response' | translate }}</p>
+</div>
+
+<div class="modal-footer">
+    <button type="button" class="btn btn-default btn-sm" ng-click="$ctrl.close()">
+        {{ 'back' | translate }}
+    </button>
+</div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-individual-results-table.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-individual-results-table.template.html
@@ -10,7 +10,9 @@
         </tr>
     </thead>
     <tbody>
-        <tr ng-repeat="response in iptCtrl.sortedResponses track by response.userId">
+        <tr ng-repeat="response in iptCtrl.sortedResponses track by response.userId"
+            ng-click="iptCtrl.onResponseRowClick(response)"
+            style="cursor: pointer;">
             <td>{{ response.userName }}</td>
             <td ng-repeat="question in iptCtrl.phaseData.descriptor.questions">
                 {{ response['r' + question.number] || ('no_response' | translate) }}


### PR DESCRIPTION
### Motivation
- Provide teachers a quick way to inspect a student's full semantic-differential (SD) response (scale value + justification) from the individual results table without leaving the dashboard. 
- Enable an extensible, view-driven flow where row selection in the individual results table triggers a modal rendered with full phase/question context.

### Description
- Add an optional callback binding `onSelectResponse` to `individual-phase-table` and `phase-state` directives to propagate row selection upwards (`ethicapp/frontend/assets/js/directives/individual-phase-table.directive.js`, `ethicapp/frontend/assets/js/directives/phase-state.directive.js`).
- Make SD individual result rows clickable and invoke the callback (`ethicapp/frontend/assets/static/views/teacher/fragments/sd-individual-results-table.template.html`).
- Wire the callback through `activity.view.html` into `DashboardController` and implement `openIndividualResponseModal(...)` to open a `$uibModal` with resolved response and phase data (`ethicapp/frontend/assets/static/views/teacher/activity.view.html`, `ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js`).
- Add a new Bootstrap 3 modal fragment that displays each question's text, left/right poles, a readonly radio scale with the selected value marked, and a readonly comment textarea when applicable (`ethicapp/frontend/assets/static/views/teacher/fragments/sd-individual-response-modal.template.html`).

### Testing
- Ran `git diff --check` to verify there are no whitespace/errors from the patch and it passed.
- Attempted `npm run lint-js` but it failed due to the environment ESLint v9 configuration mismatch (missing `eslint.config.*`), not because of syntax errors in the changed files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10846a77c832bbec2bef0b0f36725)