### PR TITLE
[codex] Extract teacher group chat component

### DIFF
--- a/ethicapp/frontend/assets/js/components/teacher-group-chat.component.js
+++ b/ethicapp/frontend/assets/js/components/teacher-group-chat.component.js
@@ -1,0 +1,170 @@
+const TeacherGroupChatController = function($timeout, $element) {
+    const $ctrl = this;
+
+    $ctrl.$onInit = function() {
+        $ctrl.draftMessage = "";
+        $ctrl.replyToMessageId = null;
+        $ctrl.lastMessageSignature = "";
+    };
+
+    $ctrl.$onChanges = function(changes) {
+        if (changes.messages) {
+            $ctrl.updateMessageSignature();
+            if ($ctrl.replyToMessageId && !$ctrl.getSelectedReplyMessage()) {
+                $ctrl.clearReplyTarget();
+            }
+            $ctrl.scrollChatToBottom();
+        }
+    };
+
+    $ctrl.$doCheck = function() {
+        const currentSignature = $ctrl.getMessageSignature();
+        if (currentSignature !== $ctrl.lastMessageSignature) {
+            $ctrl.lastMessageSignature = currentSignature;
+            $ctrl.scrollChatToBottom();
+        }
+    };
+
+    $ctrl.getMessages = function() {
+        return Array.isArray($ctrl.messages) ? $ctrl.messages : [];
+    };
+
+    $ctrl.getMessageSignature = function() {
+        const messages = $ctrl.getMessages();
+        const lastMessage = messages[messages.length - 1];
+        return `${messages.length}:${lastMessage?.id || ""}`;
+    };
+
+    $ctrl.updateMessageSignature = function() {
+        $ctrl.lastMessageSignature = $ctrl.getMessageSignature();
+    };
+
+    $ctrl.scrollChatToBottom = function() {
+        $timeout(() => {
+            const chatTranscript = $element[0].querySelector(".teacher-group-chat-transcript");
+            if (chatTranscript) {
+                chatTranscript.scrollTop = chatTranscript.scrollHeight;
+            }
+        }, 0);
+    };
+
+    $ctrl.getChatAuthorName = function(message) {
+        if (typeof $ctrl.resolveAuthorName === "function") {
+            return $ctrl.resolveAuthorName({ message });
+        }
+
+        return message?.authorName || "";
+    };
+
+    $ctrl.isOwnMessage = function(message) {
+        if (typeof $ctrl.resolveIsOwnMessage === "function") {
+            return $ctrl.resolveIsOwnMessage({ message }) === true;
+        }
+
+        return false;
+    };
+
+    $ctrl.getChatMessageById = function(messageId) {
+        const normalizedMessageId = Number(messageId);
+        return $ctrl.getMessages().find((message) =>
+            Number(message.id) === normalizedMessageId
+        ) || null;
+    };
+
+    $ctrl.getSelectedReplyMessage = function() {
+        return $ctrl.getChatMessageById($ctrl.replyToMessageId);
+    };
+
+    $ctrl.selectReplyTarget = function(message) {
+        const normalizedMessageId = Number(message?.id);
+        if (!$ctrl.canUseLiveChat || !Number.isInteger(normalizedMessageId)) {
+            return;
+        }
+
+        $ctrl.replyToMessageId = normalizedMessageId;
+    };
+
+    $ctrl.clearReplyTarget = function() {
+        $ctrl.replyToMessageId = null;
+    };
+
+    $ctrl.getReplyTarget = function(message) {
+        return Number.isInteger(message?.parentId)
+            ? $ctrl.getChatMessageById(message.parentId)
+            : null;
+    };
+
+    $ctrl.getMessageDepth = function(message) {
+        const visited = new Set();
+        let current = message;
+        let depth = 0;
+
+        while (Number.isInteger(current?.parentId) && !visited.has(current.parentId)) {
+            visited.add(current.parentId);
+            const parent = $ctrl.getChatMessageById(current.parentId);
+            if (!parent) {
+                break;
+            }
+
+            depth += 1;
+            current = parent;
+        }
+
+        return Math.min(depth, 3);
+    };
+
+    $ctrl.getReplyIndentStyle = function(message) {
+        const depth = $ctrl.getMessageDepth(message);
+        const offset = `${depth * 12}px`;
+
+        if ($ctrl.isOwnMessage(message)) {
+            return { "margin-right": offset };
+        }
+
+        return { "margin-left": offset };
+    };
+
+    $ctrl.sendMessage = function() {
+        const content = $ctrl.draftMessage.trim();
+
+        if (!content || !$ctrl.canUseLiveChat || $ctrl.chatSending || typeof $ctrl.onSend !== "function") {
+            return;
+        }
+
+        const parentId = Number.isInteger($ctrl.replyToMessageId)
+            ? $ctrl.replyToMessageId
+            : null;
+
+        Promise.resolve($ctrl.onSend({ content, parentId }))
+            .then(() => {
+                $ctrl.draftMessage = "";
+                $ctrl.clearReplyTarget();
+                $ctrl.scrollChatToBottom();
+            })
+            .catch(() => {});
+    };
+
+    $ctrl.onChatKeyDown = function(event) {
+        if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            $ctrl.sendMessage();
+        }
+    };
+};
+
+const teacherGroupChatComponent = {
+    bindings: {
+        messages: "<",
+        chatLoading: "<",
+        chatSending: "<",
+        chatError: "<",
+        canUseLiveChat: "<",
+        onSend: "&",
+        resolveAuthorName: "&",
+        resolveIsOwnMessage: "&",
+    },
+    controller: ["$timeout", "$element", TeacherGroupChatController],
+    templateUrl: "/assets/static/views/teacher/fragments/teacher-group-chat.template.html",
+};
+
+export default teacherGroupChatComponent;

--- a/ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js
@@ -47,8 +47,8 @@ function normalizeQuestion(question, index) {
 }
 
 function createModalController() {
-    return ["$scope", "$timeout", "$translate", "$uibModalInstance", "data",
-        function($scope, $timeout, $translate, $uibModalInstance, data) {
+    return ["$scope", "$translate", "$uibModalInstance", "data",
+        function($scope, $translate, $uibModalInstance, data) {
         const $ctrl = this;
 
         $ctrl.group = data.group;
@@ -59,8 +59,6 @@ function createModalController() {
         $ctrl.chatMessages = (data.chatMessages || [])
             .map((message) => $ctrl.groupChatService.normalizeMessage(message))
             .filter((message) => message.content.length > 0);
-        $ctrl.draftMessage = "";
-        $ctrl.replyToMessageId = null;
         $ctrl.chatLoading = false;
         $ctrl.chatSending = false;
         $ctrl.chatError = "";
@@ -114,77 +112,8 @@ function createModalController() {
             return message?.authorRole === "P";
         };
 
-        $ctrl.getChatMessageById = function(messageId) {
-            const normalizedMessageId = Number(messageId);
-            return $ctrl.chatMessages.find((message) =>
-                Number(message.id) === normalizedMessageId
-            ) || null;
-        };
-
-        $ctrl.getSelectedReplyMessage = function() {
-            return $ctrl.getChatMessageById($ctrl.replyToMessageId);
-        };
-
-        $ctrl.selectReplyTarget = function(message) {
-            const normalizedMessageId = Number(message?.id);
-            if (!$ctrl.canUseLiveChat || !Number.isInteger(normalizedMessageId)) {
-                return;
-            }
-
-            $ctrl.replyToMessageId = normalizedMessageId;
-        };
-
-        $ctrl.clearReplyTarget = function() {
-            $ctrl.replyToMessageId = null;
-        };
-
-        $ctrl.getReplyTarget = function(message) {
-            return Number.isInteger(message?.parentId)
-                ? $ctrl.getChatMessageById(message.parentId)
-                : null;
-        };
-
-        $ctrl.getMessageDepth = function(message) {
-            const visited = new Set();
-            let current = message;
-            let depth = 0;
-
-            while (Number.isInteger(current?.parentId) && !visited.has(current.parentId)) {
-                visited.add(current.parentId);
-                const parent = $ctrl.getChatMessageById(current.parentId);
-                if (!parent) {
-                    break;
-                }
-
-                depth += 1;
-                current = parent;
-            }
-
-            return Math.min(depth, 3);
-        };
-
-        $ctrl.getReplyIndentStyle = function(message) {
-            const depth = $ctrl.getMessageDepth(message);
-            const offset = `${depth * 12}px`;
-
-            if ($ctrl.isTeacherMessage(message)) {
-                return { "margin-right": offset };
-            }
-
-            return { "margin-left": offset };
-        };
-
         $ctrl.getFirstQuestionId = function() {
             return Number($ctrl.questions?.[0]?.id);
-        };
-
-        $ctrl.scrollChatToBottom = function() {
-            $timeout(() => {
-                const chatTranscript = document.getElementById("teacher-group-chat-transcript");
-                if (chatTranscript) {
-                    chatTranscript.scrollTop = chatTranscript.scrollHeight;
-                }
-            }, 0);
         };
 
         $ctrl.reloadChatMessages = async function() {
@@ -199,11 +128,7 @@ function createModalController() {
                 const messages = await $ctrl.groupChatService.loadMessages($ctrl.group.groupId, questionId);
                 $scope.$applyAsync(() => {
                     $ctrl.chatMessages = messages;
-                    if ($ctrl.replyToMessageId && !$ctrl.getSelectedReplyMessage()) {
-                        $ctrl.clearReplyTarget();
-                    }
                     $ctrl.chatLoading = false;
-                    $ctrl.scrollChatToBottom();
                 });
             } catch (error) {
                 console.error("Error loading group chat messages:", error);
@@ -214,8 +139,7 @@ function createModalController() {
             }
         };
 
-        $ctrl.sendMessage = async function() {
-            const content = $ctrl.draftMessage.trim();
+        $ctrl.sendChatMessage = async function(content, parentId = null) {
             const questionId = $ctrl.getFirstQuestionId();
 
             if (!content || !$ctrl.canUseLiveChat || $ctrl.chatSending || !questionId || !$ctrl.group?.groupId) {
@@ -230,7 +154,7 @@ function createModalController() {
                     questionId,
                     groupId: $ctrl.group.groupId,
                     content,
-                    parentId: Number.isInteger($ctrl.replyToMessageId) ? $ctrl.replyToMessageId : null,
+                    parentId,
                 });
 
                 $scope.$applyAsync(() => {
@@ -242,10 +166,7 @@ function createModalController() {
                             $ctrl.chatMessages.push(sentMessage);
                         }
                     }
-                    $ctrl.draftMessage = "";
-                    $ctrl.clearReplyTarget();
                     $ctrl.chatSending = false;
-                    $ctrl.scrollChatToBottom();
                 });
             } catch (error) {
                 console.error("Error sending teacher group chat message:", error);
@@ -253,13 +174,7 @@ function createModalController() {
                     $ctrl.chatSending = false;
                     $ctrl.chatError = "Unable to send chat message.";
                 });
-            }
-        };
-
-        $ctrl.onChatKeyDown = function(event) {
-            if (event.key === "Enter" && !event.shiftKey) {
-                event.preventDefault();
-                $ctrl.sendMessage();
+                throw error;
             }
         };
 
@@ -275,13 +190,10 @@ function createModalController() {
                             if (!existingMessage) {
                                 $ctrl.chatMessages.push(message);
                             }
-                            $ctrl.scrollChatToBottom();
                         });
                     }
                 );
             }
-
-            $ctrl.scrollChatToBottom();
         };
 
         $ctrl.$onDestroy = function() {

--- a/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
+++ b/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
@@ -187,6 +187,7 @@ import itemMoverComponent from '../../components/item-mover.component.js';
 import designItemComponent from '../../components/design-item.component.js';
 import caseFormEditorComponent from "../../components/case-form-editor.component.js";
 import phaseInstructionsEditComponent from "../../components/phase-instructions-edit.component.js";
+import teacherGroupChatComponent from "../../components/teacher-group-chat.component.js";
 
 app.component('activityDescription', activityDescriptionComponent);
 app.component('designDescription', designDescriptionComponent);
@@ -203,6 +204,7 @@ app.component('sdItemEditor', sdItemEditorComponent);
 app.component('designItem', designItemComponent);
 app.component("caseFormEditor", caseFormEditorComponent);
 app.component("phaseInstructionsEdit", phaseInstructionsEditComponent);
+app.component("teacherGroupChat", teacherGroupChatComponent);
 
 import { userRolesFilter } from '../../filters/user-roles.filter.js';
 app.filter("roleTranslate", ["$translate", userRolesFilter]);

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-group-response-modal.template.html
@@ -1,106 +1,3 @@
-<style>
-    .teacher-group-chat-transcript {
-        max-height: 24em;
-        overflow-y: auto;
-        padding-right: .5em;
-    }
-
-    .teacher-group-chat-message {
-        display: flex;
-        flex-direction: column;
-        margin-bottom: .75em;
-    }
-
-    .teacher-group-chat-message-peer {
-        align-items: flex-start;
-    }
-
-    .teacher-group-chat-message-teacher {
-        align-items: flex-end;
-    }
-
-    .teacher-group-chat-message-meta {
-        display: block;
-        max-width: 85%;
-        margin-bottom: .2em;
-        line-height: 1.35;
-    }
-
-    .teacher-group-chat-bubble {
-        display: block;
-        max-width: 85%;
-        padding: .35em .6em;
-        border: 1px solid #ddd;
-        border-radius: 6px;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, .075);
-        color: #333;
-        line-height: 1.4;
-        text-align: left;
-        white-space: pre-wrap;
-        word-break: break-word;
-    }
-
-    .teacher-group-chat-bubble-peer {
-        background-color: #fff;
-    }
-
-    .teacher-group-chat-bubble-teacher {
-        background-color: #deffcf;
-    }
-
-    .teacher-group-chat-reply-context {
-        max-width: 85%;
-        margin-bottom: .25em;
-        padding: .2em .5em;
-        border-left: 2px solid #bbb;
-        color: #777;
-        font-size: 12px;
-        line-height: 1.35;
-        text-align: left;
-    }
-
-    .teacher-group-chat-message-teacher .teacher-group-chat-reply-context {
-        border-right: 2px solid #bbb;
-        border-left: 0;
-        text-align: right;
-    }
-
-    .teacher-group-chat-reply-button {
-        margin-top: .15em;
-        padding: 0;
-        border: 0;
-        background: transparent;
-        color: #337ab7;
-        font-size: 12px;
-        line-height: 1.35;
-    }
-
-    .teacher-group-chat-reply-button:hover,
-    .teacher-group-chat-reply-button:focus {
-        color: #23527c;
-        text-decoration: underline;
-    }
-
-    .teacher-group-chat-reply-preview {
-        margin-bottom: .5em;
-        padding: .35em .5em;
-        border-left: 2px solid #bbb;
-        color: #777;
-        font-size: 12px;
-        line-height: 1.35;
-    }
-
-    .teacher-group-chat-reply-preview-content {
-        display: block;
-        margin-top: .15em;
-        color: #555;
-    }
-
-    .teacher-group-chat-reply-preview-dismiss {
-        float: right;
-    }
-</style>
-
 <div class="modal-header">
     <button type="button" class="close" ng-click="$ctrl.close()" aria-label="Close">
         <span aria-hidden="true">&times;</span>
@@ -166,81 +63,16 @@
             <strong>{{ 'chat_messages_label' | translate }}</strong>
         </div>
         <div class="panel-body">
-            <p class="text-muted" ng-if="$ctrl.chatLoading">{{ 'loading' | translate }}</p>
-            <p class="text-muted" ng-if="!$ctrl.chatLoading && $ctrl.chatMessages.length === 0">{{ 'no_response' | translate }}</p>
-            <div ng-if="$ctrl.chatMessages.length > 0"
-                 id="teacher-group-chat-transcript"
-                 class="teacher-group-chat-transcript">
-                <div class="teacher-group-chat-message"
-                     ng-class="{
-                        'teacher-group-chat-message-teacher': $ctrl.isTeacherMessage(message),
-                        'teacher-group-chat-message-peer': !$ctrl.isTeacherMessage(message)
-                    }"
-                     ng-style="$ctrl.getReplyIndentStyle(message)"
-                     ng-repeat="message in $ctrl.chatMessages track by message.id">
-                    <small class="text-muted teacher-group-chat-message-meta">
-                        {{ $ctrl.getChatAuthorName(message) }}
-                        <span>{{ message.stime | date:'short' }}</span>
-                    </small>
-                    <div class="teacher-group-chat-reply-context"
-                         ng-if="$ctrl.getReplyTarget(message)">
-                        <strong>{{ $ctrl.getChatAuthorName($ctrl.getReplyTarget(message)) }}</strong>:
-                        {{ $ctrl.getReplyTarget(message).content }}
-                    </div>
-                    <div class="teacher-group-chat-bubble"
-                         ng-class="{
-                            'teacher-group-chat-bubble-teacher': $ctrl.isTeacherMessage(message),
-                            'teacher-group-chat-bubble-peer': !$ctrl.isTeacherMessage(message)
-                         }">
-                        {{ message.content }}
-                    </div>
-                    <button type="button"
-                            class="teacher-group-chat-reply-button"
-                            ng-if="$ctrl.canUseLiveChat"
-                            ng-click="$ctrl.selectReplyTarget(message)">
-                        {{ 'teacher_group_chat_reply_label' | translate }}
-                    </button>
-                </div>
-            </div>
-            <div class="alert alert-danger" ng-if="$ctrl.chatError" style="margin-top: .75em; margin-bottom: 0;">
-                {{ $ctrl.chatError }}
-            </div>
-            <div ng-if="$ctrl.canUseLiveChat" style="border-top: 1px solid #ddd; margin-top: .75em; padding-top: .75em;">
-                <div class="teacher-group-chat-reply-preview"
-                     ng-if="$ctrl.getSelectedReplyMessage()">
-                    <div>
-                        {{ 'teacher_group_chat_replying_to_label' | translate }}
-                        <strong>{{ $ctrl.getChatAuthorName($ctrl.getSelectedReplyMessage()) }}</strong>
-                        <button type="button"
-                                class="teacher-group-chat-reply-button teacher-group-chat-reply-preview-dismiss"
-                                ng-click="$ctrl.clearReplyTarget()">
-                            {{ 'teacher_group_chat_cancel_reply_label' | translate }}
-                        </button>
-                    </div>
-                    <span class="teacher-group-chat-reply-preview-content">
-                        {{ $ctrl.getSelectedReplyMessage().content }}
-                    </span>
-                </div>
-                <div class="input-group">
-                    <input type="text"
-                           class="form-control"
-                           ng-model="$ctrl.draftMessage"
-                           ng-keydown="$ctrl.onChatKeyDown($event)"
-                           ng-disabled="$ctrl.chatSending"
-                           placeholder="{{ 'teacher_group_chat_placeholder' | translate }}">
-                    <span class="input-group-btn">
-                        <button type="button"
-                                class="btn btn-danger"
-                                ng-click="$ctrl.sendMessage()"
-                                ng-disabled="$ctrl.chatSending || !$ctrl.draftMessage.trim()">
-                            {{ 'send' | translate }}
-                        </button>
-                    </span>
-                </div>
-            </div>
-            <p class="text-muted small" ng-if="!$ctrl.canUseLiveChat" style="margin-top: .75em; margin-bottom: 0;">
-                {{ 'teacher_group_chat_readonly_hint' | translate }}
-            </p>
+            <teacher-group-chat
+                messages="$ctrl.chatMessages"
+                chat-loading="$ctrl.chatLoading"
+                chat-sending="$ctrl.chatSending"
+                chat-error="$ctrl.chatError"
+                can-use-live-chat="$ctrl.canUseLiveChat"
+                on-send="$ctrl.sendChatMessage(content, parentId)"
+                resolve-author-name="$ctrl.getChatAuthorName(message)"
+                resolve-is-own-message="$ctrl.isTeacherMessage(message)">
+            </teacher-group-chat>
         </div>
     </div>
 </div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/teacher-group-chat.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/teacher-group-chat.template.html
@@ -1,0 +1,177 @@
+<style>
+    .teacher-group-chat-transcript {
+        max-height: 24em;
+        overflow-y: auto;
+        padding-right: .5em;
+    }
+
+    .teacher-group-chat-message {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: .75em;
+    }
+
+    .teacher-group-chat-message-peer {
+        align-items: flex-start;
+    }
+
+    .teacher-group-chat-message-own {
+        align-items: flex-end;
+    }
+
+    .teacher-group-chat-message-meta {
+        display: block;
+        max-width: 85%;
+        margin-bottom: .2em;
+        line-height: 1.35;
+    }
+
+    .teacher-group-chat-bubble {
+        display: block;
+        max-width: 85%;
+        padding: .35em .6em;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, .075);
+        color: #333;
+        line-height: 1.4;
+        text-align: left;
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+
+    .teacher-group-chat-bubble-peer {
+        background-color: #fff;
+    }
+
+    .teacher-group-chat-bubble-own {
+        background-color: #deffcf;
+    }
+
+    .teacher-group-chat-reply-context {
+        max-width: 85%;
+        margin-bottom: .25em;
+        padding: .2em .5em;
+        border-left: 2px solid #bbb;
+        color: #777;
+        font-size: 12px;
+        line-height: 1.35;
+        text-align: left;
+    }
+
+    .teacher-group-chat-message-own .teacher-group-chat-reply-context {
+        border-right: 2px solid #bbb;
+        border-left: 0;
+        text-align: right;
+    }
+
+    .teacher-group-chat-reply-button {
+        margin-top: .15em;
+        padding: 0;
+        border: 0;
+        background: transparent;
+        color: #337ab7;
+        font-size: 12px;
+        line-height: 1.35;
+    }
+
+    .teacher-group-chat-reply-button:hover,
+    .teacher-group-chat-reply-button:focus {
+        color: #23527c;
+        text-decoration: underline;
+    }
+
+    .teacher-group-chat-reply-preview {
+        margin-bottom: .5em;
+        padding: .35em .5em;
+        border-left: 2px solid #bbb;
+        color: #777;
+        font-size: 12px;
+        line-height: 1.35;
+    }
+
+    .teacher-group-chat-reply-preview-content {
+        display: block;
+        margin-top: .15em;
+        color: #555;
+    }
+
+    .teacher-group-chat-reply-preview-dismiss {
+        float: right;
+    }
+</style>
+
+<p class="text-muted" ng-if="$ctrl.chatLoading">{{ 'loading' | translate }}</p>
+<p class="text-muted" ng-if="!$ctrl.chatLoading && $ctrl.getMessages().length === 0">{{ 'no_response' | translate }}</p>
+<div ng-if="$ctrl.getMessages().length > 0"
+     class="teacher-group-chat-transcript">
+    <div class="teacher-group-chat-message"
+         ng-class="{
+            'teacher-group-chat-message-own': $ctrl.isOwnMessage(message),
+            'teacher-group-chat-message-peer': !$ctrl.isOwnMessage(message)
+         }"
+         ng-style="$ctrl.getReplyIndentStyle(message)"
+         ng-repeat="message in $ctrl.getMessages() track by message.id">
+        <small class="text-muted teacher-group-chat-message-meta">
+            {{ $ctrl.getChatAuthorName(message) }}
+            <span>{{ message.stime | date:'short' }}</span>
+        </small>
+        <div class="teacher-group-chat-reply-context"
+             ng-if="$ctrl.getReplyTarget(message)">
+            <strong>{{ $ctrl.getChatAuthorName($ctrl.getReplyTarget(message)) }}</strong>:
+            {{ $ctrl.getReplyTarget(message).content }}
+        </div>
+        <div class="teacher-group-chat-bubble"
+             ng-class="{
+                'teacher-group-chat-bubble-own': $ctrl.isOwnMessage(message),
+                'teacher-group-chat-bubble-peer': !$ctrl.isOwnMessage(message)
+             }">
+            {{ message.content }}
+        </div>
+        <button type="button"
+                class="teacher-group-chat-reply-button"
+                ng-if="$ctrl.canUseLiveChat"
+                ng-click="$ctrl.selectReplyTarget(message)">
+            {{ 'teacher_group_chat_reply_label' | translate }}
+        </button>
+    </div>
+</div>
+<div class="alert alert-danger" ng-if="$ctrl.chatError" style="margin-top: .75em; margin-bottom: 0;">
+    {{ $ctrl.chatError }}
+</div>
+<div ng-if="$ctrl.canUseLiveChat" style="border-top: 1px solid #ddd; margin-top: .75em; padding-top: .75em;">
+    <div class="teacher-group-chat-reply-preview"
+         ng-if="$ctrl.getSelectedReplyMessage()">
+        <div>
+            {{ 'teacher_group_chat_replying_to_label' | translate }}
+            <strong>{{ $ctrl.getChatAuthorName($ctrl.getSelectedReplyMessage()) }}</strong>
+            <button type="button"
+                    class="teacher-group-chat-reply-button teacher-group-chat-reply-preview-dismiss"
+                    ng-click="$ctrl.clearReplyTarget()">
+                {{ 'teacher_group_chat_cancel_reply_label' | translate }}
+            </button>
+        </div>
+        <span class="teacher-group-chat-reply-preview-content">
+            {{ $ctrl.getSelectedReplyMessage().content }}
+        </span>
+    </div>
+    <div class="input-group">
+        <input type="text"
+               class="form-control"
+               ng-model="$ctrl.draftMessage"
+               ng-keydown="$ctrl.onChatKeyDown($event)"
+               ng-disabled="$ctrl.chatSending"
+               placeholder="{{ 'teacher_group_chat_placeholder' | translate }}">
+        <span class="input-group-btn">
+            <button type="button"
+                    class="btn btn-danger"
+                    ng-click="$ctrl.sendMessage()"
+                    ng-disabled="$ctrl.chatSending || !$ctrl.draftMessage.trim()">
+                {{ 'send' | translate }}
+            </button>
+        </span>
+    </div>
+</div>
+<p class="text-muted small" ng-if="!$ctrl.canUseLiveChat" style="margin-top: .75em; margin-bottom: 0;">
+    {{ 'teacher_group_chat_readonly_hint' | translate }}
+</p>


### PR DESCRIPTION
## Context

The semantic differential group response modal had accumulated the full teacher chat UI, including transcript markup, reply controls, input state, and styles. That makes it harder to reuse the same chat surface from future ranking group views.

## What changed

- Added a reusable `teacherGroupChat` Angular component under `ethicapp/frontend/assets/js/components/`.
- Moved the chat transcript, reply preview, reply actions, input handling, Enter-to-send behavior, auto-scroll, and chat styles into a dedicated component template.
- Kept data ownership in the modal controller: loading, websocket subscription, author resolution, own-message resolution, and send behavior stay outside the component.
- Replaced the embedded chat UI in `sd-group-response-modal.template.html` with a compact `<teacher-group-chat>` invocation.
- Registered the new component in the teacher module.

## Verification

- `node --check ethicapp/frontend/assets/js/components/teacher-group-chat.component.js`
- `node --check ethicapp/frontend/assets/js/helpers/dashboard-group-response-modal.helper.js`
- `node --check ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs`
- `git diff --check`

## Notes

Full frontend builds were not run because this checkout does not have `node_modules` installed.