### PR TITLE
[codex] Include previous response config in student phases

### DIFF
--- a/ethicapp/backend/helpers/student-activity-state-helper.js
+++ b/ethicapp/backend/helpers/student-activity-state-helper.js
@@ -148,7 +148,7 @@ export async function getCachedStudentActivityPhases(sessionId, invalidate = fal
         return { phases: [] };
     }
 
-    const cacheKey = `session:${sessionId}:phases`;
+    const cacheKey = `session:${sessionId}:phases:v2`;
 
     try {
         // Handle cache invalidation
@@ -226,23 +226,30 @@ export async function getStudentActivityPhases(sessionId) {
         });
 
         // Transform phases into the desired format
-        const phases = phasesResult.map(phase => ({
-            id: phase.id,
-            number: phase.number,
-            instructions: typeof (designPhases[Number(phase.number) - 1]?.instructions) === "string"
-                ? designPhases[Number(phase.number) - 1].instructions
-                : (typeof phase.instructions === "string" ? phase.instructions : ""),
-            features: {
-                mode: phase.mode,
-                chat: phase.chat,
-                anonymity: phase.anon,
-            },
-            tasks: [], // Placeholder: Add query to retrieve tasks
-            responses: [], // Placeholder: Add query to retrieve responses
-            peerResponses: [], // Placeholder: Add query to retrieve peer responses
-            group: {}, // Placeholder: Add query to retrieve group info
-            groupMessages: [], // Placeholder: Add query to retrieve group messages
-        }));
+        const phases = phasesResult.map(phase => {
+            const phaseDesign = designPhases[Number(phase.number) - 1] || {};
+
+            return {
+                id: phase.id,
+                number: phase.number,
+                instructions: typeof phaseDesign.instructions === "string"
+                    ? phaseDesign.instructions
+                    : (typeof phase.instructions === "string" ? phase.instructions : ""),
+                features: {
+                    mode: phase.mode,
+                    chat: phase.chat,
+                    anonymity: phase.anon,
+                    previousResponses: Array.isArray(phaseDesign.prevPhasesResponse)
+                        ? phaseDesign.prevPhasesResponse
+                        : [],
+                },
+                tasks: [], // Placeholder: Add query to retrieve tasks
+                responses: [], // Placeholder: Add query to retrieve responses
+                peerResponses: [], // Placeholder: Add query to retrieve peer responses
+                group: {}, // Placeholder: Add query to retrieve group info
+                groupMessages: [], // Placeholder: Add query to retrieve group messages
+            };
+        });
 
         return { phases };
     } catch (error) {


### PR DESCRIPTION
## Context

The previous group responses UI was not appearing because `full_state` phase payloads did not include `features.previousResponses`. The frontend therefore never called the new previous responses endpoint, even when the instructional design had `prevPhasesResponse` configured.

## What changed

- Populate `features.previousResponses` in `getStudentActivityPhases()` from the design phase's `prevPhasesResponse` array.
- Reuse the already resolved design phase object when building instructions/features.
- Version the student phases cache key (`session:{id}:phases:v2`) so existing Redis entries without `previousResponses` are not reused.

## Verification

- `node --check ethicapp/backend/helpers/student-activity-state-helper.js`
- `git diff --check`