### PR TITLE
Emit phase-advanced event and improve phase advancement + tab activation flow

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
@@ -151,7 +151,7 @@ export function DashboardController($scope, $routeParams, $http,
             // Check if we've already reached the last phase
             if (currentPhaseNumber === vm.designObj.phases.length) {
                 console.error("Cannot advance any further, reached the last phase already.");
-                return;
+                return null;
             }
     
             const nextPhaseIndex = currentPhaseNumber;
@@ -178,7 +178,7 @@ export function DashboardController($scope, $routeParams, $http,
                 );
             } else {
                 console.error("Error creating activity phase.");
-                return;
+                return null;
             }
     
             // Transition to the newly created phase
@@ -196,9 +196,11 @@ export function DashboardController($scope, $routeParams, $http,
             });
     
             // Update data for the current phase
-            vm.updateDashboardPhaseData(phaseId);
+            await vm.updateDashboardPhaseData(phaseId);
+            return phaseId;
         } catch (error) {
             console.error("Error in startNextPhase:", error);
+            return null;
         }
     };
 
@@ -408,6 +410,36 @@ export function DashboardController($scope, $routeParams, $http,
         }
         vm.updateDashboardPhaseData(currentPhaseId);
     };
+
+    vm.activatePhaseTabById = function(phaseId, retryCount = 8) {
+        const phaseIndex = vm.dashboardPhaseData.findIndex((phase) => phase?.descriptor?.id == phaseId);
+        if (phaseIndex >= 0) {
+            vm.selectedTab = phaseIndex;
+            return;
+        }
+
+        if (retryCount <= 0) {
+            vm.selectedTab = vm.dashboardPhaseData.length - 1;
+            return;
+        }
+
+        $timeout(() => vm.activatePhaseTabById(phaseId, retryCount - 1), 100);
+    };
+
+    $scope.$on("activity:phase-advanced", (event, data) => {
+        vm.activeTab = "info";
+        const phaseId = data?.phaseId;
+        if (phaseId) {
+            vm.activatePhaseTabById(phaseId);
+            return;
+        }
+
+        if (vm.dashboardPhaseData.length > 0) { 
+            $timeout(() => {
+                vm.selectedTab = vm.dashboardPhaseData.length - 1;
+            }, 0);
+        }
+    });
 
     vm.lastPhaseReached = function() {
         return vm.activityState?.descriptor.currentPhase !== null && 

--- a/ethicapp/frontend/assets/js/directives/activity-controls.directive.js
+++ b/ethicapp/frontend/assets/js/directives/activity-controls.directive.js
@@ -6,6 +6,14 @@ let activityControlsDirective = function() {
             isLastPhase: '<',
             parentCtrl: '<'  // Reference to the parent controller
         },
+        controller: ["$scope", async function($scope) {
+            $scope.startNextPhaseAndNotify = async function() {
+                const phaseId = await $scope.parentCtrl.startNextPhase();
+                if (phaseId) {
+                    $scope.$emit("activity:phase-advanced", { phaseId });
+                }
+            };
+        }],
         template: `
             <div class="panel panel-default">
                 <div class="panel-body">
@@ -13,7 +21,7 @@ let activityControlsDirective = function() {
                         <div class="col-md-12 text-center">
                             <!-- Section 1: Main Actions -->
                             <div ng-if="!isFinished" class="action-buttons">
-                                <button ng-if="!isLastPhase" class="btn btn-default btn-sm" ng-click="parentCtrl.startNextPhase()">
+                                <button ng-if="!isLastPhase" class="btn btn-default btn-sm" ng-click="startNextPhaseAndNotify()">
                                     <i class="fa-solid fa-forward text-success"></i> {{ 'start_next_phase_button' | translate }}
                                 </button>
                                 <button class="btn btn-default btn-sm" ng-click="parentCtrl.endActivity()">


### PR DESCRIPTION
### Motivation

- Ensure the UI reacts reliably when a phase is advanced by notifying listeners and selecting the corresponding dashboard tab.
- Make `startNextPhase` more deterministic by returning the created `phaseId` (or `null` on failure) and awaiting downstream updates.
- Provide a robust tab activation mechanism that copes with async dashboard data population.

### Description

- Changed `vm.startNextPhase` to return the new `phaseId` on success or `null` on failure and added `await` for `vm.updateDashboardPhaseData(phaseId)` to ensure updates complete before returning.`
- Added `vm.activatePhaseTabById` with a retry/backoff (`$timeout`) to select the correct dashboard tab when phase data may not yet be present.
- Subscribed to the `activity:phase-advanced` event in the dashboard controller to switch the active tab and set `vm.activeTab` to `info` when a phase advances.
- Added a controller to `activity-controls.directive` exposing `startNextPhaseAndNotify` which calls `startNextPhase`, and emits `activity:phase-advanced` with `{ phaseId }` when a phase is created; updated the template button to use this function.
- Minor control-flow and logging improvements around first-phase creation and error handling in `startNextPhase`.

### Testing

- Ran the JavaScript linter via `npm run lint`, which completed without errors.
- Executed the frontend unit test suite via `npm test`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12b8267e8832ba6bc679e0818bc77)