### PR TITLE
Add group join/leave and robust chat handling with validation and student notifications

### DIFF
--- a/ethicapp-student/frontend/src/pages/ActivityPage.jsx
+++ b/ethicapp-student/frontend/src/pages/ActivityPage.jsx
@@ -25,6 +25,7 @@ export default function ActivityPage() {
   const [lastSubmittedAtByResponse, setLastSubmittedAtByResponse] = useState({});
   const [chatRefreshTokenByPhaseId, setChatRefreshTokenByPhaseId] = useState({});
   const lastAutoSelectedPhaseIdRef = useRef(null);
+  const currentGroupIdRef = useRef(null);
   const {
     stateBySession,
     loadingBySession,
@@ -230,13 +231,13 @@ export default function ActivityPage() {
       dispatch({ type: 'ACTIVITY_FORCE_FINISHED' });
     };
 
-    const handleChatMessage = (payload) => {
+    const handleChatMessage = () => {
       console.debug('[student socket] onChatMessage', {
         sessionId: activeSessionId,
-        payload
+        phaseId: activityState?.descriptor?.currentPhaseId
       });
 
-      const phaseId = Number(payload?.phaseId ?? payload?.stid ?? payload?.stage_id);
+      const phaseId = Number(activityState?.descriptor?.currentPhaseId);
       if (!Number.isInteger(phaseId) || phaseId <= 0) {
         return;
       }
@@ -274,6 +275,9 @@ export default function ActivityPage() {
         return;
       }
 
+      if (Number.isInteger(Number(currentGroupIdRef.current)) && Number(currentGroupIdRef.current) > 0) {
+        socket.emit('leaveGroup', Number(currentGroupIdRef.current));
+      }
       socket.emit('leaveSession', activeSessionId);
       socket.off('onPhaseTransition', handlePhaseTransition);
       socket.off('onShareResponse', handleShareResponse);
@@ -281,6 +285,63 @@ export default function ActivityPage() {
       socket.off('onChatMessage', handleChatMessage);
     };
   }, [loadCurrentPhaseState, loadFullState, selectedSession, session.isAuthenticated, session.uid]);
+
+
+  useEffect(() => {
+    if (!session.isAuthenticated || !selectedSession || !session.uid || !activityState?.descriptor?.currentPhaseId) {
+      return;
+    }
+
+    let isUnmounted = false;
+    const phaseId = Number(activityState.descriptor.currentPhaseId);
+    if (!Number.isInteger(phaseId) || phaseId <= 0) {
+      return;
+    }
+
+    getStudentSocket()
+      .then(async (socket) => {
+        if (isUnmounted) {
+          return;
+        }
+
+        try {
+          const { data } = await legacyUserApi.get(`/phases/${phaseId}/user_group/${session.uid}`);
+          if (isUnmounted) {
+            return;
+          }
+
+          const nextGroupId = Number(data?.team_id);
+          const previousGroupId = Number(currentGroupIdRef.current);
+
+          if (Number.isInteger(previousGroupId) && previousGroupId > 0 && previousGroupId !== nextGroupId) {
+            socket.emit('leaveGroup', previousGroupId);
+          }
+
+          if (Number.isInteger(nextGroupId) && nextGroupId > 0 && previousGroupId !== nextGroupId) {
+            socket.emit('joinGroup', nextGroupId);
+            currentGroupIdRef.current = nextGroupId;
+            return;
+          }
+
+          if (!Number.isInteger(nextGroupId) || nextGroupId <= 0) {
+            currentGroupIdRef.current = null;
+          }
+        } catch (error) {
+          console.debug('[student socket] failed to resolve group for current phase', {
+            sessionId: Number(selectedSession.id),
+            phaseId,
+            error
+          });
+        }
+      })
+      .catch(() => {
+        // socket init issues are already logged elsewhere
+      });
+
+    return () => {
+      isUnmounted = true;
+    };
+  }, [activityState?.descriptor?.currentPhaseId, selectedSession, session.isAuthenticated, session.uid]);
 
   const phaseTabs = useMemo(() => {
     return Array.isArray(activityState?.phases) ? activityState.phases : [];

--- a/ethicapp/backend/controllers/group-messages.js
+++ b/ethicapp/backend/controllers/group-messages.js
@@ -9,7 +9,7 @@ import { messageCountHandlers,
     chatTranscriptHandlers, 
     chatInsertHandlers, 
     saveChatMessage } from "../helpers/chat-helper.js";
-import { teacherNotifications } from "../config/socket.config.js";
+import { studentNotifications, teacherNotifications } from "../config/socket.config.js";
 
 const router = express.Router();
 
@@ -42,7 +42,7 @@ router.get("/phases/:id/message_count", async (req, res) => {
         const results = await handler(id);
 
         if (!results || results.length === 0) {
-            return res.status(404).json({ error: "No messages found for the given phase." });
+            return res.status(200).json({ messageCount: [] });
         }
 
         // Log success and return the results
@@ -108,10 +108,8 @@ router.get("/groups/:group_id/question/:question_id/chat_messages", async (req, 
         // Step 4: Execute the handler and retrieve the chat transcript
         const results = await handler(groupId, questionId);
 
-        if (results.length === 0) {
-            return res.status(404).json({
-                error: "No messages found for the specified parameters.",
-            });
+        if (!results || results.length === 0) {
+            return res.status(200).json({ chat_transcript: [] });
         }
 
         res.status(200).json({ chat_transcript: results });
@@ -151,7 +149,7 @@ router.post("/phases/:id/question/:question_id/chat_messages", async (req, res) 
     }
 
     try {
-        if (!saveChatMessage({userId, phaseId, questionId, parentId, content})) {
+        if (!await saveChatMessage({userId, phaseId, questionId, parentId, content})) {
             return res.status(400).json({
                 error: `Error saving the chat message`,
             });
@@ -162,6 +160,7 @@ router.post("/phases/:id/question/:question_id/chat_messages", async (req, res) 
 
         // Step 4: Notify clients about the new message
         teacherNotifications.chatMessage(sessionId, phaseId, questionId, groupId, content);
+        studentNotifications?.chatMessage(groupId);
 
         // Respond with success
         res.status(201).json({

--- a/ethicapp/backend/controllers/groups.js
+++ b/ethicapp/backend/controllers/groups.js
@@ -137,9 +137,13 @@ router.get("/phases/:id/user_group/:user_id", async (req, res) => {
             sqlParams: [rpg2.param('plain', phaseId), rpg2.param('plain', userId)],
         });
 
-        // If no group is found for the user, return a 404 error
+        // If no group is found for the user, return an empty success response
         if (results.length === 0) {
-            return res.status(404).json({ error: "User not found in any group for the given phase." });
+            return res.status(200).json({
+                error: "User not found in any group for the given phase.",
+                team_id: null,
+                participants: [],
+            });
         }
 
         // Extract the team ID from the results

--- a/ethicapp/backend/helpers/chat-helper.js
+++ b/ethicapp/backend/helpers/chat-helper.js
@@ -1,6 +1,57 @@
 import * as config from "../config/config.js"; 
 import * as rpg2 from "../db/rest-pg-2.js";
+import * as Yup from "yup";
 import { getDesignTypeByPhaseId } from "./designs-helper.js";
+
+const flatChatMessageSchema = Yup.object({
+    userId: Yup.number().integer().positive().required(),
+    phaseId: Yup.number().integer().positive().required(),
+    questionId: Yup.number().integer().positive().nullable(),
+    parentId: Yup.number().integer().positive().nullable(),
+    content: Yup.string().trim().min(1).max(2000).required(),
+});
+
+const nestedChatMessageSchema = Yup.object({
+    header: Yup.object({
+        userId: Yup.number().integer().positive(),
+        uid: Yup.number().integer().positive(),
+        phaseId: Yup.number().integer().positive(),
+        stageId: Yup.number().integer().positive(),
+        itemId: Yup.number().integer().positive().nullable(),
+        questionId: Yup.number().integer().positive().nullable(),
+    }).required(),
+    payload: Yup.object({
+        parentId: Yup.number().integer().positive().nullable(),
+        parent_id: Yup.number().integer().positive().nullable(),
+        content: Yup.string().trim().min(1).max(2000).required(),
+    }).required(),
+});
+
+function normalizeChatMessageInput(data) {
+    if (data?.header && data?.payload) {
+        const userId = Number(data.header.userId ?? data.header.uid);
+        const phaseId = Number(data.header.phaseId ?? data.header.stageId);
+        const questionId = Number(data.header.questionId ?? data.header.itemId);
+        const parentId = data.payload.parentId ?? data.payload.parent_id ?? null;
+        const content = data.payload.content;
+
+        return {
+            userId,
+            phaseId,
+            questionId: Number.isFinite(questionId) ? questionId : null,
+            parentId,
+            content,
+        };
+    }
+
+    return {
+        userId: Number(data?.userId),
+        phaseId: Number(data?.phaseId),
+        questionId: data?.questionId == null ? null : Number(data.questionId),
+        parentId: data?.parentId ?? null,
+        content: data?.content,
+    };
+}
 
 /**
  * Handlers for message count queries based on design type.
@@ -45,29 +96,33 @@ export const chatInsertHandlers = {
 
 export const saveChatMessage = async function(data) {
     try {
-        // TODO: validate the incoming data with Yup
+        if (data?.header && data?.payload) {
+            await nestedChatMessageSchema.validate(data, { abortEarly: false, stripUnknown: true });
+        }
 
-        // Step 1: Determine the design type for the phase
+        const normalizedData = normalizeChatMessageInput(data);
+        const validatedData = await flatChatMessageSchema.validate(normalizedData, {
+            abortEarly: false,
+            stripUnknown: true,
+        });
+
+        const { userId, phaseId, questionId, parentId, content } = validatedData;
+
         const designType = await getDesignTypeByPhaseId(phaseId);
-
-        // Step 2: Fetch the appropriate handler for the design type
         const handler = chatInsertHandlers[designType];
         if (!handler) {
             throw new Error(`Unsupported design type: ${designType}`);
         }
 
-        const { userId, phaseId, itemId } = data.header;
-        const { parentId, content } = data.payload;
-
-        // Step 3: Execute the handler to insert the chat message
         await handler({
             userId,
             phaseId,
-            itemId,
+            questionId,
             content,
             parentId,
             dbcon: config.dbconnString,
         });
+
         return true;
     } catch(error) {
         console.error("[ChatHelper::saveChatMessage] Could not save the message. ", error);

--- a/ethicapp/backend/sockets/student.socket.js
+++ b/ethicapp/backend/sockets/student.socket.js
@@ -53,10 +53,8 @@ const toStudentsNotifications = (socketNamespace) => {
             socketNamespace.to(`session-${sessionId}`).
                 emit("onPhaseTransition");
         },
-
-        chatMessage: (groupId, messages) => {
-            socketNamespace.to(`group-${groupId}`).
-                emit("onChatMessage", { messages });            
+        chatMessage: (groupId) => {
+            socketNamespace.to(`group-${groupId}`).emit("onChatMessage");
         },
 
         shareResponse: (sessionId, content) => {


### PR DESCRIPTION
### Motivation

- Ensure students are joined to and leave the correct realtime group channel for the current phase so group-level chat notifications are routed correctly.
- Harden chat message ingestion by accepting multiple input shapes and validating content before inserting to DB. 
- Avoid returning 404s for empty chat or message-count queries and provide consistent empty-array responses.

### Description

- Frontend: add `currentGroupIdRef`, join/leave group sockets when phase changes, leave group on unmount, and simplify `handleChatMessage` to respond to phase-level chat refreshes. 
- Backend (chat helper): add Yup schemas, normalize nested/flat message shapes via `normalizeChatMessageInput`, validate inputs, make `saveChatMessage` async, and route inserts through design-specific `chatInsertHandlers`. 
- Backend (controllers): return empty arrays (`[]`) and 200 for no-results in `message_count` and `chat_messages` endpoints, and return a structured empty response for `/phases/:id/user_group/:user_id` when no group is found. 
- Backend (group-messages): import `studentNotifications` and notify students in a group after a message is saved via `studentNotifications.chatMessage(groupId)`. 
- Backend (student socket): simplify `toStudentsNotifications.chatMessage` to emit `onChatMessage` without payload for group broadcasts.

### Testing

- Ran the backend unit/integration smoke checks and API endpoint tests against the modified chat endpoints; they passed. 
- Built and ran the frontend dev build and exercised phase transition and chat flows manually to verify group join/leave and chat refresh behavior; no errors observed. 
- Existing test suites completed successfully after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23be60fc4832bb127e7097038865b)