### PR TITLE
Align and restyle chat messages for own vs others in PhaseChatOverlay

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
@@ -241,12 +241,13 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
           {messages.map((message) => {
             const depth = getMessageDepth(message);
             const replyTarget = Number.isInteger(message.parentId) ? messagesById[message.parentId] ?? null : null;
+            const isOwnMessage = message.authorId === Number(userId);
 
             return (
-              <div key={message.id} className="mb-2" style={{ marginLeft: `${depth * 12}px` }}>
-                <small className="text-muted d-block">{message.authorId === Number(userId) ? t('sessionDetail.chatYouAuthor') : resolveDisplayName(message, participantsByUserId, isAnonymousPhase, t)}</small>
-                {replyTarget ? <div className="small text-muted border-start ps-2 mb-1">↪ {replyTarget.content}</div> : null}
-                <div className="bg-light rounded px-2 py-1">{message.content}</div>
+              <div key={message.id} className={`mb-2 d-flex flex-column ${isOwnMessage ? 'align-items-end' : 'align-items-start'}`} style={{ marginLeft: `${depth * 12}px` }}>
+                <small className="text-muted d-block">{isOwnMessage ? t('sessionDetail.chatYouAuthor') : resolveDisplayName(message, participantsByUserId, isAnonymousPhase, t)}</small>
+                {replyTarget ? <div className={`small text-muted mb-1 px-2 ${isOwnMessage ? 'border-end pe-2 text-end' : 'border-start ps-2 text-start'}`}>↪ {replyTarget.content}</div> : null}
+                <div className={`rounded px-2 py-1 ${isOwnMessage ? 'bg-white text-dark border shadow-sm' : 'bg-light text-dark'}`} style={{ maxWidth: '85%' }}>{message.content}</div>
                 <button
                   type="button"
                   className="btn btn-link btn-sm p-0 mt-1 text-decoration-none"


### PR DESCRIPTION
### Motivation
- Improve chat readability by visually distinguishing the current user's messages from others and make reply previews align with the message sender.
- Prevent overly wide message bubbles on narrow overlays by constraining message width.

### Description
- Introduced `isOwnMessage` computed as `message.authorId === Number(userId)` and use it for conditional layout and styling.
- Changed message container to use flex column with either `align-items-end` or `align-items-start` so own messages are right-aligned and others left-aligned.
- Adjusted reply preview to use `border-end/pe-2 text-end` for own messages and `border-start/ps-2 text-start` for others, and updated message bubble classes to `bg-white text-dark border shadow-sm` for own messages and `bg-light text-dark` for others.
- Constrained message bubble width with inline style `maxWidth: '85%'` to avoid oversized bubbles.

### Testing
- No new automated tests were added or modified for this change.
- Existing frontend linters and unit tests were executed locally and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2715f8c14832bbc8da6f99493f766)