### PR TITLE
Fix missing chat group_id propagation in student phase chat

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
@@ -111,7 +111,7 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
   const sendMessage = async () => {
     const content = draftMessage.trim();
 
-    if (!content || sending || !Number.isInteger(fallbackQuestionId) || fallbackQuestionId <= 0) {
+    if (!content || sending || !Number.isInteger(groupId) || groupId <= 0 || !Number.isInteger(fallbackQuestionId) || fallbackQuestionId <= 0) {
       return;
     }
 

--- a/ethicapp-student/frontend/src/pages/ActivityPage.jsx
+++ b/ethicapp-student/frontend/src/pages/ActivityPage.jsx
@@ -24,6 +24,7 @@ export default function ActivityPage() {
   const [localState, dispatch] = useReducer(sessionDetailReducer, initialSessionDetailState);
   const [lastSubmittedAtByResponse, setLastSubmittedAtByResponse] = useState({});
   const [chatRefreshTokenByPhaseId, setChatRefreshTokenByPhaseId] = useState({});
+  const [groupIdByPhaseId, setGroupIdByPhaseId] = useState({});
   const lastAutoSelectedPhaseIdRef = useRef(null);
   const currentGroupIdRef = useRef(null);
   const {
@@ -313,6 +314,20 @@ export default function ActivityPage() {
           const nextGroupId = Number(data?.team_id);
           const previousGroupId = Number(currentGroupIdRef.current);
 
+          if (Number.isInteger(nextGroupId) && nextGroupId > 0) {
+            setGroupIdByPhaseId((prev) => (prev[phaseId] === nextGroupId ? prev : { ...prev, [phaseId]: nextGroupId }));
+          } else {
+            setGroupIdByPhaseId((prev) => {
+              if (!(phaseId in prev)) {
+                return prev;
+              }
+
+              const next = { ...prev };
+              delete next[phaseId];
+              return next;
+            });
+          }
+
           if (Number.isInteger(previousGroupId) && previousGroupId > 0 && previousGroupId !== nextGroupId) {
             socket.emit('leaveGroup', previousGroupId);
           }
@@ -344,8 +359,22 @@ export default function ActivityPage() {
   }, [activityState?.descriptor?.currentPhaseId, selectedSession, session.isAuthenticated, session.uid]);
 
   const phaseTabs = useMemo(() => {
-    return Array.isArray(activityState?.phases) ? activityState.phases : [];
-  }, [activityState]);
+    const phases = Array.isArray(activityState?.phases) ? activityState.phases : [];
+
+    return phases.map((phase) => {
+      const phaseId = Number(phase?.id);
+      const groupId = groupIdByPhaseId[phaseId];
+
+      if (!Number.isInteger(groupId) || groupId <= 0) {
+        return phase;
+      }
+
+      return {
+        ...phase,
+        groupId
+      };
+    });
+  }, [activityState, groupIdByPhaseId]);
 
   const currentPhaseNumber = activityState?.descriptor?.currentPhaseNumber ?? null;
   const currentPhaseId = activityState?.descriptor?.currentPhaseId ?? null;


### PR DESCRIPTION
### Motivation
- Chat messages posted from the phase overlay were arriving at the backend with `group_id` null, causing group-scoped notifications to be emitted to `group null` and breaking chat behavior.
- The overlay relied on `phase.group` data that was not reliably populated because group resolution was performed only during socket initialization in `ActivityPage`.
- The intent is to ensure the chat overlay has a valid `groupId` when posting messages to `/phases/:id/question/:question_id/chat_messages` so notifications and message scoping work correctly.

### Description
- Added `groupIdByPhaseId` state in `ActivityPage` and update it when resolving `/phases/{phaseId}/user_group/{uid}` so each phase can keep its resolved `team_id` mapped by phase id.
- Enriched `phaseTabs` in `ActivityPage` to inject `groupId` into the `phase` objects when a valid mapping exists so downstream components receive `phase.groupId` reliably.
- Hardened `PhaseChatOverlay.sendMessage` to require a valid positive integer `groupId` before posting the message payload (the request now includes `group_id` only when valid).

### Testing
- Ran `cd ethicapp-student/frontend && npm run lint` which failed because the frontend package has no `lint` script in this environment.
- Ran `cd ethicapp-student/frontend && npm run build` which failed due to the `vite` binary not being available in the local environment, preventing a full build verification.
- No other automated test suites were available or executed in this environment, so automated verification could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f253d719e4832b939367a7897d50f3)