### PR TITLE
[codex] Add teacher chat replies and teacher author label

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
@@ -5,6 +5,10 @@ const DEFAULT_HEIGHT_PX = 320;
 const MIN_HEIGHT_PX = 220;
 
 function resolveDisplayName(message, participantsByUserId, isAnonymous, t) {
+  if (message.authorRole === 'P') {
+    return t('sessionDetail.chatTeacherAuthor');
+  }
+
   const participant = participantsByUserId[Number(message.authorId)] ?? null;
 
   if (isAnonymous) {
@@ -40,6 +44,7 @@ function normalizeMessage(message) {
   const id = Number(message?.id ?? message?.msgid ?? message?.mid);
   const authorId = Number(message?.uid ?? message?.user_id ?? message?.author_id);
   const authorName = message?.display_name ?? message?.name ?? message?.username ?? '';
+  const authorRole = message?.author_role ?? message?.authorRole ?? '';
   const content = typeof message?.content === 'string' ? message.content.trim() : '';
   const createdAt = message?.date ?? message?.created_at ?? message?.createdAt ?? '';
   const parentId = Number(message?.parent_id ?? message?.parentId);
@@ -48,6 +53,7 @@ function normalizeMessage(message) {
     id: Number.isInteger(id) ? id : Math.random(),
     authorId: Number.isInteger(authorId) ? authorId : null,
     authorName: typeof authorName === 'string' ? authorName : '',
+    authorRole: typeof authorRole === 'string' ? authorRole : '',
     content,
     createdAt: typeof createdAt === 'string' ? createdAt : '',
     parentId: Number.isInteger(parentId) ? parentId : null

--- a/ethicapp-student/frontend/src/i18n/locales/en_US.js
+++ b/ethicapp-student/frontend/src/i18n/locales/en_US.js
@@ -100,6 +100,7 @@ const enUS = {
     chatResizeAria: 'Drag to resize chat',
     chatAnonymousAuthor: 'Anonymous teammate',
     chatYouAuthor: 'You',
+    chatTeacherAuthor: 'Teacher',
     chatPeerAuthor: 'Teammate',
     chatReply: 'Reply',
     chatReplyingTo: 'Replying to',

--- a/ethicapp-student/frontend/src/i18n/locales/es_CL.js
+++ b/ethicapp-student/frontend/src/i18n/locales/es_CL.js
@@ -100,6 +100,7 @@ const esCL = {
     chatResizeAria: 'Arrastrar para cambiar tamaño del chat',
     chatAnonymousAuthor: 'Integrante anónimo',
     chatYouAuthor: 'Tú',
+    chatTeacherAuthor: 'Teacher',
     chatPeerAuthor: 'Integrante',
     chatReply: 'Responder',
     chatReplyingTo: 'Respondiendo a',

--- a/ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js
@@ -60,6 +60,7 @@ function createModalController() {
             .map((message) => $ctrl.groupChatService.normalizeMessage(message))
             .filter((message) => message.content.length > 0);
         $ctrl.draftMessage = "";
+        $ctrl.replyToMessageId = null;
         $ctrl.chatLoading = false;
         $ctrl.chatSending = false;
         $ctrl.chatError = "";
@@ -113,6 +114,66 @@ function createModalController() {
             return message?.authorRole === "P";
         };
 
+        $ctrl.getChatMessageById = function(messageId) {
+            const normalizedMessageId = Number(messageId);
+            return $ctrl.chatMessages.find((message) =>
+                Number(message.id) === normalizedMessageId
+            ) || null;
+        };
+
+        $ctrl.getSelectedReplyMessage = function() {
+            return $ctrl.getChatMessageById($ctrl.replyToMessageId);
+        };
+
+        $ctrl.selectReplyTarget = function(message) {
+            const normalizedMessageId = Number(message?.id);
+            if (!$ctrl.canUseLiveChat || !Number.isInteger(normalizedMessageId)) {
+                return;
+            }
+
+            $ctrl.replyToMessageId = normalizedMessageId;
+        };
+
+        $ctrl.clearReplyTarget = function() {
+            $ctrl.replyToMessageId = null;
+        };
+
+        $ctrl.getReplyTarget = function(message) {
+            return Number.isInteger(message?.parentId)
+                ? $ctrl.getChatMessageById(message.parentId)
+                : null;
+        };
+
+        $ctrl.getMessageDepth = function(message) {
+            const visited = new Set();
+            let current = message;
+            let depth = 0;
+
+            while (Number.isInteger(current?.parentId) && !visited.has(current.parentId)) {
+                visited.add(current.parentId);
+                const parent = $ctrl.getChatMessageById(current.parentId);
+                if (!parent) {
+                    break;
+                }
+
+                depth += 1;
+                current = parent;
+            }
+
+            return Math.min(depth, 3);
+        };
+
+        $ctrl.getReplyIndentStyle = function(message) {
+            const depth = $ctrl.getMessageDepth(message);
+            const offset = `${depth * 12}px`;
+
+            if ($ctrl.isTeacherMessage(message)) {
+                return { "margin-right": offset };
+            }
+
+            return { "margin-left": offset };
+        };
+
         $ctrl.getFirstQuestionId = function() {
             return Number($ctrl.questions?.[0]?.id);
         };
@@ -138,6 +199,9 @@ function createModalController() {
                 const messages = await $ctrl.groupChatService.loadMessages($ctrl.group.groupId, questionId);
                 $scope.$applyAsync(() => {
                     $ctrl.chatMessages = messages;
+                    if ($ctrl.replyToMessageId && !$ctrl.getSelectedReplyMessage()) {
+                        $ctrl.clearReplyTarget();
+                    }
                     $ctrl.chatLoading = false;
                     $ctrl.scrollChatToBottom();
                 });
@@ -166,6 +230,7 @@ function createModalController() {
                     questionId,
                     groupId: $ctrl.group.groupId,
                     content,
+                    parentId: Number.isInteger($ctrl.replyToMessageId) ? $ctrl.replyToMessageId : null,
                 });
 
                 $scope.$applyAsync(() => {
@@ -178,6 +243,7 @@ function createModalController() {
                         }
                     }
                     $ctrl.draftMessage = "";
+                    $ctrl.clearReplyTarget();
                     $ctrl.chatSending = false;
                     $ctrl.scrollChatToBottom();
                 });

--- a/ethicapp/frontend/assets/locales/en.json
+++ b/ethicapp/frontend/assets/locales/en.json
@@ -380,6 +380,9 @@
 	"teacher_chat_author_label": "Teacher",
 	"teacher_group_chat_placeholder": "Write a message to the group",
 	"teacher_group_chat_readonly_hint": "This chat is read-only.",
+	"teacher_group_chat_reply_label": "Reply",
+	"teacher_group_chat_replying_to_label": "Replying to",
+	"teacher_group_chat_cancel_reply_label": "Cancel",
 	"loading": "Loading...",
 	"send": "Send"
 }

--- a/ethicapp/frontend/assets/locales/en_US.json
+++ b/ethicapp/frontend/assets/locales/en_US.json
@@ -618,6 +618,9 @@
 	"teacher_chat_author_label": "Teacher",
 	"teacher_group_chat_placeholder": "Write a message to the group",
 	"teacher_group_chat_readonly_hint": "This chat is read-only.",
+	"teacher_group_chat_reply_label": "Reply",
+	"teacher_group_chat_replying_to_label": "Replying to",
+	"teacher_group_chat_cancel_reply_label": "Cancel",
 	"loading": "Loading...",
 	"send": "Send"
 }

--- a/ethicapp/frontend/assets/locales/es.json
+++ b/ethicapp/frontend/assets/locales/es.json
@@ -381,6 +381,9 @@
 	"teacher_chat_author_label": "Profesor",
 	"teacher_group_chat_placeholder": "Escribe un mensaje al grupo",
 	"teacher_group_chat_readonly_hint": "Este chat está en modo lectura.",
+	"teacher_group_chat_reply_label": "Responder",
+	"teacher_group_chat_replying_to_label": "Respondiendo a",
+	"teacher_group_chat_cancel_reply_label": "Cancelar",
 	"loading": "Cargando...",
 	"send": "Enviar"
 }

--- a/ethicapp/frontend/assets/locales/es_CL.json
+++ b/ethicapp/frontend/assets/locales/es_CL.json
@@ -627,6 +627,9 @@
 	"teacher_chat_author_label": "Profesor",
 	"teacher_group_chat_placeholder": "Escribe un mensaje al grupo",
 	"teacher_group_chat_readonly_hint": "Este chat está en modo lectura.",
+	"teacher_group_chat_reply_label": "Responder",
+	"teacher_group_chat_replying_to_label": "Respondiendo a",
+	"teacher_group_chat_cancel_reply_label": "Cancelar",
 	"loading": "Cargando...",
 	"send": "Enviar"
 }

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
@@ -47,6 +47,58 @@
     .teacher-group-chat-bubble-teacher {
         background-color: #deffcf;
     }
+
+    .teacher-group-chat-reply-context {
+        max-width: 85%;
+        margin-bottom: .25em;
+        padding: .2em .5em;
+        border-left: 2px solid #bbb;
+        color: #777;
+        font-size: 12px;
+        line-height: 1.35;
+        text-align: left;
+    }
+
+    .teacher-group-chat-message-teacher .teacher-group-chat-reply-context {
+        border-right: 2px solid #bbb;
+        border-left: 0;
+        text-align: right;
+    }
+
+    .teacher-group-chat-reply-button {
+        margin-top: .15em;
+        padding: 0;
+        border: 0;
+        background: transparent;
+        color: #337ab7;
+        font-size: 12px;
+        line-height: 1.35;
+    }
+
+    .teacher-group-chat-reply-button:hover,
+    .teacher-group-chat-reply-button:focus {
+        color: #23527c;
+        text-decoration: underline;
+    }
+
+    .teacher-group-chat-reply-preview {
+        margin-bottom: .5em;
+        padding: .35em .5em;
+        border-left: 2px solid #bbb;
+        color: #777;
+        font-size: 12px;
+        line-height: 1.35;
+    }
+
+    .teacher-group-chat-reply-preview-content {
+        display: block;
+        margin-top: .15em;
+        color: #555;
+    }
+
+    .teacher-group-chat-reply-preview-dismiss {
+        float: right;
+    }
 </style>
 
 <div class="modal-header">
@@ -123,12 +175,18 @@
                      ng-class="{
                         'teacher-group-chat-message-teacher': $ctrl.isTeacherMessage(message),
                         'teacher-group-chat-message-peer': !$ctrl.isTeacherMessage(message)
-                     }"
+                    }"
+                     ng-style="$ctrl.getReplyIndentStyle(message)"
                      ng-repeat="message in $ctrl.chatMessages track by message.id">
                     <small class="text-muted teacher-group-chat-message-meta">
                         {{ $ctrl.getChatAuthorName(message) }}
                         <span>{{ message.stime | date:'short' }}</span>
                     </small>
+                    <div class="teacher-group-chat-reply-context"
+                         ng-if="$ctrl.getReplyTarget(message)">
+                        <strong>{{ $ctrl.getChatAuthorName($ctrl.getReplyTarget(message)) }}</strong>:
+                        {{ $ctrl.getReplyTarget(message).content }}
+                    </div>
                     <div class="teacher-group-chat-bubble"
                          ng-class="{
                             'teacher-group-chat-bubble-teacher': $ctrl.isTeacherMessage(message),
@@ -136,12 +194,33 @@
                          }">
                         {{ message.content }}
                     </div>
+                    <button type="button"
+                            class="teacher-group-chat-reply-button"
+                            ng-if="$ctrl.canUseLiveChat"
+                            ng-click="$ctrl.selectReplyTarget(message)">
+                        {{ 'teacher_group_chat_reply_label' | translate }}
+                    </button>
                 </div>
             </div>
             <div class="alert alert-danger" ng-if="$ctrl.chatError" style="margin-top: .75em; margin-bottom: 0;">
                 {{ $ctrl.chatError }}
             </div>
             <div ng-if="$ctrl.canUseLiveChat" style="border-top: 1px solid #ddd; margin-top: .75em; padding-top: .75em;">
+                <div class="teacher-group-chat-reply-preview"
+                     ng-if="$ctrl.getSelectedReplyMessage()">
+                    <div>
+                        {{ 'teacher_group_chat_replying_to_label' | translate }}
+                        <strong>{{ $ctrl.getChatAuthorName($ctrl.getSelectedReplyMessage()) }}</strong>
+                        <button type="button"
+                                class="teacher-group-chat-reply-button teacher-group-chat-reply-preview-dismiss"
+                                ng-click="$ctrl.clearReplyTarget()">
+                            {{ 'teacher_group_chat_cancel_reply_label' | translate }}
+                        </button>
+                    </div>
+                    <span class="teacher-group-chat-reply-preview-content">
+                        {{ $ctrl.getSelectedReplyMessage().content }}
+                    </span>
+                </div>
                 <div class="input-group">
                     <input type="text"
                            class="form-control"


### PR DESCRIPTION
## Context

The teacher live chat is now working across groups. Two coherence fixes remain:

- in the student chat overlay, teacher-authored messages should be labeled as `Teacher` instead of falling back to anonymous teammate labels;
- in the teacher group chat modal, teachers need the same reply flow students already have.

## What changed

- Normalize `author_role` in `PhaseChatOverlay` and resolve teacher-authored messages as `Teacher`, including anonymous phases.
- Add reply state to the teacher group chat modal controller.
- Render reply context for threaded messages in the teacher modal.
- Add a reply selector/preview/cancel flow above the teacher input.
- Send selected replies through the existing `parent_id` path in `TeacherGroupChatService`.
- Add teacher modal reply labels to English and Spanish locale files.

## Verification

- `node --check ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js`
- `node --check ethicapp-student/frontend/src/i18n/locales/en_US.js`
- `node --check ethicapp-student/frontend/src/i18n/locales/es_CL.js`
- JSON parse check for updated Angular locale files
- `git diff --check`

## Notes

Full frontend builds were not run because this checkout does not have `node_modules` installed for the student or Angular frontend workspaces.