### PR TITLE
[codex] Add group response dashboard modal

### DIFF
--- a/ethicapp/backend/controllers/activities/activities-teacher.js
+++ b/ethicapp/backend/controllers/activities/activities-teacher.js
@@ -186,6 +186,43 @@ router.get("/activities/:session_id/responses", async (req, res) => {
     }
 });
 
+router.get("/groups/:group_id/responses", async (req, res) => {
+    if (!requireRole(req, res, "P")) {
+        return;
+    }
+
+    const { group_id: groupId } = req.params;
+    const { phase_id: phaseId } = req.query;
+
+    if (!groupId || isNaN(Number(groupId))) {
+        return res.status(400).json({ error: "Invalid or missing required parameter: group_id" });
+    }
+
+    if (!phaseId || isNaN(Number(phaseId))) {
+        return res.status(400).json({ error: "Invalid or missing required query parameter: phase_id" });
+    }
+
+    try {
+        const designType = await getDesignTypeByGroupAndPhase(groupId, phaseId);
+
+        const handler = groupResponsesFetchHandlers[designType];
+        if (!handler) {
+            return res.status(400).json({ error: `Unsupported design type: ${designType}` });
+        }
+
+        const responses = await handler(groupId, phaseId);
+
+        return res.status(200).json({ responses });
+    } catch (err) {
+        if (err.message === "GROUP_PHASE_MISMATCH") {
+            return res.status(404).json({ error: "Group not found for this phase." });
+        }
+
+        console.error(`Error fetching responses for group_id: ${groupId}, phase_id: ${phaseId}`, err);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+});
+
 router.post("/activities/:session_id/phase_transition", async (req, res) => {
     if (!requireRole(req, res, "P")) {
         return;
@@ -438,6 +475,46 @@ async function fetchSemanticDifferentialResponses(sessionId) {
     return results;
 }
 
+async function fetchSemanticDifferentialGroupResponses(groupId, phaseId) {
+    const results = await rpg2.execSQL({
+        sql: `
+            SELECT d.stageid,
+                   d.orden,
+                   d.id AS did,
+                   tu.uid,
+                   u.name AS user_name,
+                   tu.tmid,
+                   s.sel,
+                   s.comment,
+                   s.stime
+            FROM differential AS d
+            INNER JOIN teamusers AS tu
+                ON tu.tmid = $1
+            INNER JOIN users AS u
+                ON u.id = tu.uid
+            LEFT JOIN differential_selection AS s
+                ON s.did = d.id
+               AND s.uid = tu.uid
+            WHERE d.stageid = $2
+            ORDER BY d.orden, u.name
+        `,
+        dbcon: config.dbconnString,
+        sqlParams: [rpg2.param("plain", groupId), rpg2.param("plain", phaseId)],
+    });
+
+    return results.map(row => ({
+        phaseId: row.stageid,
+        questionOrder: row.orden,
+        questionId: row.did,
+        userId: row.uid,
+        userName: row.user_name,
+        groupId: row.tmid,
+        value: row.sel,
+        comment: row.comment,
+        submittedAt: row.stime,
+    }));
+}
+
 async function fetchRankingResponses(sessionId) {
     const results = await rpg2.execSQL({
         sql: `
@@ -460,9 +537,80 @@ async function fetchRankingResponses(sessionId) {
     return results;
 }
 
+async function fetchRankingGroupResponses(groupId, phaseId) {
+    const results = await rpg2.execSQL({
+        sql: `
+            SELECT a.id,
+                   a.description,
+                   a.orden,
+                   a.actorid,
+                   tu.uid,
+                   u.name AS user_name,
+                   tu.tmid,
+                   a.stime
+            FROM teamusers AS tu
+            INNER JOIN users AS u
+                ON u.id = tu.uid
+            LEFT JOIN actor_selection AS a
+                ON a.uid = tu.uid
+               AND a.stageid = $2
+            WHERE tu.tmid = $1
+            ORDER BY tu.uid, a.orden
+        `,
+        dbcon: config.dbconnString,
+        sqlParams: [rpg2.param("plain", groupId), rpg2.param("plain", phaseId)],
+    });
+
+    return results.map(row => ({
+        phaseId,
+        selectionId: row.id,
+        description: row.description,
+        order: row.orden,
+        actorId: row.actorid,
+        userId: row.uid,
+        userName: row.user_name,
+        groupId: row.tmid,
+        submittedAt: row.stime,
+    }));
+}
+
+async function getDesignTypeByGroupAndPhase(groupId, phaseId) {
+    const groupPhase = await rpg2.execSQL({
+        sql: `
+            SELECT id
+            FROM teams
+            WHERE id = $1
+              AND stageid = $2
+        `,
+        dbcon: config.dbconnString,
+        sqlParams: [rpg2.param("plain", groupId), rpg2.param("plain", phaseId)],
+    });
+
+    if (groupPhase.length === 0) {
+        throw new Error("GROUP_PHASE_MISMATCH");
+    }
+
+    return getDesignTypeBySessionId(
+        await rpg2.singleSQL({
+            sql: `
+                SELECT sesid
+                FROM stages
+                WHERE id = $1
+            `,
+            dbcon: config.dbconnString,
+            sqlParams: [rpg2.param("plain", phaseId)],
+        }).then(row => row.sesid)
+    );
+}
+
 const activityResponsesFetchHandlers = {
     semantic_differential: fetchSemanticDifferentialResponses,
     ranking: fetchRankingResponses,
+};
+
+const groupResponsesFetchHandlers = {
+    semantic_differential: fetchSemanticDifferentialGroupResponses,
+    ranking: fetchRankingGroupResponses,
 };
 
 export default router;

--- a/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
@@ -2,6 +2,7 @@ import * as PhaseCreationHelpers from "../../helpers/phase-creation-helpers.js";
 import * as DesignHelpers from "../../helpers/design-helpers.js";
 import { DashboardDataJoiners } from "../../helpers/dashboard-data-joiners.js";
 import { openSemanticDifferentialIndividualResponseModal } from "../../helpers/dashboard-individual-response-modal.helper.js";
+import { openSemanticDifferentialGroupResponseModal } from "../../helpers/dashboard-group-response-modal.helper.js";
 
 /*eslint func-style: ["error", "expression"]*/
 export function DashboardController($scope, $routeParams, $http, 
@@ -28,6 +29,37 @@ export function DashboardController($scope, $routeParams, $http,
 
         const hydratedPhaseData = vm.hydratePhaseDataForIndividualModal(phaseData);
         openSemanticDifferentialIndividualResponseModal($uibModal, response, hydratedPhaseData);
+    };
+
+    vm.openGroupResponseModal = async function(group, phaseData) {
+        if (!group?.groupStatistics || !group.groupId || !phaseData || vm.designObj?.type !== "semantic_differential") {
+            return;
+        }
+
+        const hydratedPhaseData = vm.hydratePhaseDataForIndividualModal(phaseData);
+        const phaseId = hydratedPhaseData?.descriptor?.id;
+        const firstQuestionId = hydratedPhaseData?.descriptor?.questions?.[0]?.id;
+
+        if (!phaseId || !firstQuestionId) {
+            return;
+        }
+
+        try {
+            const [responses, chatMessages] = await Promise.all([
+                ActivityStateService.getGroupResponses(group.groupId, phaseId),
+                ActivityStateService.getChatMessages(group.groupId, firstQuestionId),
+            ]);
+
+            openSemanticDifferentialGroupResponseModal(
+                $uibModal,
+                group,
+                hydratedPhaseData,
+                responses,
+                chatMessages
+            );
+        } catch (error) {
+            console.error("Error opening group response modal:", error);
+        }
     };
 
     vm.hydratePhaseDataForIndividualModal = function(phaseData) {

--- a/ethicapp/frontend/assets/js/directives/group-phase-table.directive.js
+++ b/ethicapp/frontend/assets/js/directives/group-phase-table.directive.js
@@ -5,7 +5,8 @@ let groupPhaseTableDirective = function() {
         restrict: 'E',
         scope: {
             phaseData: '<',  // Processed group-phase data
-            designType: '<'  // Design type ('ranking', 'semantic_differential', etc.)
+            designType: '<',  // Design type ('ranking', 'semantic_differential', etc.)
+            onSelectGroup: '&?'
         },
         bindToController: true, // Bind the scope properties to the controller
         controllerAs: 'gptCtrl', // Alias for the controller        
@@ -150,7 +151,20 @@ let groupPhaseTableDirective = function() {
                     return `/assets/static/views/teacher/fragments/default-template.html`;
                 }
                 return template;
-            };            
+            };
+
+            gptCtrl.onGroupRowClick = function(group) {
+                if (gptCtrl.designType !== 'semantic_differential' || !group?.groupStatistics) {
+                    return;
+                }
+
+                if (typeof gptCtrl.onSelectGroup === 'function') {
+                    gptCtrl.onSelectGroup({
+                        group,
+                        phaseData: gptCtrl.phaseData,
+                    });
+                }
+            };
         },
         template: `
         <div>

--- a/ethicapp/frontend/assets/js/directives/phase-state.directive.js
+++ b/ethicapp/frontend/assets/js/directives/phase-state.directive.js
@@ -4,7 +4,8 @@ let phaseStateDirective = function() {
         scope: {
             designType: '<',
             phaseData: '<',
-            onSelectResponse: '&?'
+            onSelectResponse: '&?',
+            onSelectGroup: '&?'
         },
         bindToController: true,
         controllerAs: 'ctrl',

--- a/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
@@ -85,9 +85,9 @@ let sdPhaseDataJoiner = (phaseDescriptor, responses, users,
 
         // Assign chat statistics (e.g., chatR1, chatR2) to corresponding users
         relevantChats
-            .filter(chat => chat.did === question.id)
+            .filter(chat => Number(chat.did || chat.questionId) === Number(question.id))
             .forEach(chat => {
-                const user = usersMap[chat.uid];
+                const user = usersMap[chat.uid || chat.userId];
                 if (user) {
                     user[`chatR${questionNumber}`] = chat.messageCount; // Assign chat count
                 }
@@ -169,7 +169,7 @@ let rankingPhaseDataJoiner = (phaseDescriptor, responses, users,
 
         // Sum up chat counts for each user
         relevantChats.forEach(chat => {
-            const user = usersMap[chat.uid];
+            const user = usersMap[chat.uid || chat.userId];
             if (user) {
                 user.chatCount += chat.messageCount || 0;
             }
@@ -209,7 +209,7 @@ let rankingPhaseDataJoiner = (phaseDescriptor, responses, users,
 
             // Update chat counts
             relevantChats
-                .filter(chat => chat.uid === user.uid)
+                .filter(chat => (chat.uid || chat.userId) === user.uid)
                 .forEach(chat => {
                     existingUser.chatCount += chat.messageCount || 0;
                 });
@@ -338,6 +338,7 @@ let updateGroupStatistics = function(data, translator) {
         // Create the group summary object
         const groupSummary = {
             groupStatistics: true,
+            groupId,
             groupName,
             groupNumber,
             ...chatStats,

--- a/ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js
@@ -1,0 +1,113 @@
+function normalizeQuestion(question, index) {
+    const ansFormat = question?.ans_format || {};
+
+    const normalizedNumber = Number(
+        question?.number
+        || question?.order
+        || question?.itemNumber
+        || index + 1
+    );
+
+    return {
+        ...question,
+        number: normalizedNumber,
+        text: question?.text
+            || question?.q_text
+            || question?.qText
+            || question?.question
+            || question?.name
+            || question?.title
+            || question?.label
+            || null,
+        leftPole: question?.leftPole
+            || question?.left_pole
+            || question?.l_pole
+            || question?.tleft
+            || ansFormat?.l_pole
+            || null,
+        rightPole: question?.rightPole
+            || question?.right_pole
+            || question?.r_pole
+            || question?.tright
+            || ansFormat?.r_pole
+            || null,
+        range: Number(
+            question?.range
+            || question?.num
+            || question?.values
+            || ansFormat?.values
+            || 0
+        ),
+        justify: typeof question?.justify === "boolean"
+            ? question.justify
+            : (typeof question?.justificationRequired === "boolean"
+                ? question.justificationRequired
+                : Boolean(ansFormat?.just_required)),
+    };
+}
+
+function createModalController() {
+    return ["$uibModalInstance", "data", function($uibModalInstance, data) {
+        const $ctrl = this;
+
+        $ctrl.group = data.group;
+        $ctrl.phaseData = data.phaseData;
+        $ctrl.responses = data.responses || [];
+        $ctrl.chatMessages = data.chatMessages || [];
+        $ctrl.questions = (data.phaseData?.descriptor?.questions || [])
+            .map((question, index) => normalizeQuestion(question, index));
+
+        const participantNames = $ctrl.responses.reduce((acc, response) => {
+            if (response.userId && response.userName) {
+                acc[response.userId] = response.userName;
+            }
+            return acc;
+        }, {});
+
+        $ctrl.buildScaleOptions = function(question) {
+            const range = Number(question?.range) || 0;
+            return Array.from({ length: range }, (_, i) => i + 1);
+        };
+
+        $ctrl.getGroupFallbackTitle = function() {
+            return `Group ${$ctrl.group?.groupNumber || ""}`.trim();
+        };
+
+        $ctrl.getQuestionResponses = function(question) {
+            const questionId = Number(question?.id);
+            const questionNumber = Number(question?.number);
+
+            return $ctrl.responses.filter((response) => {
+                const sameQuestionId = questionId && Number(response.questionId) === questionId;
+                const sameQuestionOrder = questionNumber && Number(response.questionOrder) === questionNumber;
+                return sameQuestionId || sameQuestionOrder;
+            });
+        };
+
+        $ctrl.getUserName = function(userId) {
+            return participantNames[userId] || `User ${userId}`;
+        };
+
+        $ctrl.close = function() {
+            $uibModalInstance.dismiss("close");
+        };
+    }];
+}
+
+export function openSemanticDifferentialGroupResponseModal($uibModal, group, phaseData, responses, chatMessages) {
+    if (!group || !phaseData) {
+        return null;
+    }
+
+    return $uibModal.open({
+        animation: true,
+        size: "lg",
+        backdrop: "static",
+        templateUrl: "/assets/static/views/teacher/fragments/sd-group-response-modal.template.html",
+        controllerAs: "$ctrl",
+        controller: createModalController(),
+        resolve: {
+            data: () => ({ group, phaseData, responses, chatMessages }),
+        },
+    });
+}

--- a/ethicapp/frontend/assets/js/services/activity-state.service.js
+++ b/ethicapp/frontend/assets/js/services/activity-state.service.js
@@ -387,8 +387,8 @@ let ActivityStateService = function($http, TeacherSocketService) {
                 const response = await $http.get(`/phases/${phaseId}/message_count`);
                 
                 // Check if the response data is valid and contains the expected "messages" field
-                if (response && response.data && Array.isArray(response.messageCount)) {
-                    return response.messageCount; // Return the list of message counts
+                if (response && response.data && Array.isArray(response.data.messageCount)) {
+                    return response.data.messageCount; // Return the list of message counts
                 } else {
                     console.warn("Unexpected response format:", response);
                     return []; // Return an empty array if the format is not as expected
@@ -421,7 +421,7 @@ let ActivityStateService = function($http, TeacherSocketService) {
         getChatMessages: async function(groupId, questionId) {
             try {
                 // Make the HTTP GET request to the endpoint
-                const response = await $http.get(`/groups/${groupId}/question/${questionId}/chat`);
+                const response = await $http.get(`/groups/${groupId}/question/${questionId}/chat_messages`);
                 
                 // Check if the response data is valid and contains the expected "chat_transcript" field
                 if (response && response.data && Array.isArray(response.data.chat_transcript)) {
@@ -434,6 +434,24 @@ let ActivityStateService = function($http, TeacherSocketService) {
                 // Log the error for debugging purposes
                 console.error("Error fetching chat messages:", error);
                 return []; // Return an empty array in case of an error
+            }
+        },
+
+        getGroupResponses: async function(groupId, phaseId) {
+            try {
+                const response = await $http.get(`/groups/${groupId}/responses`, {
+                    params: { phase_id: phaseId },
+                });
+
+                if (response?.data && Array.isArray(response.data.responses)) {
+                    return response.data.responses;
+                }
+
+                console.warn("Unexpected response format:", response);
+                return [];
+            } catch (error) {
+                console.error(`Error fetching responses for group ${groupId} in phase ${phaseId}:`, error);
+                return [];
             }
         },
 

--- a/ethicapp/frontend/assets/static/views/teacher/activity.view.html
+++ b/ethicapp/frontend/assets/static/views/teacher/activity.view.html
@@ -70,7 +70,8 @@
                                     <phase-state
                                         phase-data="phase"
                                         design-type="dc.designObj.type"
-                                        on-select-response="dc.openIndividualResponseModal(response, phaseData)">
+                                        on-select-response="dc.openIndividualResponseModal(response, phaseData)"
+                                        on-select-group="dc.openGroupResponseModal(group, phaseData)">
                                     </phase-state>
                                 </div>
                             </div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/phase-state.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/phase-state.template.html
@@ -8,7 +8,10 @@
         </individual-phase-table>
     </div>
     <div ng-if="ctrl.phaseData.descriptor.mode === 'team'">
-        <group-phase-table phase-data="ctrl.phaseData" design-type="ctrl.designType">
+        <group-phase-table
+            phase-data="ctrl.phaseData"
+            design-type="ctrl.designType"
+            on-select-group="ctrl.onSelectGroup({ group: group, phaseData: phaseData })">
         </group-phase-table>
     </div>
 </div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
@@ -1,0 +1,88 @@
+<div class="modal-header">
+    <button type="button" class="close" ng-click="$ctrl.close()" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <h4 class="modal-title">
+        {{ $ctrl.group.groupName || $ctrl.getGroupFallbackTitle() }}
+    </h4>
+</div>
+
+<div class="modal-body" ng-if="$ctrl.questions.length > 0">
+    <div class="panel panel-default" ng-repeat="question in $ctrl.questions track by question.number">
+        <div class="panel-heading">
+            <strong>{{ 'item_label' | translate }} {{ $index + 1 }}</strong>
+        </div>
+        <div class="panel-body">
+            <p>
+                {{ question.text || ('no_response' | translate) }}
+            </p>
+
+            <div ng-if="$ctrl.getQuestionResponses(question).length === 0">
+                <p class="text-muted">{{ 'no_response' | translate }}</p>
+            </div>
+
+            <div class="panel panel-default"
+                 ng-repeat="response in $ctrl.getQuestionResponses(question) track by response.userId"
+                 style="margin-bottom: .75em;">
+                <div class="panel-heading">
+                    <strong>{{ response.userName }}</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="row" style="margin-top: .25em; margin-bottom: .75em;">
+                        <div class="col-sm-3 text-right">
+                            <strong>{{ question.leftPole || ('left_pole_label' | translate) }}</strong>
+                        </div>
+                        <div class="col-sm-6 text-center">
+                            <label class="radio-inline"
+                                   ng-repeat="option in $ctrl.buildScaleOptions(question) track by option"
+                                   style="margin-right: .5em; margin-left: .5em;">
+                                <input type="radio"
+                                       disabled
+                                       ng-checked="response.value == option">
+                                {{ option }}
+                            </label>
+                        </div>
+                        <div class="col-sm-3 text-left">
+                            <strong>{{ question.rightPole || ('right_pole_label' | translate) }}</strong>
+                        </div>
+                    </div>
+
+                    <div class="form-group" ng-if="question.justify">
+                        <label>{{ 'comment' | translate }}</label>
+                        <textarea class="form-control"
+                                  rows="3"
+                                  readonly>{{ response.comment || ('no_response' | translate) }}</textarea>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <strong>{{ 'chat_messages_label' | translate }}</strong>
+        </div>
+        <div class="panel-body">
+            <p class="text-muted" ng-if="$ctrl.chatMessages.length === 0">{{ 'no_response' | translate }}</p>
+            <div class="media" ng-repeat="message in $ctrl.chatMessages track by message.id">
+                <div class="media-body">
+                    <h5 class="media-heading">
+                        {{ $ctrl.getUserName(message.uid) }}
+                        <small>{{ message.stime | date:'short' }}</small>
+                    </h5>
+                    <p>{{ message.content }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal-body" ng-if="$ctrl.questions.length === 0">
+    <p>{{ 'no_response' | translate }}</p>
+</div>
+
+<div class="modal-footer">
+    <button type="button" class="btn btn-default btn-sm" ng-click="$ctrl.close()">
+        {{ 'back' | translate }}
+    </button>
+</div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-results-table.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-results-table.template.html
@@ -12,7 +12,10 @@
         </tr>
     </thead>
     <tbody>
-        <tr ng-repeat="user in gptCtrl.phaseData.state track by $index" ng-class="{'group-summary': user.groupStatistics}">
+        <tr ng-repeat="user in gptCtrl.phaseData.state track by $index"
+            ng-class="{'group-summary': user.groupStatistics}"
+            ng-click="gptCtrl.onGroupRowClick(user)"
+            ng-style="user.groupStatistics && {'cursor': 'pointer'}">
             <td>
                 <span ng-if="!user.groupStatistics">{{ user.userName }}</span>
                 <strong ng-if="user.groupStatistics">{{ user.groupName }}</strong>


### PR DESCRIPTION
## Context

Teacher dashboards already support opening a semantic differential individual response modal from individual phase tables. Team phases showed group summaries, but there was no equivalent drill-down for a group.

## What changed

- Added a teacher endpoint to fetch responses for a specific group and phase.
- Added group dashboard row selection for semantic differential group summaries.
- Added a semantic differential group response modal showing each question followed by current member responses.
- Added the group chat transcript at the end of the modal, using the first question as the phase chat room.
- Fixed teacher chat transcript fetching to call the existing `/chat_messages` endpoint.
- Fixed dashboard chat count handling to read the current message-count payload shape.

## Verification

- `git diff --check`
- `node --check ethicapp/backend/controllers/activities/activities-teacher.js`
- `node --check ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js`
- `node --check ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js`
- `node --check ethicapp/frontend/assets/js/services/activity-state.service.js`
- `node --check ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js`
- `node --check ethicapp/frontend/assets/js/directives/phase-state.directive.js`
- `node --check ethicapp/frontend/assets/js/directives/group-phase-table.directive.js`

## Notes

Full build/lint was not run because this checkout does not have `node_modules` installed.