### PR TITLE
Mostrar instrucciones de fase en vistas estudiantiles

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/RankingPhaseView.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/RankingPhaseView.jsx
@@ -1,4 +1,8 @@
 export default function RankingPhaseView({ phase, isReadOnly, isActivePhase, t }) {
+  const phaseInstructions = typeof phase?.instructions === 'string' && phase.instructions.trim().length > 0
+    ? phase.instructions
+    : (typeof phase?.question === 'string' ? phase.question : '');
+
   return (
     <div className="d-flex flex-column gap-3">
       {!isActivePhase && !isReadOnly ? (
@@ -7,9 +11,9 @@ export default function RankingPhaseView({ phase, isReadOnly, isActivePhase, t }
         </div>
       ) : null}
 
-      {typeof phase?.instructions === 'string' && phase.instructions.trim().length > 0 ? (
+      {phaseInstructions.trim().length > 0 ? (
         <div className="alert alert-secondary mb-0" role="note">
-          <strong>{t('sessionDetail.instructionsLabel')}:</strong> {phase.instructions}
+          <strong>{t('sessionDetail.instructionsLabel')}:</strong> {phaseInstructions}
         </div>
       ) : null}
 

--- a/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx
@@ -49,6 +49,13 @@ export default function SemanticDifferentialPhaseView({
   t
 }) {
   const responsesByTask = useMemo(() => mapResponsesByTaskId(phase), [phase]);
+  const phaseInstructions = useMemo(() => {
+    if (typeof phase?.instructions === 'string' && phase.instructions.trim().length > 0) {
+      return phase.instructions;
+    }
+
+    return typeof phase?.question === 'string' ? phase.question : '';
+  }, [phase]);
   const safeDraftByTaskId = draftByTaskId ?? {};
   const [submittingTaskId, setSubmittingTaskId] = useState(null);
   const [feedbackByTaskId, setFeedbackByTaskId] = useState({});
@@ -139,9 +146,9 @@ export default function SemanticDifferentialPhaseView({
         </div>
       ) : null}
 
-      {typeof phase?.instructions === 'string' && phase.instructions.trim().length > 0 ? (
+      {phaseInstructions.trim().length > 0 ? (
         <div className="alert alert-secondary mb-0" role="note">
-          <strong>{t('sessionDetail.instructionsLabel')}:</strong> {phase.instructions}
+          <strong>{t('sessionDetail.instructionsLabel')}:</strong> {phaseInstructions}
         </div>
       ) : null}
 

--- a/ethicapp/backend/helpers/student-activity-state-helper.js
+++ b/ethicapp/backend/helpers/student-activity-state-helper.js
@@ -27,6 +27,9 @@ export const buildInitialPhaseState = async function (phaseId) {
             phase: {
                 id: phaseId,
                 number: phaseNumber,
+                instructions: typeof phaseDesign?.instructions === "string"
+                    ? phaseDesign.instructions
+                    : (typeof phaseDesign?.question === "string" ? phaseDesign.question : ""),
                 features: {
                     chat: phaseDesign.chat,
                     anonymity: phaseDesign.anonymous,
@@ -192,7 +195,8 @@ export async function getStudentActivityPhases(sessionId) {
                 st.number, 
                 st.type AS mode, 
                 st.anon, 
-                st.chat
+                st.chat,
+                st.question AS instructions
             FROM 
                 stages st
             WHERE 
@@ -209,6 +213,7 @@ export async function getStudentActivityPhases(sessionId) {
         const phases = phasesResult.map(phase => ({
             id: phase.id,
             number: phase.number,
+            instructions: typeof phase.instructions === "string" ? phase.instructions : "",
             features: {
                 mode: phase.mode,
                 chat: phase.chat,


### PR DESCRIPTION
### Motivation
- Las instrucciones definidas a nivel de fase en el diseño (`phases[].instructions`) no se mostraban en la vista estudiantil para diseños `semantic_differential` porque el estado construido/servido al cliente no exponía la columna adecuada y las vistas solo consumían `phase.instructions`.
- La intención es mostrar las instrucciones de fase en la UI manteniendo compatibilidad con payloads legacy que almacenan texto en `question`.

### Description
- Backend: `buildInitialPhaseState` ahora incluye `phase.instructions` tomando primero `phaseDesign.instructions` y, si no existe, haciendo fallback a `phaseDesign.question` (archivo `ethicapp/backend/helpers/student-activity-state-helper.js`).
- Backend: `getStudentActivityPhases` ahora selecciona `st.question AS instructions` y llena `instructions` en cada fase para que el estado de sesión exponga el texto de instrucciones (archivo `ethicapp/backend/helpers/student-activity-state-helper.js`).
- Frontend: `SemanticDifferentialPhaseView` ahora normaliza `phaseInstructions` usando `phase.instructions` y, de no existir, `phase.question`, y renderiza ese valor en el banner de instrucciones (archivo `ethicapp-student/frontend/src/components/session-detail/phases/SemanticDifferentialPhaseView.jsx`).
- Frontend: `RankingPhaseView` aplica la misma lógica de fallback y renderizado de instrucciones para mantener consistencia entre tipos de fase (archivo `ethicapp-student/frontend/src/components/session-detail/phases/RankingPhaseView.jsx`).

### Testing
- Ejecuté `npm run lint-js`; la tarea falló debido a una gran cantidad de errores de lint preexistentes en el repositorio que están fuera del alcance de este cambio (resultado: fallido).
- Ejecuté `npx eslint` sobre los archivos modificados (`SemanticDifferentialPhaseView.jsx`, `RankingPhaseView.jsx`, `student-activity-state-helper.js`); la verificación arrojó errores de parse/lint relacionados con la configuración global del repositorio (resultado: fallido).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12145a190832b8bdb537fefcc45a2)