### PR TITLE
Validate/normalize chat input, return empty arrays for no-chat, and notify students on new messages

### DIFF
--- a/ethicapp/backend/controllers/group-messages.js
+++ b/ethicapp/backend/controllers/group-messages.js
@@ -9,7 +9,7 @@ import { messageCountHandlers,
     chatTranscriptHandlers, 
     chatInsertHandlers, 
     saveChatMessage } from "../helpers/chat-helper.js";
-import { teacherNotifications } from "../config/socket.config.js";
+import { studentNotifications, teacherNotifications } from "../config/socket.config.js";
 
 const router = express.Router();
 
@@ -42,7 +42,7 @@ router.get("/phases/:id/message_count", async (req, res) => {
         const results = await handler(id);
 
         if (!results || results.length === 0) {
-            return res.status(404).json({ error: "No messages found for the given phase." });
+            return res.status(200).json({ messageCount: [] });
         }
 
         // Log success and return the results
@@ -108,10 +108,8 @@ router.get("/groups/:group_id/question/:question_id/chat_messages", async (req, 
         // Step 4: Execute the handler and retrieve the chat transcript
         const results = await handler(groupId, questionId);
 
-        if (results.length === 0) {
-            return res.status(404).json({
-                error: "No messages found for the specified parameters.",
-            });
+        if (!results || results.length === 0) {
+            return res.status(200).json({ chat_transcript: [] });
         }
 
         res.status(200).json({ chat_transcript: results });
@@ -151,7 +149,7 @@ router.post("/phases/:id/question/:question_id/chat_messages", async (req, res) 
     }
 
     try {
-        if (!saveChatMessage({userId, phaseId, questionId, parentId, content})) {
+        if (!await saveChatMessage({userId, phaseId, questionId, parentId, content})) {
             return res.status(400).json({
                 error: `Error saving the chat message`,
             });
@@ -162,6 +160,7 @@ router.post("/phases/:id/question/:question_id/chat_messages", async (req, res) 
 
         // Step 4: Notify clients about the new message
         teacherNotifications.chatMessage(sessionId, phaseId, questionId, groupId, content);
+        studentNotifications?.chatMessage(groupId);
 
         // Respond with success
         res.status(201).json({

--- a/ethicapp/backend/helpers/chat-helper.js
+++ b/ethicapp/backend/helpers/chat-helper.js
@@ -1,6 +1,57 @@
 import * as config from "../config/config.js"; 
 import * as rpg2 from "../db/rest-pg-2.js";
+import * as Yup from "yup";
 import { getDesignTypeByPhaseId } from "./designs-helper.js";
+
+const flatChatMessageSchema = Yup.object({
+    userId: Yup.number().integer().positive().required(),
+    phaseId: Yup.number().integer().positive().required(),
+    questionId: Yup.number().integer().positive().nullable(),
+    parentId: Yup.number().integer().positive().nullable(),
+    content: Yup.string().trim().min(1).max(2000).required(),
+});
+
+const nestedChatMessageSchema = Yup.object({
+    header: Yup.object({
+        userId: Yup.number().integer().positive(),
+        uid: Yup.number().integer().positive(),
+        phaseId: Yup.number().integer().positive(),
+        stageId: Yup.number().integer().positive(),
+        itemId: Yup.number().integer().positive().nullable(),
+        questionId: Yup.number().integer().positive().nullable(),
+    }).required(),
+    payload: Yup.object({
+        parentId: Yup.number().integer().positive().nullable(),
+        parent_id: Yup.number().integer().positive().nullable(),
+        content: Yup.string().trim().min(1).max(2000).required(),
+    }).required(),
+});
+
+function normalizeChatMessageInput(data) {
+    if (data?.header && data?.payload) {
+        const userId = Number(data.header.userId ?? data.header.uid);
+        const phaseId = Number(data.header.phaseId ?? data.header.stageId);
+        const questionId = Number(data.header.questionId ?? data.header.itemId);
+        const parentId = data.payload.parentId ?? data.payload.parent_id ?? null;
+        const content = data.payload.content;
+
+        return {
+            userId,
+            phaseId,
+            questionId: Number.isFinite(questionId) ? questionId : null,
+            parentId,
+            content,
+        };
+    }
+
+    return {
+        userId: Number(data?.userId),
+        phaseId: Number(data?.phaseId),
+        questionId: data?.questionId == null ? null : Number(data.questionId),
+        parentId: data?.parentId ?? null,
+        content: data?.content,
+    };
+}
 
 /**
  * Handlers for message count queries based on design type.
@@ -45,29 +96,33 @@ export const chatInsertHandlers = {
 
 export const saveChatMessage = async function(data) {
     try {
-        // TODO: validate the incoming data with Yup
+        if (data?.header && data?.payload) {
+            await nestedChatMessageSchema.validate(data, { abortEarly: false, stripUnknown: true });
+        }
 
-        // Step 1: Determine the design type for the phase
+        const normalizedData = normalizeChatMessageInput(data);
+        const validatedData = await flatChatMessageSchema.validate(normalizedData, {
+            abortEarly: false,
+            stripUnknown: true,
+        });
+
+        const { userId, phaseId, questionId, parentId, content } = validatedData;
+
         const designType = await getDesignTypeByPhaseId(phaseId);
-
-        // Step 2: Fetch the appropriate handler for the design type
         const handler = chatInsertHandlers[designType];
         if (!handler) {
             throw new Error(`Unsupported design type: ${designType}`);
         }
 
-        const { userId, phaseId, itemId } = data.header;
-        const { parentId, content } = data.payload;
-
-        // Step 3: Execute the handler to insert the chat message
         await handler({
             userId,
             phaseId,
-            itemId,
+            questionId,
             content,
             parentId,
             dbcon: config.dbconnString,
         });
+
         return true;
     } catch(error) {
         console.error("[ChatHelper::saveChatMessage] Could not save the message. ", error);

--- a/ethicapp/backend/sockets/student.socket.js
+++ b/ethicapp/backend/sockets/student.socket.js
@@ -53,10 +53,8 @@ const toStudentsNotifications = (socketNamespace) => {
             socketNamespace.to(`session-${sessionId}`).
                 emit("onPhaseTransition");
         },
-
-        chatMessage: (groupId, messages) => {
-            socketNamespace.to(`group-${groupId}`).
-                emit("onChatMessage", { messages });            
+        chatMessage: (groupId) => {
+            socketNamespace.to(`group-${groupId}`).emit("onChatMessage");
         },
 
         shareResponse: (sessionId, content) => {


### PR DESCRIPTION
### Motivation
- Improve robustness of chat message handling by validating and normalizing multiple incoming payload shapes before persisting. 
- Avoid treating an empty result set as an error for chat endpoints and return a consistent empty array response. 
- Broadcast new chat events to student clients in addition to teacher notifications.

### Description
- Added Yup schemas and a `normalizeChatMessageInput` helper to `helpers/chat-helper.js` and validate both nested (`header`/`payload`) and flat message shapes before saving. 
- Updated `saveChatMessage` to normalize input, validate fields, look up the design type, and call the appropriate insert handler with `questionId`/`phaseId`/`parentId` values. 
- Changed endpoints in `controllers/group-messages.js` to return `200` with an empty array when no messages are found instead of `404` and `saveChatMessage` is now `await`ed; imported `studentNotifications` and emit student notifications when a message is posted. 
- Adjusted student socket notifier in `sockets/student.socket.js` to emit `onChatMessage` to the group without requiring a payload to match server-side notification usage.

### Testing
- Ran the project test suite with `npm test` and linter with `npm run lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23be60fc4832bb127e7097038865b)