### PR TITLE
Improve chat message alignment and styling in PhaseChatOverlay

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
@@ -241,12 +241,18 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
           {messages.map((message) => {
             const depth = getMessageDepth(message);
             const replyTarget = Number.isInteger(message.parentId) ? messagesById[message.parentId] ?? null : null;
+            const isOwnMessage = message.authorId === Number(userId);
 
             return (
-              <div key={message.id} className="mb-2" style={{ marginLeft: `${depth * 12}px` }}>
-                <small className="text-muted d-block">{message.authorId === Number(userId) ? t('sessionDetail.chatYouAuthor') : resolveDisplayName(message, participantsByUserId, isAnonymousPhase, t)}</small>
-                {replyTarget ? <div className="small text-muted border-start ps-2 mb-1">↪ {replyTarget.content}</div> : null}
-                <div className="bg-light rounded px-2 py-1">{message.content}</div>
+              <div key={message.id} className={`mb-2 d-flex flex-column ${isOwnMessage ? 'align-items-end' : 'align-items-start'}`} style={{ marginLeft: `${depth * 12}px` }}>
+                <small className="text-muted d-block">{isOwnMessage ? t('sessionDetail.chatYouAuthor') : resolveDisplayName(message, participantsByUserId, isAnonymousPhase, t)}</small>
+                {replyTarget ? <div className={`small text-muted mb-1 px-2 ${isOwnMessage ? 'border-end pe-2 text-end' : 'border-start ps-2 text-start'}`}>↪ {replyTarget.content}</div> : null}
+                <div
+                  className="rounded px-2 py-1 text-dark border shadow-sm"
+                  style={{ maxWidth: '85%', backgroundColor: isOwnMessage ? '#deffcf' : '#ffffff' }}
+                >
+                  {message.content}
+                </div>
                 <button
                   type="button"
                   className="btn btn-link btn-sm p-0 mt-1 text-decoration-none"


### PR DESCRIPTION
### Motivation
- Improve readability of the session chat by visually distinguishing the current user's messages and aligning replies for clearer context.

### Description
- Introduced `isOwnMessage` to detect messages authored by the current user and apply conditional layout and alignment.
- Aligned own messages to the right and other messages to the left by adding `align-items-end`/`align-items-start` and updated container classes accordingly.
- Enhanced reply preview and message bubble styling with conditional borders, text alignment, a subtle shadow, and a highlighted background for own messages (`#deffcf`) while constraining bubble width to `85%`.
- Kept existing reply action and messaging flow while updating visual presentation in `PhaseChatOverlay.jsx`.

### Testing
- Ran the frontend unit test suite and linting (`npm test`, `npm run lint`) and they completed successfully.
- Performed a quick UI smoke check to verify message alignment, reply preview placement, and bubble styling in the chat overlay.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2715f8c14832bbc8da6f99493f766)