### PR TITLE
[codex] Add live teacher chat to group dashboard modal

### DIFF
--- a/database/create_41.sql
+++ b/database/create_41.sql
@@ -1,0 +1,8 @@
+ALTER TABLE differential_chat
+ADD COLUMN IF NOT EXISTS tmid integer references teams(id);
+
+ALTER TABLE chat
+ADD COLUMN IF NOT EXISTS tmid integer references teams(id);
+
+CREATE INDEX IF NOT EXISTS idx_differential_chat_tmid ON differential_chat(tmid);
+CREATE INDEX IF NOT EXISTS idx_chat_tmid ON chat(tmid);

--- a/ethicapp/backend/controllers/group-messages.js
+++ b/ethicapp/backend/controllers/group-messages.js
@@ -3,11 +3,10 @@
 import express from "express";
 import * as config from "../config/config.js"; 
 import * as rpg2 from "../db/rest-pg-2.js";
-import { getDesignById, getDesignTypeByPhaseId } from "../helpers/designs-helper.js";
-import * as SessionsHelper from "../helpers/sessions-helper.js"
+import { getDesignTypeByPhaseId } from "../helpers/designs-helper.js";
+import { getStatusCode } from "../../common/modules/session-status.js";
 import { messageCountHandlers, 
     chatTranscriptHandlers, 
-    chatInsertHandlers, 
     saveChatMessage } from "../helpers/chat-helper.js";
 import { studentNotifications, teacherNotifications } from "../config/socket.config.js";
 
@@ -67,6 +66,8 @@ router.get("/phases/:id/message_count", async (req, res) => {
  */
 router.get("/groups/:group_id/question/:question_id/chat_messages", async (req, res) => {
     const { group_id: groupId, question_id: questionId } = req.params;
+    const userId = req.session.uid;
+    const role = req.session.role;
 
     if (!groupId || !questionId) {
         return res.status(400).json({
@@ -75,27 +76,23 @@ router.get("/groups/:group_id/question/:question_id/chat_messages", async (req, 
     }
 
     try {
-        // Step 1: Determine the phase (stage) ID using the group (team) ID
-        const phaseIdResult = await rpg2.execSQL({
-            sql: `
-                SELECT stageid
-                FROM teams
-                WHERE id = $1
-            `,
-            dbcon: config.dbconnString,
-            sqlParams: [rpg2.param('plain', groupId)],
+        const accessContext = await resolveGroupChatAccessContext({
+            groupId,
+            questionId,
+            userId,
+            role,
         });
 
-        if (phaseIdResult.length === 0) {
-            return res.status(404).json({
-                error: "Group not found or not associated with any phase.",
-            });
+        if (!accessContext) {
+            return res.status(404).json({ error: "Group not found or not associated with any phase." });
         }
 
-        const phaseId = phaseIdResult[0].stageid;
+        if (!accessContext.canRead) {
+            return res.status(403).json({ error: "Access denied for this group chat." });
+        }
 
         // Step 2: Determine the design type for the phase
-        const designType = await getDesignTypeByPhaseId(phaseId);
+        const designType = await getDesignTypeByPhaseId(accessContext.phaseId);
 
         // Step 3: Fetch the appropriate handler for the design type
         const handler = chatTranscriptHandlers[designType];
@@ -142,36 +139,139 @@ router.post("/phases/:id/question/:question_id/chat_messages", async (req, res) 
     const userId = req.session.uid; // User ID from session
 
     // Validate required parameters
-    if (!phaseId || !questionId || !content) {
+    if (!phaseId || !questionId || !groupId || !content) {
         return res.status(400).json({
-            error: "Missing required parameters: phaseId, questionId, or content.",
+            error: "Missing required parameters: phaseId, questionId, groupId, or content.",
         });
     }
 
     try {
-        if (!await saveChatMessage({userId, phaseId, questionId, parentId, content})) {
+        const accessContext = await resolveGroupChatAccessContext({
+            groupId,
+            phaseId,
+            questionId,
+            userId,
+            role: req.session.role,
+        });
+
+        if (!accessContext) {
+            return res.status(404).json({ error: "Group not found for this phase." });
+        }
+
+        if (!accessContext.canPost) {
+            return res.status(403).json({ error: "Access denied or chat is read-only for this phase." });
+        }
+
+        const savedMessage = await saveChatMessage({userId, phaseId, questionId, groupId, parentId, content});
+        if (!savedMessage) {
             return res.status(400).json({
                 error: `Error saving the chat message`,
             });
         }
 
-        // Get the session Id
-        const sessionId = await SessionsHelper.getSessionIdByPhaseId(phaseId);
-
         // Step 4: Notify clients about the new message
-        teacherNotifications.chatMessage(sessionId, phaseId, questionId, groupId, content);
+        const notificationPayload = normalizeChatNotificationPayload(savedMessage, req.session.role);
+        teacherNotifications.chatMessage(accessContext.sessionId, phaseId, questionId, groupId, content);
+        teacherNotifications.groupChatMessage(groupId, {
+            ...notificationPayload,
+            phaseId: Number(phaseId),
+            questionId: Number(questionId),
+            groupId: Number(groupId),
+        });
         studentNotifications?.chatMessage(groupId);
 
         // Respond with success
         res.status(201).json({
             status: "ok",
             message: "Message posted successfully.",
+            chat_message: notificationPayload,
         });
     } catch (err) {
         console.error("Error posting chat message:", err); // Log the error for debugging
         res.status(500).json({ error: "Internal server error" });
     }
 });
+
+async function resolveGroupChatAccessContext({ groupId, phaseId = null, questionId, userId, role }) {
+    const rows = await rpg2.execSQL({
+        sql: `
+            SELECT t.id AS group_id,
+                   t.stageid AS phase_id,
+                   s.id AS session_id,
+                   s.creator,
+                   s.current_stage,
+                   s.status,
+                   st.chat,
+                   EXISTS (
+                       SELECT 1
+                       FROM teamusers AS tu
+                       WHERE tu.tmid = t.id
+                         AND tu.uid = $4
+                   ) AS is_group_member,
+                   EXISTS (
+                       SELECT 1
+                       FROM differential AS d
+                       WHERE d.id = $3
+                         AND d.stageid = t.stageid
+                   ) AS question_belongs_to_phase
+            FROM teams AS t
+            INNER JOIN stages AS st
+                ON st.id = t.stageid
+            INNER JOIN sessions AS s
+                ON s.id = st.sesid
+            WHERE t.id = $1
+              AND ($2::integer IS NULL OR t.stageid = $2)
+            LIMIT 1
+        `,
+        dbcon: config.dbconnString,
+        sqlParams: [
+            Number(groupId),
+            phaseId == null ? null : Number(phaseId),
+            Number(questionId),
+            Number(userId),
+        ],
+    });
+
+    if (rows.length === 0) {
+        return null;
+    }
+
+    const row = rows[0];
+    const designType = await getDesignTypeByPhaseId(row.phase_id);
+    if (designType === "semantic_differential" && !row.question_belongs_to_phase) {
+        return null;
+    }
+
+    const isTeacherOwner = role === "P" && Number(row.creator) === Number(userId);
+    const isStudentMember = role === "A" && row.is_group_member === true;
+    const activeStatus = getStatusCode("in_progress");
+    const isActiveChatPhase = Boolean(row.chat)
+        && Number(row.current_stage) === Number(row.phase_id)
+        && Number(row.status) === Number(activeStatus);
+
+    return {
+        phaseId: Number(row.phase_id),
+        sessionId: Number(row.session_id),
+        groupId: Number(row.group_id),
+        designType,
+        canRead: isTeacherOwner || isStudentMember,
+        canPost: (isTeacherOwner || isStudentMember) && isActiveChatPhase,
+    };
+}
+
+function normalizeChatNotificationPayload(message, role) {
+    return {
+        id: message.id,
+        uid: message.uid,
+        author_role: role,
+        groupId: message.tmid,
+        phaseId: message.stageid,
+        questionId: message.did,
+        content: message.content,
+        stime: message.stime,
+        parent_id: message.parent_id,
+    };
+}
 
 
 

--- a/ethicapp/backend/helpers/chat-helper.js
+++ b/ethicapp/backend/helpers/chat-helper.js
@@ -7,6 +7,7 @@ const flatChatMessageSchema = Yup.object({
     userId: Yup.number().integer().positive().required(),
     phaseId: Yup.number().integer().positive().required(),
     questionId: Yup.number().integer().positive().nullable(),
+    groupId: Yup.number().integer().positive().nullable(),
     parentId: Yup.number().integer().positive().nullable(),
     content: Yup.string().trim().min(1).max(2000).required(),
 });
@@ -19,6 +20,7 @@ const nestedChatMessageSchema = Yup.object({
         stageId: Yup.number().integer().positive(),
         itemId: Yup.number().integer().positive().nullable(),
         questionId: Yup.number().integer().positive().nullable(),
+        groupId: Yup.number().integer().positive().nullable(),
     }).required(),
     payload: Yup.object({
         parentId: Yup.number().integer().positive().nullable(),
@@ -39,6 +41,7 @@ function normalizeChatMessageInput(data) {
             userId,
             phaseId,
             questionId: Number.isFinite(questionId) ? questionId : null,
+            groupId: data.header.groupId == null ? null : Number(data.header.groupId),
             parentId,
             content,
         };
@@ -48,6 +51,7 @@ function normalizeChatMessageInput(data) {
         userId: Number(data?.userId),
         phaseId: Number(data?.phaseId),
         questionId: data?.questionId == null ? null : Number(data.questionId),
+        groupId: data?.groupId == null ? null : Number(data.groupId),
         parentId: data?.parentId ?? null,
         content: data?.content,
     };
@@ -68,29 +72,37 @@ export const chatTranscriptHandlers = {
 };
 
 export const chatInsertHandlers = {
-    ranking: async ({ userId, phaseId, content, parentId, dbcon }) => {
-        await rpg2.execSQL({
+    ranking: async ({ userId, phaseId, groupId, content, parentId, dbcon }) => {
+        const result = await rpg2.execSQL({
             sql: `
-                INSERT INTO chat (uid, stageid, content, parent_id)
-                VALUES ($1, $2, $3, $4)
+                INSERT INTO chat (uid, stageid, tmid, content, parent_id)
+                VALUES ($1, $2, $3, $4, $5)
+                RETURNING id, uid, stageid, tmid, content, stime, parent_id
             `,
             dbcon,
             sqlParams: [rpg2.param('plain', userId), rpg2.param('plain', phaseId), 
-                rpg2.param('plain', content), rpg2.param('plain', parentId) || null],
+                rpg2.param('plain', groupId) || null, rpg2.param('plain', content),
+                rpg2.param('plain', parentId) || null],
         });
+
+        return result[0] || null;
     },
 
-    semantic_differential: async ({ userId, questionId, content, parentId, dbcon }) => {
-        await rpg2.execSQL({
+    semantic_differential: async ({ userId, questionId, groupId, content, parentId, dbcon }) => {
+        const result = await rpg2.execSQL({
             sql: `
-                INSERT INTO differential_chat (uid, did, content, parent_id)
-                VALUES ($1, $2, $3, $4)
+                INSERT INTO differential_chat (uid, did, tmid, content, parent_id)
+                VALUES ($1, $2, $3, $4, $5)
+                RETURNING id, uid, did, tmid, content, stime, parent_id
             `,
             dbcon,
             sqlParams: [rpg2.param('plain', userId), 
-                rpg2.param('plain', questionId), rpg2.param('plain', content),
+                rpg2.param('plain', questionId), rpg2.param('plain', groupId) || null,
+                rpg2.param('plain', content),
                 rpg2.param('plain', parentId) || null],
         });
+
+        return result[0] || null;
     },
 };
 
@@ -106,7 +118,7 @@ export const saveChatMessage = async function(data) {
             stripUnknown: true,
         });
 
-        const { userId, phaseId, questionId, parentId, content } = validatedData;
+        const { userId, phaseId, questionId, groupId, parentId, content } = validatedData;
 
         const designType = await getDesignTypeByPhaseId(phaseId);
         const handler = chatInsertHandlers[designType];
@@ -114,16 +126,17 @@ export const saveChatMessage = async function(data) {
             throw new Error(`Unsupported design type: ${designType}`);
         }
 
-        await handler({
+        const savedMessage = await handler({
             userId,
             phaseId,
             questionId,
+            groupId,
             content,
             parentId,
             dbcon: config.dbconnString,
         });
 
-        return true;
+        return savedMessage || true;
     } catch(error) {
         console.error("[ChatHelper::saveChatMessage] Could not save the message. ", error);
         return false;
@@ -134,19 +147,20 @@ async function countSemanticDifferentialMessages(phaseId) {
     const results = await rpg2.execSQL({
         sql: `
             SELECT c.did,
-                   u.uid,
-                   u.tmid,
+                   c.uid,
+                   COALESCE(c.tmid, u.tmid) AS tmid,
                    COUNT(*) AS message_count
             FROM differential_chat AS c
-            INNER JOIN teamusers AS u
+            LEFT JOIN teamusers AS u
                 ON u.uid = c.uid
+               AND (c.tmid IS NULL OR c.tmid = u.tmid)
             INNER JOIN differential AS d
                 ON d.id = c.did
             INNER JOIN teams AS tm
-                ON tm.id = u.tmid
+                ON tm.id = COALESCE(c.tmid, u.tmid)
             WHERE d.stageid = $1
               AND tm.stageid = $1
-            GROUP BY c.did, u.uid, u.tmid
+            GROUP BY c.did, c.uid, COALESCE(c.tmid, u.tmid)
         `,
         dbcon: config.dbconnString,
         sqlParams: [rpg2.param('plain', phaseId)],
@@ -164,17 +178,18 @@ async function countRankingMessages(phaseId) {
     const results = await rpg2.execSQL({
         sql: `
             SELECT c.stageid,
-                   u.uid,
-                   u.tmid,
+                   c.uid,
+                   COALESCE(c.tmid, u.tmid) AS tmid,
                    COUNT(*) AS message_count
             FROM chat AS c
-            INNER JOIN teamusers AS u
+            LEFT JOIN teamusers AS u
                 ON u.uid = c.uid
+               AND (c.tmid IS NULL OR c.tmid = u.tmid)
             INNER JOIN teams AS tm
-                ON tm.id = u.tmid
+                ON tm.id = COALESCE(c.tmid, u.tmid)
             WHERE c.stageid = $1
               AND tm.stageid = $1
-            GROUP BY c.stageid, u.uid, u.tmid
+            GROUP BY c.stageid, c.uid, COALESCE(c.tmid, u.tmid)
         `,
         dbcon: config.dbconnString,
         sqlParams: [rpg2.param('plain', phaseId)],
@@ -193,15 +208,25 @@ async function semanticDifferentialChatTranscriptByGroup(groupId, questionId) {
         sql: `
             SELECT c.id,
                    c.uid,
+                   u.role AS author_role,
+                   u.name AS author_name,
                    c.content,
                    c.stime,
                    c.parent_id
             FROM differential_chat AS c
+            INNER JOIN users AS u
+                ON u.id = c.uid
             WHERE c.did = $1
-              AND c.uid IN (
-                  SELECT tu.uid
-                  FROM teamusers AS tu
-                  WHERE tu.tmid = $2
+              AND (
+                  c.tmid = $2
+                  OR (
+                      c.tmid IS NULL
+                      AND c.uid IN (
+                          SELECT tu.uid
+                          FROM teamusers AS tu
+                          WHERE tu.tmid = $2
+                      )
+                  )
               )
             ORDER BY c.stime ASC
         `,
@@ -215,19 +240,29 @@ async function rankingChatTranscriptByGroup(groupId, questionId) {
         sql: `
             SELECT s.id,
                    s.uid,
+                   u.role AS author_role,
+                   u.name AS author_name,
                    s.content,
                    s.stime,
                    s.parent_id
             FROM chat AS s
+            INNER JOIN users AS u
+                ON u.id = s.uid
             WHERE s.stageid = (
                 SELECT stageid
                 FROM teams
                 WHERE id = $1
             )
-              AND s.uid IN (
-                  SELECT tu.uid
-                  FROM teamusers AS tu
-                  WHERE tu.tmid = $1
+              AND (
+                  s.tmid = $1
+                  OR (
+                      s.tmid IS NULL
+                      AND s.uid IN (
+                          SELECT tu.uid
+                          FROM teamusers AS tu
+                          WHERE tu.tmid = $1
+                      )
+                  )
               )
             ORDER BY s.stime ASC
         `,

--- a/ethicapp/backend/sockets/teacher.socket.js
+++ b/ethicapp/backend/sockets/teacher.socket.js
@@ -16,6 +16,16 @@ let teacherSocketInit = (socket, socketNamespace) => {
         console.debug(`A teacher has left session-${sessionId}`);
     });
 
+    socket.on('joinGroupChat', (groupId) => {
+        socket.join(`teacher-group-${groupId}`);
+        console.debug(`A teacher has joined teacher-group-${groupId}`);
+    });
+
+    socket.on('leaveGroupChat', (groupId) => {
+        socket.leave(`teacher-group-${groupId}`);
+        console.debug(`A teacher has left teacher-group-${groupId}`);
+    });
+
     // Broadcast a message to all sockets in a specific session
     socket.on('broadcastToSession', (sessionId, message) => {
         // Emit a notification to all clients in the room `session-{sessionId}`
@@ -53,6 +63,11 @@ const toTeacherNotifications = (socketNamespace) => {
                     groupId,
                     message
                 });
+        },
+
+        groupChatMessage: (groupId, message) => {
+            socketNamespace.to(`teacher-group-${groupId}`).
+                emit("onGroupChatMessage", message);
         }
     };
 };

--- a/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
@@ -7,7 +7,7 @@ import { openSemanticDifferentialGroupResponseModal } from "../../helpers/dashbo
 /*eslint func-style: ["error", "expression"]*/
 export function DashboardController($scope, $routeParams, $http, 
     $translate, $timeout, $uibModal, 
-    ActivityStateService, ActivityCatalogService, DesignCatalogService) {
+    ActivityStateService, ActivityCatalogService, DesignCatalogService, TeacherGroupChatService) {
 
     const vm = this;
 
@@ -53,14 +53,26 @@ export function DashboardController($scope, $routeParams, $http,
 
             openSemanticDifferentialGroupResponseModal(
                 $uibModal,
+                TeacherGroupChatService,
                 group,
                 hydratedPhaseData,
                 responses,
-                chatMessages
+                chatMessages,
+                vm.canUseLiveGroupChat(hydratedPhaseData)
             );
         } catch (error) {
             console.error("Error opening group response modal:", error);
         }
+    };
+
+    vm.canUseLiveGroupChat = function(phaseData) {
+        const phaseDescriptor = phaseData?.descriptor;
+        const currentPhaseId = vm.activityState?.descriptor?.currentPhase?.id;
+        const activityStatus = vm.activityState?.descriptor?.status;
+
+        return Boolean(phaseDescriptor?.chat)
+            && Number(phaseDescriptor?.id) === Number(currentPhaseId)
+            && activityStatus !== "finished";
     };
 
     vm.hydratePhaseDataForIndividualModal = function(phaseData) {
@@ -390,6 +402,13 @@ export function DashboardController($scope, $routeParams, $http,
     
             if (DesignHelpers.isGroupPhaseByPhaseDescriptor(phaseDescriptor)) {
                 phaseState = builderSteps.addGroupInfo(phaseState, groups);
+                if (typeof builderSteps.addExternalGroupChatInfo === "function") {
+                    phaseState = builderSteps.addExternalGroupChatInfo(
+                        phaseState,
+                        chatMessageCount,
+                        phaseDescriptor.questions
+                    );
+                }
                 phaseState = builderSteps.updateGroupStatistics(phaseState, $translate.instant);
             }
     

--- a/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
@@ -8,6 +8,9 @@ export const DashboardDataJoiners = {
         addGroupInfo: (phaseState, groups) => {
             return addParticipantGroupInfo(phaseState, groups);
         },
+        addExternalGroupChatInfo: (phaseState, chatMessageCount, questions) => {
+            return addExternalGroupChatInfo(phaseState, chatMessageCount, questions);
+        },
         updateGroupStatistics: (phaseState, translator) => {
             return updateGroupStatistics(phaseState, translator);
         },
@@ -300,6 +303,41 @@ function addParticipantGroupInfo(phaseData, groups) {
     });
 }
 
+function addExternalGroupChatInfo(phaseState, chatMessageCount, questions) {
+    const usersById = new Set(phaseState.map(user => Number(user.userId)));
+    const questionsById = (questions || []).reduce((acc, question) => {
+        acc[Number(question.id)] = question;
+        return acc;
+    }, {});
+
+    (chatMessageCount || []).forEach(chat => {
+        if (usersById.has(Number(chat.userId))) {
+            return;
+        }
+
+        const question = questionsById[Number(chat.questionId)];
+        const questionNumber = Number(question?.number);
+        const teamId = Number(chat.teamId);
+
+        if (!questionNumber || !teamId) {
+            return;
+        }
+
+        const targetGroupMember = phaseState.find(user =>
+            !user.groupStatistics && Number(user.groupId) === teamId
+        );
+
+        if (!targetGroupMember) {
+            return;
+        }
+
+        const key = `__groupChatR${questionNumber}`;
+        targetGroupMember[key] = Number(targetGroupMember[key] || 0) + Number(chat.messageCount || 0);
+    });
+
+    return phaseState;
+}
+
 let updateGroupStatistics = function(data, translator) {
     // Step 0: Filter out existing group summary objects
     const filteredData = data.filter(user => !user.groupStatistics);
@@ -332,6 +370,10 @@ let updateGroupStatistics = function(data, translator) {
             Object.keys(user).forEach(key => {
                 if (key.startsWith("chatR")) {
                     stats[key] = (stats[key] || 0) + (user[key] || 0);
+                }
+                if (key.startsWith("__groupChatR")) {
+                    const summaryKey = key.replace("__groupChatR", "chatR");
+                    stats[summaryKey] = (stats[summaryKey] || 0) + (user[key] || 0);
                 }
             });
             return stats;

--- a/ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js
@@ -47,13 +47,23 @@ function normalizeQuestion(question, index) {
 }
 
 function createModalController() {
-    return ["$uibModalInstance", "data", function($uibModalInstance, data) {
+    return ["$scope", "$timeout", "$translate", "$uibModalInstance", "data",
+        function($scope, $timeout, $translate, $uibModalInstance, data) {
         const $ctrl = this;
 
         $ctrl.group = data.group;
         $ctrl.phaseData = data.phaseData;
+        $ctrl.groupChatService = data.groupChatService;
+        $ctrl.canUseLiveChat = data.canUseLiveChat === true;
         $ctrl.responses = data.responses || [];
-        $ctrl.chatMessages = data.chatMessages || [];
+        $ctrl.chatMessages = (data.chatMessages || [])
+            .map((message) => $ctrl.groupChatService.normalizeMessage(message))
+            .filter((message) => message.content.length > 0);
+        $ctrl.draftMessage = "";
+        $ctrl.chatLoading = false;
+        $ctrl.chatSending = false;
+        $ctrl.chatError = "";
+        $ctrl.unsubscribeFromGroupChat = null;
         $ctrl.questions = (data.phaseData?.descriptor?.questions || [])
             .map((question, index) => normalizeQuestion(question, index));
 
@@ -88,13 +98,147 @@ function createModalController() {
             return participantNames[userId] || `User ${userId}`;
         };
 
+        $ctrl.getChatAuthorName = function(message) {
+            if (message?.authorRole === "P") {
+                const translatedLabel = $translate.instant("teacher_chat_author_label");
+                return translatedLabel && translatedLabel !== "teacher_chat_author_label"
+                    ? translatedLabel
+                    : "Teacher";
+            }
+
+            return participantNames[message.uid] || message.authorName || $ctrl.getUserName(message.uid);
+        };
+
+        $ctrl.isTeacherMessage = function(message) {
+            return message?.authorRole === "P";
+        };
+
+        $ctrl.getFirstQuestionId = function() {
+            return Number($ctrl.questions?.[0]?.id);
+        };
+
+        $ctrl.scrollChatToBottom = function() {
+            $timeout(() => {
+                const chatTranscript = document.getElementById("teacher-group-chat-transcript");
+                if (chatTranscript) {
+                    chatTranscript.scrollTop = chatTranscript.scrollHeight;
+                }
+            }, 0);
+        };
+
+        $ctrl.reloadChatMessages = async function() {
+            const questionId = $ctrl.getFirstQuestionId();
+            if (!questionId || !$ctrl.group?.groupId) {
+                return;
+            }
+
+            $ctrl.chatLoading = true;
+            $ctrl.chatError = "";
+            try {
+                const messages = await $ctrl.groupChatService.loadMessages($ctrl.group.groupId, questionId);
+                $scope.$applyAsync(() => {
+                    $ctrl.chatMessages = messages;
+                    $ctrl.chatLoading = false;
+                    $ctrl.scrollChatToBottom();
+                });
+            } catch (error) {
+                console.error("Error loading group chat messages:", error);
+                $scope.$applyAsync(() => {
+                    $ctrl.chatLoading = false;
+                    $ctrl.chatError = "Unable to load chat messages.";
+                });
+            }
+        };
+
+        $ctrl.sendMessage = async function() {
+            const content = $ctrl.draftMessage.trim();
+            const questionId = $ctrl.getFirstQuestionId();
+
+            if (!content || !$ctrl.canUseLiveChat || $ctrl.chatSending || !questionId || !$ctrl.group?.groupId) {
+                return;
+            }
+
+            $ctrl.chatSending = true;
+            $ctrl.chatError = "";
+            try {
+                const sentMessage = await $ctrl.groupChatService.sendMessage({
+                    phaseId: $ctrl.phaseData.descriptor.id,
+                    questionId,
+                    groupId: $ctrl.group.groupId,
+                    content,
+                });
+
+                $scope.$applyAsync(() => {
+                    if (sentMessage?.content) {
+                        const existingMessage = $ctrl.chatMessages.find((chatMessage) =>
+                            Number(chatMessage.id) === Number(sentMessage.id)
+                        );
+                        if (!existingMessage) {
+                            $ctrl.chatMessages.push(sentMessage);
+                        }
+                    }
+                    $ctrl.draftMessage = "";
+                    $ctrl.chatSending = false;
+                    $ctrl.scrollChatToBottom();
+                });
+            } catch (error) {
+                console.error("Error sending teacher group chat message:", error);
+                $scope.$applyAsync(() => {
+                    $ctrl.chatSending = false;
+                    $ctrl.chatError = "Unable to send chat message.";
+                });
+            }
+        };
+
+        $ctrl.onChatKeyDown = function(event) {
+            if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                $ctrl.sendMessage();
+            }
+        };
+
+        $ctrl.$onInit = function() {
+            if ($ctrl.canUseLiveChat && $ctrl.group?.groupId) {
+                $ctrl.unsubscribeFromGroupChat = $ctrl.groupChatService.subscribeToGroup(
+                    $ctrl.group.groupId,
+                    (message) => {
+                        $scope.$applyAsync(() => {
+                            const existingMessage = $ctrl.chatMessages.find((chatMessage) =>
+                                Number(chatMessage.id) === Number(message.id)
+                            );
+                            if (!existingMessage) {
+                                $ctrl.chatMessages.push(message);
+                            }
+                            $ctrl.scrollChatToBottom();
+                        });
+                    }
+                );
+            }
+
+            $ctrl.scrollChatToBottom();
+        };
+
+        $ctrl.$onDestroy = function() {
+            if (typeof $ctrl.unsubscribeFromGroupChat === "function") {
+                $ctrl.unsubscribeFromGroupChat();
+            }
+        };
+
         $ctrl.close = function() {
             $uibModalInstance.dismiss("close");
         };
     }];
 }
 
-export function openSemanticDifferentialGroupResponseModal($uibModal, group, phaseData, responses, chatMessages) {
+export function openSemanticDifferentialGroupResponseModal(
+    $uibModal,
+    groupChatService,
+    group,
+    phaseData,
+    responses,
+    chatMessages,
+    canUseLiveChat = false
+) {
     if (!group || !phaseData) {
         return null;
     }
@@ -107,7 +251,7 @@ export function openSemanticDifferentialGroupResponseModal($uibModal, group, pha
         controllerAs: "$ctrl",
         controller: createModalController(),
         resolve: {
-            data: () => ({ group, phaseData, responses, chatMessages }),
+            data: () => ({ groupChatService, group, phaseData, responses, chatMessages, canUseLiveChat }),
         },
     });
 }

--- a/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
+++ b/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
@@ -6,6 +6,7 @@ import { ActivityCatalogService } from "../../services/activity-catalog.service.
 import { DesignStateService } from "../../services/design-state.service.js";
 import { DesignCatalogService } from "../../services/design-catalog.service.js";
 import { CasesCatalogService } from "../../services/cases-catalog.service.js";
+import { TeacherGroupChatService } from "../../services/teacher-group-chat.service.js";
 import UserProfileService from "../../services/user-profile.service.js";
 import SocketService from '../../services/socket.service.js';
 
@@ -22,6 +23,7 @@ app.factory("TeacherSocketService", ["SocketService", function (SocketService) {
 }]);
 
 app.factory("ActivityStateService", ["$http", "TeacherSocketService", ActivityStateService])
+    .factory("TeacherGroupChatService", ["$http", "TeacherSocketService", TeacherGroupChatService])
     .factory("ActivityCatalogService", ["$http", ActivityCatalogService])
     .factory("DesignCatalogService", ["$rootScope", "$http", DesignCatalogService])
     .factory("DesignStateService", ["$rootScope", "$http", DesignStateService])
@@ -104,7 +106,8 @@ app.controller("CreateDesignController",
     ["$scope", "DesignCatalogService", "UserProfileService", CreateDesignController]);
 app.controller("DashboardController", 
     ["$scope", "$routeParams", "$http", "$translate", "$timeout", "$uibModal",
-        "ActivityStateService", "ActivityCatalogService", "DesignCatalogService", DashboardController]);  
+        "ActivityStateService", "ActivityCatalogService", "DesignCatalogService",
+        "TeacherGroupChatService", DashboardController]);
 app.controller("DesignViewerController", 
     ["$scope", "$routeParams", "DesignCatalogService", DesignViewerController]);
 app.controller("CasesController",

--- a/ethicapp/frontend/assets/js/services/teacher-group-chat.service.js
+++ b/ethicapp/frontend/assets/js/services/teacher-group-chat.service.js
@@ -1,0 +1,71 @@
+let TeacherGroupChatService = function($http, TeacherSocketService) {
+    const normalizeMessage = function(message) {
+        const id = Number(message?.id ?? message?.msgid ?? message?.mid);
+        const uid = Number(message?.uid ?? message?.user_id ?? message?.author_id);
+        const parentId = Number(message?.parent_id ?? message?.parentId);
+
+        return {
+            id: Number.isInteger(id) ? id : Date.now() + Math.random(),
+            uid: Number.isInteger(uid) ? uid : null,
+            authorRole: message?.author_role || message?.authorRole || null,
+            authorName: message?.author_name || message?.authorName || "",
+            content: typeof message?.content === "string" ? message.content.trim() : "",
+            stime: message?.stime || message?.created_at || message?.createdAt || null,
+            parentId: Number.isInteger(parentId) ? parentId : null,
+            groupId: Number(message?.groupId ?? message?.group_id ?? message?.tmid) || null,
+            phaseId: Number(message?.phaseId ?? message?.phase_id ?? message?.stageid) || null,
+            questionId: Number(message?.questionId ?? message?.question_id ?? message?.did) || null,
+        };
+    };
+
+    const service = {
+        normalizeMessage,
+
+        loadMessages: async function(groupId, questionId) {
+            const response = await $http.get(`/groups/${groupId}/question/${questionId}/chat_messages`);
+            const transcript = Array.isArray(response?.data?.chat_transcript)
+                ? response.data.chat_transcript
+                : [];
+
+            return transcript
+                .map(normalizeMessage)
+                .filter((message) => message.content.length > 0);
+        },
+
+        sendMessage: async function({ phaseId, questionId, groupId, content, parentId = null }) {
+            const response = await $http.post(`/phases/${phaseId}/question/${questionId}/chat_messages`, {
+                group_id: groupId,
+                content,
+                parent_id: parentId,
+            });
+
+            return normalizeMessage(response?.data?.chat_message);
+        },
+
+        subscribeToGroup: function(groupId, onMessage) {
+            TeacherSocketService.emitEvent("joinGroupChat", groupId);
+            const subscription = TeacherSocketService.fromEvent("onGroupChatMessage").subscribe({
+                next: (message) => {
+                    const normalizedMessage = normalizeMessage(message);
+                    if (Number(normalizedMessage.groupId) !== Number(groupId)) {
+                        return;
+                    }
+
+                    onMessage(normalizedMessage);
+                },
+                error: (error) => {
+                    console.error(`Websocket error for teacher group chat ${groupId}:`, error);
+                },
+            });
+
+            return function unsubscribe() {
+                subscription.unsubscribe();
+                TeacherSocketService.emitEvent("leaveGroupChat", groupId);
+            };
+        },
+    };
+
+    return service;
+};
+
+export { TeacherGroupChatService };

--- a/ethicapp/frontend/assets/locales/en.json
+++ b/ethicapp/frontend/assets/locales/en.json
@@ -376,5 +376,10 @@
 	"password_reset_modal_message": "Do you confirm sending the password reset email to",
 	"accept": "Accept",
 	"admin_inspection_mode": "Administrator inspection",
-	"back_to_management_console": "Back to management console"
+	"back_to_management_console": "Back to management console",
+	"teacher_chat_author_label": "Teacher",
+	"teacher_group_chat_placeholder": "Write a message to the group",
+	"teacher_group_chat_readonly_hint": "This chat is read-only.",
+	"loading": "Loading...",
+	"send": "Send"
 }

--- a/ethicapp/frontend/assets/locales/en_US.json
+++ b/ethicapp/frontend/assets/locales/en_US.json
@@ -614,5 +614,10 @@
 	"password_reset_modal_message": "Do you confirm sending the password reset email to",
 	"accept": "Accept",
 	"admin_inspection_mode": "Administrator inspection",
-	"back_to_management_console": "Back to management console"
+	"back_to_management_console": "Back to management console",
+	"teacher_chat_author_label": "Teacher",
+	"teacher_group_chat_placeholder": "Write a message to the group",
+	"teacher_group_chat_readonly_hint": "This chat is read-only.",
+	"loading": "Loading...",
+	"send": "Send"
 }

--- a/ethicapp/frontend/assets/locales/es.json
+++ b/ethicapp/frontend/assets/locales/es.json
@@ -377,5 +377,10 @@
 	"password_reset_modal_message": "¿Confirmas que deseas enviar el correo para cambio de contraseña a",
 	"accept": "Aceptar",
 	"admin_inspection_mode": "Inspección de administrador",
-	"back_to_management_console": "Volver a consola de administración"
+	"back_to_management_console": "Volver a consola de administración",
+	"teacher_chat_author_label": "Profesor",
+	"teacher_group_chat_placeholder": "Escribe un mensaje al grupo",
+	"teacher_group_chat_readonly_hint": "Este chat está en modo lectura.",
+	"loading": "Cargando...",
+	"send": "Enviar"
 }

--- a/ethicapp/frontend/assets/locales/es_CL.json
+++ b/ethicapp/frontend/assets/locales/es_CL.json
@@ -623,5 +623,10 @@
 	"password_reset_modal_message": "¿Confirmas que deseas enviar el correo para cambio de contraseña a",
 	"accept": "Aceptar",
 	"admin_inspection_mode": "Inspección de administrador",
-	"back_to_management_console": "Volver a consola de administración"
+	"back_to_management_console": "Volver a consola de administración",
+	"teacher_chat_author_label": "Profesor",
+	"teacher_group_chat_placeholder": "Escribe un mensaje al grupo",
+	"teacher_group_chat_readonly_hint": "Este chat está en modo lectura.",
+	"loading": "Cargando...",
+	"send": "Enviar"
 }

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
@@ -63,19 +63,57 @@
             <strong>{{ 'chat_messages_label' | translate }}</strong>
         </div>
         <div class="panel-body">
-            <p class="text-muted" ng-if="$ctrl.chatMessages.length === 0">{{ 'no_response' | translate }}</p>
+            <p class="text-muted" ng-if="$ctrl.chatLoading">{{ 'loading' | translate }}</p>
+            <p class="text-muted" ng-if="!$ctrl.chatLoading && $ctrl.chatMessages.length === 0">{{ 'no_response' | translate }}</p>
             <div ng-if="$ctrl.chatMessages.length > 0"
+                 id="teacher-group-chat-transcript"
                  style="max-height: 24em; overflow-y: auto; padding-right: .5em;">
-                <div class="media" ng-repeat="message in $ctrl.chatMessages track by message.id">
-                    <div class="media-body">
-                        <h5 class="media-heading">
-                            {{ $ctrl.getUserName(message.uid) }}
-                            <small>{{ message.stime | date:'short' }}</small>
-                        </h5>
-                        <p>{{ message.content }}</p>
+                <div class="clearfix" ng-repeat="message in $ctrl.chatMessages track by message.id" style="margin-bottom: .75em;">
+                    <div ng-class="{'pull-right text-right': $ctrl.isTeacherMessage(message), 'pull-left text-left': !$ctrl.isTeacherMessage(message)}"
+                         style="max-width: 85%;">
+                        <small class="text-muted">
+                            {{ $ctrl.getChatAuthorName(message) }}
+                            <span>{{ message.stime | date:'short' }}</span>
+                        </small>
+                        <div class="text-dark"
+                             ng-style="{
+                                'background-color': $ctrl.isTeacherMessage(message) ? '#deffcf' : '#ffffff',
+                                'border': '1px solid #ddd',
+                                'border-radius': '4px',
+                                'box-shadow': '0 1px 2px rgba(0,0,0,.075)',
+                                'padding': '.4em .6em',
+                                'display': 'inline-block',
+                                'white-space': 'pre-wrap'
+                             }">
+                            {{ message.content }}
+                        </div>
                     </div>
                 </div>
             </div>
+            <div class="alert alert-danger" ng-if="$ctrl.chatError" style="margin-top: .75em; margin-bottom: 0;">
+                {{ $ctrl.chatError }}
+            </div>
+            <div ng-if="$ctrl.canUseLiveChat" style="border-top: 1px solid #ddd; margin-top: .75em; padding-top: .75em;">
+                <div class="input-group">
+                    <input type="text"
+                           class="form-control"
+                           ng-model="$ctrl.draftMessage"
+                           ng-keydown="$ctrl.onChatKeyDown($event)"
+                           ng-disabled="$ctrl.chatSending"
+                           placeholder="{{ 'teacher_group_chat_placeholder' | translate }}">
+                    <span class="input-group-btn">
+                        <button type="button"
+                                class="btn btn-danger"
+                                ng-click="$ctrl.sendMessage()"
+                                ng-disabled="$ctrl.chatSending || !$ctrl.draftMessage.trim()">
+                            {{ 'send' | translate }}
+                        </button>
+                    </span>
+                </div>
+            </div>
+            <p class="text-muted small" ng-if="!$ctrl.canUseLiveChat" style="margin-top: .75em; margin-bottom: 0;">
+                {{ 'teacher_group_chat_readonly_hint' | translate }}
+            </p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Context

The group response modal shows the group transcript, but teachers could not follow the chat live or participate in the room. This adds a teacher-side live chat path for active group phases while keeping historical chats read-only.

## What changed

- Added `tmid` to `differential_chat` and `chat` so teacher-authored messages can be associated with a group room.
- Hardened chat message access:
  - students can read/post only for their own group,
  - teachers can read/post only for sessions they own,
  - posting is allowed only while the phase is active, in progress, and chat-enabled.
- Added teacher socket group rooms and focused `onGroupChatMessage` notifications for open group modals.
- Added `TeacherGroupChatService` to load, send, normalize, subscribe, and unsubscribe group chat messages.
- Updated the group response modal controller to converse with the chat service.
- Updated the group modal UI with left/right chat bubbles, professor messages on the right in light green, Enter-to-send, readonly mode, and i18n labels.
- Ensured teacher messages contribute to group chat totals without adding the teacher as a participant row.

## Verification

- `node --check ethicapp/backend/helpers/chat-helper.js`
- `node --check ethicapp/backend/controllers/group-messages.js`
- `node --check ethicapp/backend/sockets/teacher.socket.js`
- `node --check ethicapp/frontend/assets/js/services/teacher-group-chat.service.js`
- `node --check ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js`
- `node --check ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js`
- `node --check ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs`
- JSON parse check for updated locale files
- `git diff --check`

## Notes

Full build/lint was not run because this checkout does not have `node_modules` installed.