### PR TITLE
Return empty chat/message arrays instead of 404 and notify students on new chat messages

### DIFF
--- a/ethicapp/backend/controllers/group-messages.js
+++ b/ethicapp/backend/controllers/group-messages.js
@@ -9,7 +9,7 @@ import { messageCountHandlers,
     chatTranscriptHandlers, 
     chatInsertHandlers, 
     saveChatMessage } from "../helpers/chat-helper.js";
-import { teacherNotifications } from "../config/socket.config.js";
+import { studentNotifications, teacherNotifications } from "../config/socket.config.js";
 
 const router = express.Router();
 
@@ -42,7 +42,7 @@ router.get("/phases/:id/message_count", async (req, res) => {
         const results = await handler(id);
 
         if (!results || results.length === 0) {
-            return res.status(404).json({ error: "No messages found for the given phase." });
+            return res.status(200).json({ messageCount: [] });
         }
 
         // Log success and return the results
@@ -108,10 +108,8 @@ router.get("/groups/:group_id/question/:question_id/chat_messages", async (req, 
         // Step 4: Execute the handler and retrieve the chat transcript
         const results = await handler(groupId, questionId);
 
-        if (results.length === 0) {
-            return res.status(404).json({
-                error: "No messages found for the specified parameters.",
-            });
+        if (!results || results.length === 0) {
+            return res.status(200).json({ chat_transcript: [] });
         }
 
         res.status(200).json({ chat_transcript: results });
@@ -162,6 +160,7 @@ router.post("/phases/:id/question/:question_id/chat_messages", async (req, res) 
 
         // Step 4: Notify clients about the new message
         teacherNotifications.chatMessage(sessionId, phaseId, questionId, groupId, content);
+        studentNotifications?.chatMessage(groupId);
 
         // Respond with success
         res.status(201).json({

--- a/ethicapp/backend/sockets/student.socket.js
+++ b/ethicapp/backend/sockets/student.socket.js
@@ -53,10 +53,8 @@ const toStudentsNotifications = (socketNamespace) => {
             socketNamespace.to(`session-${sessionId}`).
                 emit("onPhaseTransition");
         },
-
-        chatMessage: (groupId, messages) => {
-            socketNamespace.to(`group-${groupId}`).
-                emit("onChatMessage", { messages });            
+        chatMessage: (groupId) => {
+            socketNamespace.to(`group-${groupId}`).emit("onChatMessage");
         },
 
         shareResponse: (sessionId, content) => {


### PR DESCRIPTION
### Motivation
- Ensure API endpoints return consistent, non-error responses when no chat data exists by returning empty arrays instead of `404` errors.
- Notify student clients in addition to teachers when a new chat message is posted.
- Simplify the student socket notification payload to emit an event without embedding the messages payload.

### Description
- Imported `studentNotifications` from `../config/socket.config.js` and invoked `studentNotifications?.chatMessage(groupId)` after saving a chat message in the `POST /phases/:id/question/:question_id/chat_messages` route.
- Changed `GET /phases/:id/message_count` to respond with `200` and `{ messageCount: [] }` when there are no results instead of returning `404`.
- Changed `GET /groups/:group_id/question/:question_id/chat_messages` to respond with `200` and `{ chat_transcript: [] }` when there are no results instead of returning `404`.
- Updated `toStudentsNotifications.chatMessage` in `student.socket.js` to accept only `groupId` and emit `onChatMessage` without a `messages` payload.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23be60fc4832bb127e7097038865b)