### PR TITLE
Align own vs peer chat bubbles in PhaseChatOverlay

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
@@ -241,12 +241,13 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
           {messages.map((message) => {
             const depth = getMessageDepth(message);
             const replyTarget = Number.isInteger(message.parentId) ? messagesById[message.parentId] ?? null : null;
+            const isOwnMessage = message.authorId === Number(userId);
 
             return (
-              <div key={message.id} className="mb-2" style={{ marginLeft: `${depth * 12}px` }}>
-                <small className="text-muted d-block">{message.authorId === Number(userId) ? t('sessionDetail.chatYouAuthor') : resolveDisplayName(message, participantsByUserId, isAnonymousPhase, t)}</small>
-                {replyTarget ? <div className="small text-muted border-start ps-2 mb-1">↪ {replyTarget.content}</div> : null}
-                <div className="bg-light rounded px-2 py-1">{message.content}</div>
+              <div key={message.id} className={`mb-2 d-flex flex-column ${isOwnMessage ? 'align-items-end' : 'align-items-start'}`} style={{ marginLeft: `${depth * 12}px` }}>
+                <small className="text-muted d-block">{isOwnMessage ? t('sessionDetail.chatYouAuthor') : resolveDisplayName(message, participantsByUserId, isAnonymousPhase, t)}</small>
+                {replyTarget ? <div className={`small text-muted mb-1 px-2 ${isOwnMessage ? 'border-end pe-2 text-end' : 'border-start ps-2 text-start'}`}>↪ {replyTarget.content}</div> : null}
+                <div className={`rounded px-2 py-1 ${isOwnMessage ? 'bg-primary text-white' : 'bg-light text-dark'}`} style={{ maxWidth: '85%' }}>{message.content}</div>
                 <button
                   type="button"
                   className="btn btn-link btn-sm p-0 mt-1 text-decoration-none"


### PR DESCRIPTION
### Motivation
- Improve chat readability by aligning messages authored by the current user to the right and peer messages to the left so the UI behaves like common instant-messaging apps.

### Description
- Updated `ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx` to compute `isOwnMessage` and conditionally apply alignment classes so own messages use `align-items-end` and peers use `align-items-start`.
- Styled message bubbles so own messages use `bg-primary text-white` while peer messages use `bg-light text-dark`, and limited bubble width with `style={{ maxWidth: '85%' }}` for better readability.
- Mirrored the reply-preview direction by switching border and text alignment classes based on `isOwnMessage`.

### Testing
- Ran `npm --prefix ethicapp-student/frontend run` which listed available scripts successfully.
- Ran `npm --prefix ethicapp-student/frontend run lint` which failed because the `lint` script is not defined in that `package.json`.
- Ran `npm --prefix ethicapp-student/frontend run build` which failed in this environment because the `vite` binary is not installed (build could not be executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2715f8c14832bbc8da6f99493f766)