### PR TITLE
[codex] Open individual modal from group dashboard rows

### DIFF
--- a/ethicapp/frontend/assets/js/directives/group-phase-table.directive.js
+++ b/ethicapp/frontend/assets/js/directives/group-phase-table.directive.js
@@ -6,6 +6,7 @@ let groupPhaseTableDirective = function() {
         scope: {
             phaseData: '<',  // Processed group-phase data
             designType: '<',  // Design type ('ranking', 'semantic_differential', etc.)
+            onSelectResponse: '&?',
             onSelectGroup: '&?'
         },
         bindToController: true, // Bind the scope properties to the controller
@@ -153,14 +154,22 @@ let groupPhaseTableDirective = function() {
                 return template;
             };
 
-            gptCtrl.onGroupRowClick = function(group) {
-                if (gptCtrl.designType !== 'semantic_differential' || !group?.groupStatistics) {
+            gptCtrl.onRowClick = function(row) {
+                if (gptCtrl.designType !== 'semantic_differential') {
                     return;
                 }
 
-                if (typeof gptCtrl.onSelectGroup === 'function') {
+                if (row?.groupStatistics && typeof gptCtrl.onSelectGroup === 'function') {
                     gptCtrl.onSelectGroup({
-                        group,
+                        group: row,
+                        phaseData: gptCtrl.phaseData,
+                    });
+                    return;
+                }
+
+                if (!row?.groupStatistics && typeof gptCtrl.onSelectResponse === 'function') {
+                    gptCtrl.onSelectResponse({
+                        response: row,
                         phaseData: gptCtrl.phaseData,
                     });
                 }

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/phase-state.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/phase-state.template.html
@@ -11,6 +11,7 @@
         <group-phase-table
             phase-data="ctrl.phaseData"
             design-type="ctrl.designType"
+            on-select-response="ctrl.onSelectResponse({ response: response, phaseData: phaseData })"
             on-select-group="ctrl.onSelectGroup({ group: group, phaseData: phaseData })">
         </group-phase-table>
     </div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-results-table.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-results-table.template.html
@@ -14,8 +14,8 @@
     <tbody>
         <tr ng-repeat="user in gptCtrl.phaseData.state track by $index"
             ng-class="{'group-summary': user.groupStatistics}"
-            ng-click="gptCtrl.onGroupRowClick(user)"
-            ng-style="user.groupStatistics && {'cursor': 'pointer'}">
+            ng-click="gptCtrl.onRowClick(user)"
+            style="cursor: pointer;">
             <td>
                 <span ng-if="!user.groupStatistics">{{ user.userName }}</span>
                 <strong ng-if="user.groupStatistics">{{ user.groupName }}</strong>


### PR DESCRIPTION
## Context

The group dashboard modal from PR #499 lets teachers inspect a group summary row. The same table can also expose the existing individual response modal for participant rows.

## What changed

- Added `onSelectResponse` support to `group-phase-table`.
- Routed participant rows in the semantic differential group table to the existing individual response modal.
- Kept group summary rows opening the group response modal.
- Made all semantic differential group table rows visibly clickable.

## Verification

- `node --check ethicapp/frontend/assets/js/directives/group-phase-table.directive.js`
- `git diff --check`

## Notes

This is a small follow-up on top of PR #499, which was already merged into `ethicapp-v2-gdpr`.