### PR TITLE
[codex] Refresh dashboard chat counts from socket events

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
@@ -15,6 +15,7 @@ export function DashboardController($scope, $routeParams, $http,
     vm.userList = [];
     vm.reachedLastPhase = false;
     vm.dashboardPhaseData = [];
+    vm.dashboardPhaseUpdateState = new Map();
     
     vm.selectedTab = 0; // Default to the first tab
 
@@ -279,6 +280,22 @@ export function DashboardController($scope, $routeParams, $http,
     };
 
     vm.updateDashboardPhaseData = async (phaseId) => {    
+        const updateKey = Number(phaseId);
+        const updateState = vm.dashboardPhaseUpdateState.get(updateKey) || {
+            inProgress: false,
+            queued: false,
+        };
+
+        if (updateState.inProgress) {
+            updateState.queued = true;
+            vm.dashboardPhaseUpdateState.set(updateKey, updateState);
+            return;
+        }
+
+        updateState.inProgress = true;
+        updateState.queued = false;
+        vm.dashboardPhaseUpdateState.set(updateKey, updateState);
+
         try {
             let phaseData = vm.dashboardPhaseData.find(pd => pd.descriptor.id == phaseId);
 
@@ -302,6 +319,17 @@ export function DashboardController($scope, $routeParams, $http,
             }
         } catch(error) {
             console.error("Error updating dashboard phase state:", error);
+        } finally {
+            const latestUpdateState = vm.dashboardPhaseUpdateState.get(updateKey);
+            if (latestUpdateState?.queued) {
+                latestUpdateState.inProgress = false;
+                latestUpdateState.queued = false;
+                vm.dashboardPhaseUpdateState.set(updateKey, latestUpdateState);
+                vm.updateDashboardPhaseData(phaseId);
+                return;
+            }
+
+            vm.dashboardPhaseUpdateState.delete(updateKey);
         }
     };
     
@@ -438,12 +466,12 @@ export function DashboardController($scope, $routeParams, $http,
     };
 
     vm.defaultEventHandler = function (data) {
-        const currentPhaseId = vm?.activityState?.descriptor?.currentPhase?.id;
-        if (!currentPhaseId) {
-            console.warn("Unable to resolve the current phase");
+        const phaseId = data?.phaseId || data?.response?.phaseId || vm?.activityState?.descriptor?.currentPhase?.id;
+        if (!phaseId) {
+            console.warn("Unable to resolve the phase to refresh");
             return;
         }
-        vm.updateDashboardPhaseData(currentPhaseId);
+        vm.updateDashboardPhaseData(phaseId);
     };
 
     vm.activatePhaseTabById = function(phaseId, retryCount = 8) {

--- a/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
@@ -94,6 +94,11 @@ let sdPhaseDataJoiner = (phaseDescriptor, responses, users,
             });
     });
 
+    Object.values(usersMap).forEach(user => {
+        user.totalChatCount = questions.reduce((total, question) =>
+            total + Number(user[`chatR${question.number}`] || 0), 0);
+    });
+
     // If no existingData is provided, return the newly created data structure
     if (!existingData) {
         return Object.values(usersMap);

--- a/ethicapp/frontend/assets/js/services/activity-state.service.js
+++ b/ethicapp/frontend/assets/js/services/activity-state.service.js
@@ -1,8 +1,13 @@
 import * as PhaseCreationHelpers from "../helpers/phase-creation-helpers.js";
 
 let ActivityStateService = function($http, TeacherSocketService) {
+    const CHAT_NOTIFY_THROTTLE_MS = 3000;
+    const CHAT_REFRESH_WATCHDOG_MS = 10000;
+
     const service = {
         subscriptionsMap: new Map(), // Subscription to socket events
+        chatNotificationState: new Map(),
+        chatRefreshIntervals: new Map(),
         activityStates: {}, // Activity states
         listeners: {}, // Subscribed listeners
         rankingResponseMerger: async function(sessionId, response, responses) {
@@ -207,15 +212,14 @@ let ActivityStateService = function($http, TeacherSocketService) {
                 })                
             );
         
+            service.startChatRefreshWatchdog(sessionId);
+
             // Subscribe to `onChatMessage`
             subscriptions.push(
                 TeacherSocketService.fromEvent('onChatMessage').subscribe({
                     next: (data) => {
                         console.debug(`New chat message ${sessionId}:`, data);
-
-                        // Notify listeners
-                        service.notifyListeners("onChatMessage", { 
-                            messages: data.messages });                        
+                        service.handleChatMessageNotification(sessionId, data);
                     },
                     error: (err) => console.error(`Websocket error for phaseChanged in session ${sessionId}:`, err),
                 })
@@ -225,6 +229,8 @@ let ActivityStateService = function($http, TeacherSocketService) {
             const unsubscribeAll = () => {
                 subscriptions.forEach((subscription) => subscription.unsubscribe());
                 TeacherSocketService.leaveSession(sessionId);
+                service.stopChatRefreshWatchdog(sessionId);
+                service.clearChatNotificationState(sessionId);
                 service.subscriptionsMap.delete(sessionId); // Remove from the map
             };
         
@@ -232,6 +238,128 @@ let ActivityStateService = function($http, TeacherSocketService) {
             service.subscriptionsMap.set(sessionId, { subscriptions, unsubscribeAll });
         
             return unsubscribeAll; // Return the unsubscribe function
+        },
+
+        handleChatMessageNotification: function(sessionId, data) {
+            const phaseId = Number(data?.phaseId);
+            if (!phaseId) {
+                console.warn("[ActivityStateService] Received chat notification without phaseId.", data);
+                return;
+            }
+
+            const notificationKey = `${sessionId}:${phaseId}`;
+            const now = Date.now();
+            const state = service.chatNotificationState.get(notificationKey) || {
+                lastNotifiedAt: 0,
+                trailingTimeoutId: null,
+                latestData: null,
+            };
+
+            state.latestData = data;
+            const elapsed = now - state.lastNotifiedAt;
+
+            if (elapsed >= CHAT_NOTIFY_THROTTLE_MS) {
+                if (state.trailingTimeoutId) {
+                    clearTimeout(state.trailingTimeoutId);
+                    state.trailingTimeoutId = null;
+                }
+
+                service.emitChatDashboardRefresh(sessionId, phaseId, data, "socket");
+                state.lastNotifiedAt = now;
+                service.chatNotificationState.set(notificationKey, state);
+                return;
+            }
+
+            if (!state.trailingTimeoutId) {
+                state.trailingTimeoutId = setTimeout(() => {
+                    const latestState = service.chatNotificationState.get(notificationKey);
+                    if (!latestState) {
+                        return;
+                    }
+
+                    latestState.trailingTimeoutId = null;
+                    latestState.lastNotifiedAt = Date.now();
+                    service.emitChatDashboardRefresh(
+                        sessionId,
+                        phaseId,
+                        latestState.latestData,
+                        "socket-trailing"
+                    );
+                    service.chatNotificationState.set(notificationKey, latestState);
+                }, CHAT_NOTIFY_THROTTLE_MS - elapsed);
+            }
+
+            service.chatNotificationState.set(notificationKey, state);
+        },
+
+        emitChatDashboardRefresh: function(sessionId, phaseId, data, reason) {
+            service.notifyListeners("onChatMessage", {
+                ...data,
+                sessionId,
+                phaseId,
+                refreshReason: reason,
+            });
+        },
+
+        startChatRefreshWatchdog: function(sessionId) {
+            if (service.chatRefreshIntervals.has(sessionId)) {
+                return;
+            }
+
+            const intervalId = setInterval(() => {
+                const activityState = service.activityStates[sessionId];
+                const descriptor = activityState?.descriptor;
+                const currentPhase = descriptor?.currentPhase;
+                const currentPhaseDescriptor = descriptor?.phases?.find((phase) =>
+                    Number(phase.id) === Number(currentPhase?.id)
+                ) || currentPhase;
+
+                if (!currentPhase || descriptor?.status === "finished" || !currentPhaseDescriptor?.chat) {
+                    return;
+                }
+
+                const phaseId = Number(currentPhase.id);
+                const notificationKey = `${sessionId}:${phaseId}`;
+                const state = service.chatNotificationState.get(notificationKey);
+                const lastNotifiedAt = state?.lastNotifiedAt || 0;
+
+                if (Date.now() - lastNotifiedAt >= CHAT_REFRESH_WATCHDOG_MS) {
+                    service.emitChatDashboardRefresh(sessionId, phaseId, {
+                        phaseId,
+                    }, "watchdog");
+                    service.chatNotificationState.set(notificationKey, {
+                        ...(state || {}),
+                        lastNotifiedAt: Date.now(),
+                        trailingTimeoutId: state?.trailingTimeoutId || null,
+                        latestData: state?.latestData || null,
+                    });
+                }
+            }, CHAT_REFRESH_WATCHDOG_MS);
+
+            service.chatRefreshIntervals.set(sessionId, intervalId);
+        },
+
+        stopChatRefreshWatchdog: function(sessionId) {
+            const intervalId = service.chatRefreshIntervals.get(sessionId);
+            if (intervalId) {
+                clearInterval(intervalId);
+                service.chatRefreshIntervals.delete(sessionId);
+            }
+        },
+
+        clearChatNotificationState: function(sessionId) {
+            const prefix = `${sessionId}:`;
+            Array.from(service.chatNotificationState.entries()).forEach(([key, state]) => {
+                if (!key.startsWith(prefix)) {
+                    return;
+                }
+
+                if (state?.trailingTimeoutId) {
+                    clearTimeout(state.trailingTimeoutId);
+                }
+
+                service.chatNotificationState.delete(key);
+            });
         },
         
         getSessionUsers: async function(sessionId, refresh = false) {


### PR DESCRIPTION
## Context

The teacher dashboard already receives `onChatMessage` socket notifications and reloads phase dashboard data, but chat counters were not reliably updating in the group dashboard. The refresh path also refreshed the current phase by default and could fire too often under active chat load.

## What changed

- Preserved `phaseId` from incoming `onChatMessage` notifications and forwarded it to dashboard listeners.
- Refreshed the notified phase rather than always falling back to the current phase.
- Added a 3-second throttle with trailing refresh for chat-triggered dashboard updates.
- Added a 10-second watchdog refresh for the active running chat phase.
- Serialized dashboard refreshes per phase so repeated notifications do not create overlapping API refreshes.
- Added `totalChatCount` consolidation for semantic differential participant rows, so individual and group totals both update from `chatR*` counts.

## Verification

- `node --check ethicapp/frontend/assets/js/services/activity-state.service.js`
- `node --check ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js`
- `node --check ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js`
- `git diff --check origin/ethicapp-v2-gdpr...HEAD`

## Notes

Full build/lint was not run because this checkout does not have `node_modules` installed.