### PR TITLE
[codex] Show associated case in design view

### DIFF
--- a/ethicapp/frontend/assets/js/controllers/teacher/design-viewer.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/design-viewer.controller.js
@@ -1,20 +1,50 @@
-export function DesignViewerController($scope, $routeParams, DesignCatalogService) {
+export function DesignViewerController($scope, $routeParams, DesignCatalogService, CasesCatalogService) {
     const vm = this;
     vm.designId = 0;
+    vm.design = null;
+    vm.associatedCase = null;
 
     vm.init = async function() {
         vm.designId = Number($routeParams.id);
         if (!isNaN(vm.designId)) {
             vm.design = await DesignCatalogService.getDesignById(vm.designId);
+            await vm.loadAssociatedCase();
 
-            $scope.$applyAsync(async () => {
+            $scope.$applyAsync(() => {
                 console.log(`[DesignViewerController::init] Design: ${JSON.stringify(vm.design)}`);
             });
         } else {
             console.error("[DesignViewerController::init] Design not found.");
             $scope.navigateTo("/error/404/2");
         }
-    }
+    };
+
+    vm.loadAssociatedCase = async function() {
+        vm.associatedCase = null;
+        if (!vm.designId) {
+            return;
+        }
+
+        try {
+            vm.associatedCase = await CasesCatalogService.getCaseByDesignId(vm.designId);
+        } catch (error) {
+            console.error("[DesignViewerController::loadAssociatedCase] Error loading associated case.", error);
+            vm.associatedCase = null;
+        } finally {
+            $scope.$applyAsync();
+        }
+    };
+
+    vm.formatCaseLabel = function(caseItem) {
+        if (!caseItem) {
+            return "";
+        }
+        const hasAuthor = caseItem.authorFirstname || caseItem.authorLastname;
+        if (hasAuthor) {
+            return `${caseItem.title} (${caseItem.authorFirstname || ""} ${caseItem.authorLastname || ""})`.trim();
+        }
+        return caseItem.title;
+    };
     
     vm.handleLaunch = function() {
         $scope.navigateTo('/activities/new/' + vm.designId);

--- a/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
+++ b/ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs
@@ -109,7 +109,7 @@ app.controller("DashboardController",
         "ActivityStateService", "ActivityCatalogService", "DesignCatalogService",
         "TeacherGroupChatService", DashboardController]);
 app.controller("DesignViewerController", 
-    ["$scope", "$routeParams", "DesignCatalogService", DesignViewerController]);
+    ["$scope", "$routeParams", "DesignCatalogService", "CasesCatalogService", DesignViewerController]);
 app.controller("CasesController",
     ["$scope", "$routeParams", "CasesCatalogService", CasesController]);
 app.controller("ErrorController", 

--- a/ethicapp/frontend/assets/static/views/teacher/design.view.html
+++ b/ethicapp/frontend/assets/static/views/teacher/design.view.html
@@ -13,6 +13,18 @@
                     on-toggle-public="dvc.designPublic">
                 </design-item>                
             </div>
+            <div class="panel panel-default" style="margin-top: 1em">
+                <div class="panel-body">
+                    <h4 style="margin-top: 0">{{ 'design_associated_case_label' | translate }}</h4>
+                    <p class="help-block" ng-if="!dvc.associatedCase">
+                        {{ 'design_no_case_associated' | translate }}
+                    </p>
+                    <p class="help-block" ng-if="dvc.associatedCase">
+                        <strong>{{ 'design_associated_case_current' | translate }}:</strong>
+                        {{ dvc.formatCaseLabel(dvc.associatedCase) }}
+                    </p>
+                </div>
+            </div>
         </div>
     </div>
     <div class="row">

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/ranking-phase-description.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/ranking-phase-description.template.html
@@ -15,7 +15,7 @@
         <p>
             <strong>{{ 'group_size_label' | translate }}:</strong> {{ ctrl.phaseDetails.stdntAmount }}
         </p>
-        <p ng-if="ctrl.phaseDetails.prevPhasesResponse.length > 0">
+        <p ng-if="ctrl.phaseDetails.prevPhasesResponse && ctrl.phaseDetails.prevPhasesResponse.length > 0">
             <strong>{{ 'previous_phases_label' | translate }}:</strong>
             {{ ctrl.phaseDetails.prevPhasesResponse.join(', ') }}
         </p>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/sd-phase-description.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/sd-phase-description.template.html
@@ -6,7 +6,7 @@
         <li ng-if="ctrl.phaseMode === 'team'"><strong>{{ 'chat_enabled_label' | translate }}:</strong> {{ ctrl.phaseDetails.chat ? ('yes_label' | translate) : ('no_label' | translate) }}</li>
         <li ng-if="ctrl.phaseMode === 'team'"><strong>{{ 'grouping_algorithm_label' | translate }}:</strong> {{ ctrl.phaseDetails.grouping_algorithm | translate }}</li>
         <li ng-if="ctrl.phaseMode === 'team'"><strong>{{ 'group_size_label' | translate }}:</strong> {{ ctrl.phaseDetails.stdntAmount }}</li>
-        <li ng-if="$ctrl.phaseDetails.prevPhasesResponse.length > 0"><strong>{{ 'previous_phases_label' | translate }}:</strong> {{ ctrl.phaseDetails.prevPhasesResponse.join(', ') }}</li>
+        <li ng-if="ctrl.phaseDetails.prevPhasesResponse && ctrl.phaseDetails.prevPhasesResponse.length > 0"><strong>{{ 'previous_phases_label' | translate }}:</strong> {{ ctrl.phaseDetails.prevPhasesResponse.join(', ') }}</li>
     </ul>
     <hr>
     <div ng-if="ctrl.phaseDetails.instructions && ctrl.phaseDetails.instructions.trim().length > 0">


### PR DESCRIPTION
## Summary
- Shows the case associated with a design in the teacher read-only design view, using the same label formatting as the edit view.
- Wires `DesignViewerController` to `CasesCatalogService` so it can load the associated case.
- Fixes previous-phase response feature display in semantic differential and ranking phase descriptions with a guarded condition.

## Validation
- `node --check ethicapp/frontend/assets/js/controllers/teacher/design-viewer.controller.js`
- `node --check ethicapp/frontend/assets/js/modules/teacher/teacher-admin.mjs`
- `git diff --check`