### PR TITLE
Support group context and anonymous display names in phase chat; enhance user_group API

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
@@ -4,6 +4,38 @@ import { legacyUserApi } from '../../../api/studentApi.js';
 const DEFAULT_HEIGHT_PX = 320;
 const MIN_HEIGHT_PX = 220;
 
+function resolveDisplayName(message, participantsByUserId, isAnonymous, t) {
+  const participant = participantsByUserId[Number(message.authorId)] ?? null;
+
+  if (isAnonymous) {
+    if (participant?.anon_mask) {
+      return participant.anon_mask;
+    }
+
+    return t('sessionDetail.chatAnonymousAuthor');
+  }
+
+  if (participant) {
+    const firstName = typeof participant.firstname === 'string' ? participant.firstname.trim() : '';
+    const lastName = typeof participant.lastname === 'string' ? participant.lastname.trim() : '';
+    const fullName = `${firstName} ${lastName}`.trim();
+
+    if (fullName.length > 0) {
+      return fullName;
+    }
+
+    if (typeof participant.name === 'string' && participant.name.trim().length > 0) {
+      return participant.name.trim();
+    }
+  }
+
+  if (typeof message.authorName === 'string' && message.authorName.trim().length > 0) {
+    return message.authorName.trim();
+  }
+
+  return t('sessionDetail.chatPeerAuthor');
+}
+
 function normalizeMessage(message) {
   const id = Number(message?.id ?? message?.msgid ?? message?.mid);
   const authorId = Number(message?.uid ?? message?.user_id ?? message?.author_id);
@@ -38,6 +70,22 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
   }, [heightPx, isOpen, onHeightChange]);
 
   const groupId = Number(phase?.group?.id ?? phase?.groupId);
+  const participantsByUserId = useMemo(() => {
+    const participants = Array.isArray(phase?.groupParticipants) ? phase.groupParticipants : [];
+
+    return participants.reduce((acc, participant) => {
+      const participantUserId = Number(participant?.user_id);
+      if (!Number.isInteger(participantUserId) || participantUserId <= 0) {
+        return acc;
+      }
+
+      acc[participantUserId] = participant;
+      return acc;
+    }, {});
+  }, [phase]);
+
+  const isAnonymousPhase = phase?.features?.anonymous === true || phase?.groupAnonymous === true;
+
   const fallbackQuestionId = useMemo(() => {
     const orderedTasks = Array.isArray(phase?.tasks) ? [...phase.tasks] : [];
     orderedTasks.sort((leftTask, rightTask) => Number(leftTask?.order ?? 0) - Number(rightTask?.order ?? 0));
@@ -111,7 +159,7 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
   const sendMessage = async () => {
     const content = draftMessage.trim();
 
-    if (!content || sending || !Number.isInteger(fallbackQuestionId) || fallbackQuestionId <= 0) {
+    if (!content || sending || !Number.isInteger(groupId) || groupId <= 0 || !Number.isInteger(fallbackQuestionId) || fallbackQuestionId <= 0) {
       return;
     }
 
@@ -155,7 +203,7 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
           {!loading && messages.length === 0 ? <p className="text-muted small mb-0">{t('sessionDetail.chatEmpty')}</p> : null}
           {messages.map((message) => (
             <div key={message.id} className="mb-2">
-              <small className="text-muted d-block">{phase?.features?.anonymous ? t('sessionDetail.chatAnonymousAuthor') : (message.authorId === Number(userId) ? t('sessionDetail.chatYouAuthor') : (message.authorName || t('sessionDetail.chatPeerAuthor')))}</small>
+              <small className="text-muted d-block">{message.authorId === Number(userId) ? t('sessionDetail.chatYouAuthor') : resolveDisplayName(message, participantsByUserId, isAnonymousPhase, t)}</small>
               <div className="bg-light rounded px-2 py-1">{message.content}</div>
             </div>
           ))}

--- a/ethicapp-student/frontend/src/pages/ActivityPage.jsx
+++ b/ethicapp-student/frontend/src/pages/ActivityPage.jsx
@@ -24,8 +24,11 @@ export default function ActivityPage() {
   const [localState, dispatch] = useReducer(sessionDetailReducer, initialSessionDetailState);
   const [lastSubmittedAtByResponse, setLastSubmittedAtByResponse] = useState({});
   const [chatRefreshTokenByPhaseId, setChatRefreshTokenByPhaseId] = useState({});
+  const [groupIdByPhaseId, setGroupIdByPhaseId] = useState({});
+  const [groupContextByPhaseId, setGroupContextByPhaseId] = useState({});
   const lastAutoSelectedPhaseIdRef = useRef(null);
   const currentGroupIdRef = useRef(null);
+  const currentPhaseIdRef = useRef(null);
   const {
     stateBySession,
     loadingBySession,
@@ -69,6 +72,17 @@ export default function ActivityPage() {
   const activityState = stateBySession[selectedSessionId] ?? null;
   const loadingActivityState = loadingBySession[selectedSessionId] ?? false;
   const activityStateError = errorBySession[selectedSessionId] ?? '';
+
+  useEffect(() => {
+    const phaseId = Number(activityState?.descriptor?.currentPhaseId);
+
+    if (!Number.isInteger(phaseId) || phaseId <= 0) {
+      currentPhaseIdRef.current = null;
+      return;
+    }
+
+    currentPhaseIdRef.current = phaseId;
+  }, [activityState?.descriptor?.currentPhaseId]);
 
   useEffect(() => {
     lastAutoSelectedPhaseIdRef.current = null;
@@ -234,10 +248,10 @@ export default function ActivityPage() {
     const handleChatMessage = () => {
       console.debug('[student socket] onChatMessage', {
         sessionId: activeSessionId,
-        phaseId: activityState?.descriptor?.currentPhaseId
+        phaseId: currentPhaseIdRef.current
       });
 
-      const phaseId = Number(activityState?.descriptor?.currentPhaseId);
+      const phaseId = Number(currentPhaseIdRef.current);
       if (!Number.isInteger(phaseId) || phaseId <= 0) {
         return;
       }
@@ -313,6 +327,45 @@ export default function ActivityPage() {
           const nextGroupId = Number(data?.team_id);
           const previousGroupId = Number(currentGroupIdRef.current);
 
+          if (Number.isInteger(nextGroupId) && nextGroupId > 0) {
+            setGroupIdByPhaseId((prev) => (prev[phaseId] === nextGroupId ? prev : { ...prev, [phaseId]: nextGroupId }));
+            setGroupContextByPhaseId((prev) => {
+              const nextContext = {
+                phaseAnonymous: Boolean(data?.phase_anonymous),
+                participants: Array.isArray(data?.participants) ? data.participants : []
+              };
+
+              const previousContext = prev[phaseId];
+              if (
+                previousContext?.phaseAnonymous === nextContext.phaseAnonymous
+                && JSON.stringify(previousContext?.participants ?? []) === JSON.stringify(nextContext.participants)
+              ) {
+                return prev;
+              }
+
+              return { ...prev, [phaseId]: nextContext };
+            });
+          } else {
+            setGroupIdByPhaseId((prev) => {
+              if (!(phaseId in prev)) {
+                return prev;
+              }
+
+              const next = { ...prev };
+              delete next[phaseId];
+              return next;
+            });
+            setGroupContextByPhaseId((prev) => {
+              if (!(phaseId in prev)) {
+                return prev;
+              }
+
+              const next = { ...prev };
+              delete next[phaseId];
+              return next;
+            });
+          }
+
           if (Number.isInteger(previousGroupId) && previousGroupId > 0 && previousGroupId !== nextGroupId) {
             socket.emit('leaveGroup', previousGroupId);
           }
@@ -344,8 +397,26 @@ export default function ActivityPage() {
   }, [activityState?.descriptor?.currentPhaseId, selectedSession, session.isAuthenticated, session.uid]);
 
   const phaseTabs = useMemo(() => {
-    return Array.isArray(activityState?.phases) ? activityState.phases : [];
-  }, [activityState]);
+    const phases = Array.isArray(activityState?.phases) ? activityState.phases : [];
+
+    return phases.map((phase) => {
+      const phaseId = Number(phase?.id);
+      const groupId = groupIdByPhaseId[phaseId];
+
+      if (!Number.isInteger(groupId) || groupId <= 0) {
+        return phase;
+      }
+
+      const groupContext = groupContextByPhaseId[phaseId];
+
+      return {
+        ...phase,
+        groupId,
+        groupParticipants: Array.isArray(groupContext?.participants) ? groupContext.participants : [],
+        groupAnonymous: typeof groupContext?.phaseAnonymous === 'boolean' ? groupContext.phaseAnonymous : undefined
+      };
+    });
+  }, [activityState, groupContextByPhaseId, groupIdByPhaseId]);
 
   const currentPhaseNumber = activityState?.descriptor?.currentPhaseNumber ?? null;
   const currentPhaseId = activityState?.descriptor?.currentPhaseId ?? null;

--- a/ethicapp/backend/controllers/groups.js
+++ b/ethicapp/backend/controllers/groups.js
@@ -126,10 +126,13 @@ router.get("/phases/:id/user_group/:user_id", async (req, res) => {
             sql: `
                 SELECT t.id AS team_id,
                        tu.uid AS user_id,
-                       tu.anon_character
+                       tu.anon_mask,
+                       st.anon AS phase_anonymous
                 FROM teams AS t
                 INNER JOIN teamusers AS tu
                     ON t.id = tu.tmid
+                INNER JOIN stages AS st
+                    ON st.id = t.stageid
                 WHERE t.stageid = $1 AND tu.uid = $2
                 ORDER BY tu.uid
             `,
@@ -153,8 +156,13 @@ router.get("/phases/:id/user_group/:user_id", async (req, res) => {
         const groupParticipants = await rpg2.execSQL({
             sql: `
                 SELECT tu.uid AS user_id,
-                       tu.anon_character
+                       tu.anon_mask,
+                       u.firstname,
+                       u.lastname,
+                       u.name
                 FROM teamusers AS tu
+                INNER JOIN users AS u
+                    ON u.id = tu.uid
                 WHERE tu.tmid = $1
                 ORDER BY tu.uid
             `,
@@ -165,9 +173,13 @@ router.get("/phases/:id/user_group/:user_id", async (req, res) => {
         // Respond with the team details and its participants
         res.status(200).json({
             team_id: teamId,
+            phase_anonymous: Boolean(results[0]?.phase_anonymous),
             participants: groupParticipants.map(row => ({
                 user_id: row.user_id,
-                anon_character: row.anon_character,
+                anon_mask: row.anon_mask,
+                firstname: row.firstname,
+                lastname: row.lastname,
+                name: row.name,
             })),
         });
     } catch (err) {


### PR DESCRIPTION
### Motivation
- Ensure chat messages show appropriate display names whether phases are anonymous or not and prefer group participant data when available.
- Track and cache per-phase group context so chat UI can resolve participant names and anonymous masks without extra requests on render.
- Make socket chat refreshes and group join/leave logic reference the correct current phase and group to avoid missed or misrouted events.

### Description
- Added `resolveDisplayName` and participant lookup (`participantsByUserId`) to `PhaseChatOverlay.jsx` and compute `isAnonymousPhase` to correctly render author labels using anon masks, participant names, or fallbacks.
- Require a valid `groupId` when sending chat messages and keep existing message normalization in `normalizeMessage` to handle varied API shapes.
- In `ActivityPage.jsx` track `groupIdByPhaseId` and `groupContextByPhaseId`, populate them from the `/phases/:id/user_group/:user_id` response, and expose `groupParticipants` and `groupAnonymous` on phase objects in `phaseTabs` so the UI can consume group info.
- Use a `currentPhaseIdRef` to ensure socket `onChatMessage` handler refreshes the correct phase's chat, and update join/leave group socket behavior when group membership changes.
- Backend `groups.js` endpoint `/phases/:id/user_group/:user_id` now returns `team_id`, `phase_anonymous`, and participant objects with `anon_mask` and user name fields, and the SQL was adjusted to join `stages` and `users` and rename `anon_character` to `anon_mask`.

### Testing
- Ran frontend linting with `npm run lint` and frontend unit tests with `npm test`, and they completed successfully.
- Ran backend test and basic API checks via the existing test suite with `npm test`, and they passed.
- Verified socket-related behavior by running the integrated student socket tests, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f253d719e4832b939367a7897d50f3)