### PR TITLE
[codex] Migrate auth-backend to ESM

### DIFF
--- a/auth-backend/app.js
+++ b/auth-backend/app.js
@@ -1,16 +1,20 @@
-const path = require('path');
-const express = require('express');
-const session = require('express-session');
-const passport = require('passport');
-const LocalStrategy = require('passport-local').Strategy;
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import express from 'express';
+import session from 'express-session';
+import passport from 'passport';
+import passportLocal from 'passport-local';
 
-const userService = require('./services/user.service');
-const { createSessionStore } = require('./services/session-store.service');
+import userService from './services/user.service.js';
+import { createSessionStore } from './services/session-store.service.js';
 
-const viewRoutes = require('./routes/view.routes');
-const authRoutes = require('./routes/auth.routes');
+import viewRoutes from './routes/view.routes.js';
+import authRoutes from './routes/auth.routes.js';
 
 const app = express();
+const { Strategy: LocalStrategy } = passportLocal;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // --------------------------------------------------
 // Basic Express setup
@@ -177,4 +181,4 @@ app.use(function errorHandler(err, req, res, next) {
 });
 
 
-module.exports = app;
+export default app;

--- a/auth-backend/config/database.js
+++ b/auth-backend/config/database.js
@@ -1,4 +1,6 @@
-const { Pool } = require('pg');
+import pg from 'pg';
+
+const { Pool } = pg;
 
 const useSsl = process.env.PGSSLMODE === 'require';
 
@@ -46,7 +48,10 @@ async function query(text, params) {
   }
 }
 
-module.exports = {
+const db = {
   pool,
   query
 };
+
+export { pool, query };
+export default db;

--- a/auth-backend/i18n/locale.js
+++ b/auth-backend/i18n/locale.js
@@ -31,7 +31,7 @@ function translateMessage(req, key, catalog) {
   return catalog[locale]?.[key] || catalog[DEFAULT_LOCALE]?.[key] || key;
 }
 
-module.exports = {
+export {
   DEFAULT_LOCALE,
   normalizePreferredLocale,
   inferPreferredLocaleFromRequest,

--- a/auth-backend/i18n/messages/auth-messages.js
+++ b/auth-backend/i18n/messages/auth-messages.js
@@ -47,4 +47,4 @@ const authMessages = {
   }
 };
 
-module.exports = authMessages;
+export default authMessages;

--- a/auth-backend/package.json
+++ b/auth-backend/package.json
@@ -2,7 +2,7 @@
   "name": "auth-backend",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "dev": "nodemon server.js",
     "start": "node server.js",
@@ -14,7 +14,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "bcrypt": "^6.0.0",
     "connect-redis": "^7.1.1",

--- a/auth-backend/routes/auth.routes.js
+++ b/auth-backend/routes/auth.routes.js
@@ -1,12 +1,12 @@
-const express = require('express');
-const bcrypt = require('bcrypt');
-const crypto = require('crypto');
+import crypto from 'node:crypto';
+import express from 'express';
+import bcrypt from 'bcrypt';
 
-const db = require('../config/database');
-const mailService = require('../services/mail.service');
-const recaptchaService = require('../services/recaptcha.service');
-const authMessages = require('../i18n/messages/auth-messages');
-const { inferPreferredLocaleFromRequest, normalizePreferredLocale, translateMessage } = require('../i18n/locale');
+import db from '../config/database.js';
+import mailService from '../services/mail.service.js';
+import recaptchaService from '../services/recaptcha.service.js';
+import authMessages from '../i18n/messages/auth-messages.js';
+import { inferPreferredLocaleFromRequest, normalizePreferredLocale, translateMessage } from '../i18n/locale.js';
 
 const router = express.Router();
 
@@ -744,4 +744,4 @@ router.post('/reset-password', async (req, res) => {
   }
 });
 
-module.exports = router;
+export default router;

--- a/auth-backend/routes/view.routes.js
+++ b/auth-backend/routes/view.routes.js
@@ -1,7 +1,10 @@
-const express = require('express');
-const path = require('path');
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import express from 'express';
 
 const router = express.Router();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const spaIndexPath = path.join(__dirname, '..', 'public', 'app', 'index.html');
 
 router.get('/', (req, res) => {
@@ -24,4 +27,4 @@ router.get('/reset-password', (req, res) => {
   res.sendFile(spaIndexPath);
 });
 
-module.exports = router;
+export default router;

--- a/auth-backend/scripts/create-admin.js
+++ b/auth-backend/scripts/create-admin.js
@@ -1,7 +1,8 @@
-require('dotenv').config();
+import 'dotenv/config';
 
-const pool = require('../config/database.js');
-const bcrypt = require('bcrypt');
+import bcrypt from 'bcrypt';
+
+import db from '../config/database.js';
 
 async function main() {
   const firstname = (process.env.ADMIN_FIRSTNAME || '').trim();
@@ -28,7 +29,7 @@ Optional:
     process.exit(1);
   }
 
-  const existing = await pool.query(
+  const existing = await db.query(
     `
       SELECT id, mail, rut
       FROM users
@@ -46,7 +47,7 @@ Optional:
   const hash = await bcrypt.hash(password, 12);
   const fullName = [firstname, lastname].filter(Boolean).join(' ').trim();
 
-  await pool.query(
+  await db.query(
     `
       INSERT INTO users
         (firstname, lastname, name, rut, pass, mail, sex, role, password_bcrypt, auth_provider, active)

--- a/auth-backend/scripts/create-user.js
+++ b/auth-backend/scripts/create-user.js
@@ -1,7 +1,8 @@
-require('dotenv').config();
+import 'dotenv/config';
 
-const pool = require('../config/database.js');
-const bcrypt = require('bcrypt');
+import bcrypt from 'bcrypt';
+
+import db from '../config/database.js';
 
 async function main() {
   const [
@@ -25,7 +26,7 @@ node scripts/create-user.js <firstname> <lastname> <rut> <email> <password> [rol
   const fullName = [firstname, lastname].filter(Boolean).join(' ').trim();
   const normalizedEmail = email.trim().toLowerCase();
 
-  const existing = await pool.query(
+  const existing = await db.query(
     `
       SELECT id
       FROM users
@@ -42,7 +43,7 @@ node scripts/create-user.js <firstname> <lastname> <rut> <email> <password> [rol
 
   const hash = await bcrypt.hash(password, 12);
 
-  await pool.query(
+  await db.query(
     `
       INSERT INTO users
         (firstname, lastname, name, rut, mail, sex, role, password_bcrypt, auth_provider, active)

--- a/auth-backend/scripts/seed-users.js
+++ b/auth-backend/scripts/seed-users.js
@@ -1,6 +1,6 @@
-require('dotenv').config();
+import 'dotenv/config';
 
-const { spawnSync } = require('child_process');
+import { spawnSync } from 'node:child_process';
 
 function createUser(args) {
   const result = spawnSync(

--- a/auth-backend/server.js
+++ b/auth-backend/server.js
@@ -1,6 +1,6 @@
-require('dotenv').config();
+import 'dotenv/config';
 
-const app = require('./app');
+import app from './app.js';
 
 const port = process.env.PORT || 3000;
 

--- a/auth-backend/services/mail.service.js
+++ b/auth-backend/services/mail.service.js
@@ -1,7 +1,10 @@
-const path = require('path');
-const ejs = require('ejs');
-const nodemailer = require('nodemailer');
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ejs from 'ejs';
+import nodemailer from 'nodemailer';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const EMAIL_TEMPLATES_PATH = path.join(__dirname, '..', 'views', 'emails');
 const SMTP_HOST = process.env.SMTP_HOST;
 const SMTP_PORT = Number(process.env.SMTP_PORT || 587);
@@ -98,9 +101,17 @@ async function sendPasswordResetEmail({ to, rawToken, preferredLocale }) {
   };
 }
 
-module.exports = {
+const mailService = {
   sendPasswordResetEmail,
   buildResetUrl,
   normalizePreferredLocale,
   resolvePreferredLocale
 };
+
+export {
+  sendPasswordResetEmail,
+  buildResetUrl,
+  normalizePreferredLocale,
+  resolvePreferredLocale
+};
+export default mailService;

--- a/auth-backend/services/password.service.js
+++ b/auth-backend/services/password.service.js
@@ -1,232 +1,26 @@
-const express = require('express');
-const passport = require('passport');
-const userService = require('../services/user.service');
+import bcrypt from 'bcrypt';
+import crypto from 'node:crypto';
 
-const router = express.Router();
+const SALT_ROUNDS = Number(process.env.BCRYPT_SALT_ROUNDS || 10);
 
-function isValidEmail(email) {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+async function hashPassword(password) {
+  return bcrypt.hash(password, SALT_ROUNDS);
 }
 
-function isStrongEnoughPassword(password) {
-  if (!password || password.length < 10) {
+async function verifyPassword(password, passwordHash) {
+  if (!password || !passwordHash) {
     return false;
   }
 
-  const symbolCount = (password.match(/[^a-zA-Z0-9]/g) || []).length;
-  return symbolCount >= 2;
+  return bcrypt.compare(password, passwordHash);
 }
 
-router.post('/login', (req, res, next) => {
-  passport.authenticate('local', (error, user, info) => {
-    if (error) {
-      return next(error);
-    }
+function generateResetToken() {
+  return crypto.randomBytes(32).toString('hex');
+}
 
-    if (!user) {
-      return res.status(401).json({
-        error: info?.message || 'Credenciales inválidas.'
-      });
-    }
-
-    if (!user.isActive) {
-      return res.status(403).json({
-        error: 'La cuenta no está activa.'
-      });
-    }
-
-    req.logIn(user, (loginError) => {
-      if (loginError) {
-        return next(loginError);
-      }
-
-      return res.json({
-        ok: true,
-        redirectTo: '/'
-      });
-    });
-  })(req, res, next);
-});
-
-router.post('/register', async (req, res, next) => {
-  try {
-    const {
-      name,
-      lastname,
-      dni,
-      email,
-      gender,
-      password,
-      password_confirmation: passwordConfirmation
-    } = req.body;
-
-    if (!name || !lastname || !dni || !email || !gender || !password || !passwordConfirmation) {
-      return res.status(400).json({
-        error: 'Faltan campos obligatorios.'
-      });
-    }
-
-    if (!isValidEmail(email)) {
-      return res.status(400).json({
-        error: 'El correo electrónico no es válido.'
-      });
-    }
-
-    if (password !== passwordConfirmation) {
-      return res.status(400).json({
-        error: 'Las contraseñas no coinciden.'
-      });
-    }
-
-    if (!isStrongEnoughPassword(password)) {
-      return res.status(400).json({
-        error: 'La contraseña debe tener al menos 10 caracteres y 2 símbolos.'
-      });
-    }
-
-    const existingByEmail = await userService.findByEmail(email);
-    if (existingByEmail) {
-      return res.status(409).json({
-        error: 'Ya existe una cuenta con ese correo.'
-      });
-    }
-
-    const existingByLogin = await userService.findByLogin(dni);
-    if (existingByLogin) {
-      return res.status(409).json({
-        error: 'Ya existe una cuenta con ese identificador.'
-      });
-    }
-
-    await userService.createUser({
-      name,
-      lastname,
-      dni,
-      email,
-      gender,
-      password
-    });
-
-    return res.status(201).json({ ok: true });
-  } catch (error) {
-    return next(error);
-  }
-});
-
-router.post('/forgot', async (req, res, next) => {
-  try {
-    const email = String(req.body.email || '').trim();
-
-    if (!email) {
-      return res.status(400).json({
-        error: 'El correo electrónico es obligatorio.'
-      });
-    }
-
-    if (!isValidEmail(email)) {
-      return res.status(400).json({
-        error: 'El correo electrónico no es válido.'
-      });
-    }
-
-    const user = await userService.findByEmail(email);
-
-    if (user) {
-      const token = await userService.createPasswordReset(email);
-
-      // TODO: Replace with real mail delivery
-      console.log(`Password reset token for ${email}: ${token}`);
-    }
-
-    return res.json({
-      ok: true
-    });
-  } catch (error) {
-    return next(error);
-  }
-});
-
-router.post('/reset-password', async (req, res, next) => {
-  try {
-    const {
-      token,
-      password,
-      password_confirmation: passwordConfirmation
-    } = req.body;
-
-    if (!token || !password || !passwordConfirmation) {
-      return res.status(400).json({
-        error: 'Faltan datos obligatorios.'
-      });
-    }
-
-    if (password !== passwordConfirmation) {
-      return res.status(400).json({
-        error: 'Las contraseñas no coinciden.'
-      });
-    }
-
-    if (!isStrongEnoughPassword(password)) {
-      return res.status(400).json({
-        error: 'La contraseña debe tener al menos 10 caracteres y 2 símbolos.'
-      });
-    }
-
-    const resetRecord = await userService.findPasswordResetByToken(token);
-
-    if (!resetRecord) {
-      return res.status(400).json({
-        error: 'El enlace no es válido o ha expirado.'
-      });
-    }
-
-    await userService.updatePasswordByEmail(resetRecord.mail, password);
-    await userService.deletePasswordResetToken(token);
-
-    return res.json({ ok: true });
-  } catch (error) {
-    return next(error);
-  }
-});
-
-router.post('/logout', (req, res, next) => {
-  req.logout((logoutError) => {
-    if (logoutError) {
-      return next(logoutError);
-    }
-
-    req.session.destroy(() => {
-      res.clearCookie(process.env.SESSION_COOKIE_NAME || 'auth.sid');
-      return res.json({ ok: true });
-    });
-  });
-});
-
-router.get('/me', (req, res) => {
-  if (!req.isAuthenticated || !req.isAuthenticated()) {
-    return res.status(401).json({
-      error: 'No autenticado.'
-    });
-  }
-
-  return res.json({
-    id: req.user.id,
-    name: req.user.name,
-    email: req.user.email,
-    role: req.user.role
-  });
-});
-
-router.get('/auth/session/check', (req, res) => {
-  if (!req.isAuthenticated || !req.isAuthenticated()) {
-    return res.status(401).end();
-  }
-
-  res.set('X-User-Id', String(req.user.id));
-  res.set('X-User-Role', String(req.user.role || 'A'));
-  res.set('X-User-Email', String(req.user.email || ''));
-
-  return res.status(200).end();
-});
-
-module.exports = router;
+export {
+  hashPassword,
+  verifyPassword,
+  generateResetToken
+};

--- a/auth-backend/services/recaptcha.service.js
+++ b/auth-backend/services/recaptcha.service.js
@@ -42,6 +42,9 @@ async function verifyRecaptchaToken({ token, remoteIp }) {
   return body.success === true;
 }
 
-module.exports = {
+const recaptchaService = {
   verifyRecaptchaToken
 };
+
+export { verifyRecaptchaToken };
+export default recaptchaService;

--- a/auth-backend/services/session-store.service.js
+++ b/auth-backend/services/session-store.service.js
@@ -1,5 +1,5 @@
-const { createClient } = require('redis');
-const RedisStore = require('connect-redis').default;
+import { createClient } from 'redis';
+import RedisStore from 'connect-redis';
 
 function createSessionRedisClient() {
   const host = process.env.REDIS_HOST || '127.0.0.1';
@@ -31,6 +31,4 @@ function createSessionStore() {
   });
 }
 
-module.exports = {
-  createSessionStore
-};
+export { createSessionStore };

--- a/auth-backend/services/user.service.js
+++ b/auth-backend/services/user.service.js
@@ -1,5 +1,5 @@
-const { query } = require('../config/database');
-const { hashPassword, verifyPassword, generateResetToken } = require('./password.service');
+import { query } from '../config/database.js';
+import { hashPassword, verifyPassword, generateResetToken } from './password.service.js';
 
 function mapUser(row) {
   if (!row) return null;
@@ -168,7 +168,7 @@ async function deletePasswordResetToken(token) {
   );
 }
 
-module.exports = {
+const userService = {
   findById,
   findByLogin,
   findByEmail,
@@ -179,3 +179,16 @@ module.exports = {
   updatePasswordByEmail,
   deletePasswordResetToken
 };
+
+export {
+  findById,
+  findByLogin,
+  findByEmail,
+  authenticateLocal,
+  createUser,
+  createPasswordReset,
+  findPasswordResetByToken,
+  updatePasswordByEmail,
+  deletePasswordResetToken
+};
+export default userService;


### PR DESCRIPTION
## Context

`auth-backend` was the remaining CommonJS backend in the workspace. This PR migrates its backend/runtime code to native ES Modules so it aligns with the rest of the newer JavaScript projects.

## What changed

- Switch `auth-backend/package.json` from `type: commonjs` to `type: module` and set `main` to `server.js`.
- Convert backend entrypoints, routes, services, i18n modules, config, and utility scripts from `require/module.exports` to `import/export`.
- Add ESM-safe `__dirname` handling where filesystem paths are needed for views, static assets, and email templates.
- Replace the accidental route-like contents of `services/password.service.js` with the password helper exports that `user.service.js` expects: `hashPassword`, `verifyPassword`, and `generateResetToken`.

## Impact

Runtime behavior should stay the same, except the password service import path is now corrected and explicit under ESM. Local scripts such as `create:user`, `create:admin`, and `seed-users` continue to run as Node ESM scripts.

## Risks / limitations

- I did not run full Docker builds or live DB/Redis-backed endpoint flows.
- A local import of `app.js` emits the existing `express-session` warning when `SESSION_SECRET` is absent in the isolated shell environment.

## Verification

- `node --check auth-backend/server.js`
- `find auth-backend -path '*/node_modules' -prune -o -path 'auth-backend/frontend' -prune -o -name '*.js' -print | xargs node --check`
- `node -e "import('./app.js').then(() => process.exit(0)).catch((err) => { console.error(err); process.exit(1); })"` from `auth-backend/`
- `node -e "import('./routes/auth.routes.js').then(() => console.log('auth routes ok'))"` from `auth-backend/`
- Password helper smoke test with `hashPassword`, `verifyPassword`, and `generateResetToken`
- `git diff --check -- auth-backend`