### PR TITLE
[codex] Constrain group modal chat transcript height

### DIFF
--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
@@ -64,13 +64,16 @@
         </div>
         <div class="panel-body">
             <p class="text-muted" ng-if="$ctrl.chatMessages.length === 0">{{ 'no_response' | translate }}</p>
-            <div class="media" ng-repeat="message in $ctrl.chatMessages track by message.id">
-                <div class="media-body">
-                    <h5 class="media-heading">
-                        {{ $ctrl.getUserName(message.uid) }}
-                        <small>{{ message.stime | date:'short' }}</small>
-                    </h5>
-                    <p>{{ message.content }}</p>
+            <div ng-if="$ctrl.chatMessages.length > 0"
+                 style="max-height: 24em; overflow-y: auto; padding-right: .5em;">
+                <div class="media" ng-repeat="message in $ctrl.chatMessages track by message.id">
+                    <div class="media-body">
+                        <h5 class="media-heading">
+                            {{ $ctrl.getUserName(message.uid) }}
+                            <small>{{ message.stime | date:'short' }}</small>
+                        </h5>
+                        <p>{{ message.content }}</p>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Context

The group response modal now includes the group chat transcript, but long conversations can make the modal too tall.

## What changed

- Wrapped chat messages in a fixed-height scrollable transcript area.
- Kept the empty-state message outside the scroll container.

## Verification

- `git diff --check`

## Notes

This is a small UI follow-up before exploring live teacher participation in group chats.