### PR TITLE
[codex] Fix teacher group chat modal availability and layout

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js
@@ -69,10 +69,29 @@ export function DashboardController($scope, $routeParams, $http,
         const phaseDescriptor = phaseData?.descriptor;
         const currentPhaseId = vm.activityState?.descriptor?.currentPhase?.id;
         const activityStatus = vm.activityState?.descriptor?.status;
+        const isFinishedStatus = activityStatus === "finished" || Number(activityStatus) === 3;
 
-        return Boolean(phaseDescriptor?.chat)
+        return Boolean(vm.isChatEnabledForPhase(phaseDescriptor))
             && Number(phaseDescriptor?.id) === Number(currentPhaseId)
-            && activityStatus !== "finished";
+            && !isFinishedStatus;
+    };
+
+    vm.getDesignPhaseForDescriptor = function(phaseDescriptor) {
+        const designPhases = vm.designObj?.phases || [];
+        const phaseNumber = Number(phaseDescriptor?.number);
+
+        return designPhases.find((phase, index) => {
+            const designPhaseNumber = Number(phase?.number || index + 1);
+            return designPhaseNumber === phaseNumber;
+        }) || designPhases[phaseNumber - 1] || null;
+    };
+
+    vm.isChatEnabledForPhase = function(phaseDescriptor) {
+        if (typeof phaseDescriptor?.chat === "boolean") {
+            return phaseDescriptor.chat;
+        }
+
+        return vm.getDesignPhaseForDescriptor(phaseDescriptor)?.chat === true;
     };
 
     vm.hydratePhaseDataForIndividualModal = function(phaseData) {
@@ -84,11 +103,17 @@ export function DashboardController($scope, $routeParams, $http,
         }
 
         const phaseIndex = Number(descriptor.number) - 1;
-        const designPhase = vm.designObj?.phases?.[phaseIndex];
+        const designPhase = vm.getDesignPhaseForDescriptor(descriptor) || vm.designObj?.phases?.[phaseIndex];
         const designQuestions = designPhase?.questions || [];
 
         if (designQuestions.length === 0) {
-            return phaseData;
+            return {
+                ...phaseData,
+                descriptor: {
+                    ...descriptor,
+                    chat: vm.isChatEnabledForPhase(descriptor),
+                },
+            };
         }
 
         const mergedQuestions = descriptorQuestions.map((question, index) => {
@@ -123,6 +148,7 @@ export function DashboardController($scope, $routeParams, $http,
             ...phaseData,
             descriptor: {
                 ...descriptor,
+                chat: vm.isChatEnabledForPhase(descriptor),
                 questions: mergedQuestions,
             },
         };

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
@@ -1,3 +1,54 @@
+<style>
+    .teacher-group-chat-transcript {
+        max-height: 24em;
+        overflow-y: auto;
+        padding-right: .5em;
+    }
+
+    .teacher-group-chat-message {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: .75em;
+    }
+
+    .teacher-group-chat-message-peer {
+        align-items: flex-start;
+    }
+
+    .teacher-group-chat-message-teacher {
+        align-items: flex-end;
+    }
+
+    .teacher-group-chat-message-meta {
+        display: block;
+        max-width: 85%;
+        margin-bottom: .2em;
+        line-height: 1.35;
+    }
+
+    .teacher-group-chat-bubble {
+        display: block;
+        max-width: 85%;
+        padding: .35em .6em;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, .075);
+        color: #333;
+        line-height: 1.4;
+        text-align: left;
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+
+    .teacher-group-chat-bubble-peer {
+        background-color: #fff;
+    }
+
+    .teacher-group-chat-bubble-teacher {
+        background-color: #deffcf;
+    }
+</style>
+
 <div class="modal-header">
     <button type="button" class="close" ng-click="$ctrl.close()" aria-label="Close">
         <span aria-hidden="true">&times;</span>
@@ -67,26 +118,23 @@
             <p class="text-muted" ng-if="!$ctrl.chatLoading && $ctrl.chatMessages.length === 0">{{ 'no_response' | translate }}</p>
             <div ng-if="$ctrl.chatMessages.length > 0"
                  id="teacher-group-chat-transcript"
-                 style="max-height: 24em; overflow-y: auto; padding-right: .5em;">
-                <div class="clearfix" ng-repeat="message in $ctrl.chatMessages track by message.id" style="margin-bottom: .75em;">
-                    <div ng-class="{'pull-right text-right': $ctrl.isTeacherMessage(message), 'pull-left text-left': !$ctrl.isTeacherMessage(message)}"
-                         style="max-width: 85%;">
-                        <small class="text-muted">
-                            {{ $ctrl.getChatAuthorName(message) }}
-                            <span>{{ message.stime | date:'short' }}</span>
-                        </small>
-                        <div class="text-dark"
-                             ng-style="{
-                                'background-color': $ctrl.isTeacherMessage(message) ? '#deffcf' : '#ffffff',
-                                'border': '1px solid #ddd',
-                                'border-radius': '4px',
-                                'box-shadow': '0 1px 2px rgba(0,0,0,.075)',
-                                'padding': '.4em .6em',
-                                'display': 'inline-block',
-                                'white-space': 'pre-wrap'
-                             }">
-                            {{ message.content }}
-                        </div>
+                 class="teacher-group-chat-transcript">
+                <div class="teacher-group-chat-message"
+                     ng-class="{
+                        'teacher-group-chat-message-teacher': $ctrl.isTeacherMessage(message),
+                        'teacher-group-chat-message-peer': !$ctrl.isTeacherMessage(message)
+                     }"
+                     ng-repeat="message in $ctrl.chatMessages track by message.id">
+                    <small class="text-muted teacher-group-chat-message-meta">
+                        {{ $ctrl.getChatAuthorName(message) }}
+                        <span>{{ message.stime | date:'short' }}</span>
+                    </small>
+                    <div class="teacher-group-chat-bubble"
+                         ng-class="{
+                            'teacher-group-chat-bubble-teacher': $ctrl.isTeacherMessage(message),
+                            'teacher-group-chat-bubble-peer': !$ctrl.isTeacherMessage(message)
+                         }">
+                        {{ message.content }}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Context

The live teacher group chat feature was merged, but two follow-up issues appeared in the group response modal:

- chat was shown as read-only even when the phase was active and chat-enabled;
- message bubbles inherited layout behavior that made metadata and content misalign, producing oversized bubbles.

## What changed

- Resolve chat-enabled state from the design phase when the dashboard phase descriptor does not include `chat`.
- Treat both string and numeric finished statuses as read-only.
- Preserve the resolved `chat` flag when hydrating modal phase data.
- Replace Bootstrap float-based chat layout with modal-scoped chat classes so identity/date render above the bubble and teacher messages align right with a compact light-green bubble.

## Verification

- `node --check ethicapp/frontend/assets/js/controllers/teacher/dashboard.controller.js`
- `git diff --check`