### PR TITLE
Fix teacher dashboard live user update on student join

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
@@ -388,18 +388,21 @@ export function DashboardController($scope, $routeParams, $http,
         console.log('Downloading chat log...');
     };
 
-    vm.studentJoinHandler = function (data) {
-        if (vm.checkActivityFinished()) {
+    vm.studentJoinHandler = function () {
+        if (!vm.activityState || vm.checkActivityFinished()) {
             return;
         }
 
+        const users = Array.isArray(vm.activityState.users) ? vm.activityState.users : [];
         const currentPhaseId = vm?.activityState?.descriptor?.currentPhase?.id;
 
-        $scope.$applyAsync(() => { 
-            vm.userList = vm.activityState.users;
+        $scope.$applyAsync(() => {
+            vm.userList = users;
         });
 
-        vm.updateDashboardPhaseData(currentPhaseId);
+        if (currentPhaseId) {
+            vm.updateDashboardPhaseData(currentPhaseId);
+        }
     };
 
     vm.defaultEventHandler = function (data) {

--- a/ethicapp/frontend/assets/js/services/activity-state.service.js
+++ b/ethicapp/frontend/assets/js/services/activity-state.service.js
@@ -136,23 +136,29 @@ let ActivityStateService = function($http, TeacherSocketService) {
                     next: async (data) => {
                         console.debug(`Peer joined session ${sessionId}:`, 
                             JSON.stringify(data));
-                            
-                        const userList = service.activityStates[sessionId].users;
-                        const existingUser = userList.find(user => user.id === data.id);
+
+                        const activityState = service.activityStates[sessionId] || {};
+                        const userList = Array.isArray(activityState.users) ? activityState.users : [];
+                        service.activityStates[sessionId].users = userList;
+
+                        const existingUser = userList.find((user) =>
+                            Number(user.id) === Number(data.id)
+                        );
 
                         if (!existingUser) {
                             userList.push({
                                 id: data.id,
                                 name: data.name,
-                                role: 'A',
+                                role: data.role || "A",
                                 mail: data.mail,
                                 device: data.device,
                             });
                         }
 
                         // Notify listeners
-                        service.notifyListeners("onStudentJoined", { 
-                            response: data });                            
+                        service.notifyListeners("onStudentJoined", {
+                            response: data
+                        });
                     },
                     error: (err) => {
                         console.error(`Websocket error for onStudentJoined event in session ${sessionId}:`, err)


### PR DESCRIPTION
### Motivation
- The teacher dashboard `Users` tab did not update in real time when a student joined because websocket `onStudentJoined` events could arrive before the activity state and user list were initialized and ID type mismatches produced false duplicates.

### Description
- Ensure the per-session user list is always initialized in `ActivityStateService.subscribeToActivityEvents` by assigning `service.activityStates[sessionId].users` to a validated array before mutating it in `ethicapp/frontend/assets/js/services/activity-state.service.js`.
- Normalize user id comparisons using `Number(...)` and preserve an incoming `role` (`data.role || "A"`) to avoid false duplicates and incorrect defaults in `activity-state.service.js`.
- Harden `vm.studentJoinHandler` in `ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js` to guard against early events by validating `vm.activityState`, binding `vm.userList` from a safe array, and only recomputing phase dashboard data when a `currentPhaseId` exists.

### Testing
- Ran syntax checks: `node --check ethicapp/frontend/assets/js/services/activity-state.service.js` which passed and `node --check ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js` which passed.
- Changes committed and are ready for further integration/manual verification (open teacher dashboard, join as student, confirm live appearance without refreshing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13078abb8832b816dff4493dbb1a7)