### PR TITLE
[codex] add CSRF protection to auth and management

### DIFF
--- a/auth-backend/.env.example
+++ b/auth-backend/.env.example
@@ -1,11 +1,24 @@
 PORT=8502
-SESSION_SECRET=...
+
+# Session signing secret for the auth-backend cookie (`auth.sid`). Use a strong
+# service-specific value in production. It does not need to match
+# management-console's MNG_SESSION_SECRET.
+AUTH_SESSION_SECRET=change-this-in-production
+
+# Legacy/shared fallback used only if AUTH_SESSION_SECRET is not set.
+# Prefer AUTH_SESSION_SECRET for auth-backend deployments.
+# SESSION_SECRET=change-this-in-production
 SESSION_COOKIE_NAME=auth.sid
 SESSION_COOKIE_SAMESITE=lax
 SESSION_COOKIE_SECURE=false
 AUTH_SESSION_COOKIE_MAX_AGE_MS=28800000
 AUTH_SESSION_TTL_SECONDS=28800
 AUTH_SESSION_REDIS_PREFIX=auth:sess:
+
+# Shared service-auth secret for management-console -> auth-backend internal
+# calls. This value must match management-console's AUTH_INTERNAL_SERVICE_TOKEN.
+AUTH_INTERNAL_SERVICE_TOKEN=change-this-in-production
+
 BCRYPT_SALT_ROUNDS=10
 RESET_TOKEN_TTL_MINUTES=60
 CREATE_ADMIN=true

--- a/auth-backend/app.js
+++ b/auth-backend/app.js
@@ -7,6 +7,7 @@ import passportLocal from 'passport-local';
 
 import userService from './services/user.service.js';
 import { createSessionStore } from './services/session-store.service.js';
+import { csrfProtection } from './middleware/csrfProtection.js';
 
 import viewRoutes from './routes/view.routes.js';
 import authRoutes from './routes/auth.routes.js';
@@ -48,7 +49,7 @@ app.use(
   session({
     store: createSessionStore(),
     name: process.env.SESSION_COOKIE_NAME || 'auth.sid',
-    secret: process.env.SESSION_SECRET,
+    secret: process.env.AUTH_SESSION_SECRET || process.env.SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
     rolling: false,
@@ -130,6 +131,7 @@ app.use(function exposeAuthState(req, res, next) {
 // Routes
 // --------------------------------------------------
 app.use('/', viewRoutes);
+app.use('/api/auth', csrfProtection);
 app.use('/api/auth', authRoutes);
 
 // --------------------------------------------------

--- a/auth-backend/frontend/src/api/authApi.js
+++ b/auth-backend/frontend/src/api/authApi.js
@@ -6,6 +6,35 @@ const authApiClient = axios.create({
   withCredentials: true
 });
 
+let csrfTokenPromise = null;
+
+function isMutatingMethod(method = 'get') {
+  return ['post', 'put', 'patch', 'delete'].includes(method.toLowerCase());
+}
+
+async function getCsrfToken() {
+  if (!csrfTokenPromise) {
+    csrfTokenPromise = authApiClient
+      .get('/csrf-token')
+      .then((response) => response.data.csrfToken)
+      .catch((error) => {
+        csrfTokenPromise = null;
+        throw error;
+      });
+  }
+
+  return csrfTokenPromise;
+}
+
+authApiClient.interceptors.request.use(async (config) => {
+  if (isMutatingMethod(config.method)) {
+    config.headers = config.headers || {};
+    config.headers['X-CSRF-Token'] = await getCsrfToken();
+  }
+
+  return config;
+});
+
 export async function login(credentials) {
   const response = await authApiClient.post('/login', credentials);
   return response.data;

--- a/auth-backend/middleware/README.md
+++ b/auth-backend/middleware/README.md
@@ -1,0 +1,17 @@
+# Auth backend middleware
+
+## CSRF protection
+
+`csrfProtection.js` protects browser-initiated mutating requests by requiring a
+session-bound token in `X-CSRF-Token`. The token is issued by
+`GET /api/auth/csrf-token` and stored in the Express session.
+
+CSRF applies to browser requests that automatically carry cookies. Internal
+server-to-server requests should not use browser CSRF tokens. Instead,
+`management-console` authenticates its internal calls to `auth-backend` with
+`X-Internal-Service-Token`, and this service validates it against
+`AUTH_INTERNAL_SERVICE_TOKEN`.
+
+Production deployments must set the same `AUTH_INTERNAL_SERVICE_TOKEN` value in
+both `auth-backend` and `management-console`. The development fallback exists
+only to keep local Docker Compose usable when the variable is not set.

--- a/auth-backend/middleware/__tests__/csrfProtection.node-test.mjs
+++ b/auth-backend/middleware/__tests__/csrfProtection.node-test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import express from 'express';
+import { describe, it } from 'node:test';
+
+import { csrfProtection, csrfTokenHandler } from '../csrfProtection.js';
+
+async function withServer(app, callback) {
+  const server = app.listen(0, '127.0.0.1');
+
+  await new Promise((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  }
+}
+
+function createTestApp(sessionStore = {}) {
+  const app = express();
+
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.session = sessionStore;
+    next();
+  });
+  app.get('/api/auth/csrf-token', csrfTokenHandler);
+  app.use('/api/auth', csrfProtection);
+  app.get('/api/auth/read', (req, res) => res.json({ ok: true }));
+  app.post('/api/auth/write', (req, res) => res.json({ ok: true }));
+
+  return app;
+}
+
+describe('auth-backend csrfProtection', () => {
+  it('allows safe methods without a CSRF token', async () => {
+    const app = createTestApp();
+
+    await withServer(app, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/auth/read`);
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { ok: true });
+    });
+  });
+
+  it('issues a session-bound CSRF token', async () => {
+    const session = {};
+    const app = createTestApp(session);
+
+    await withServer(app, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/auth/csrf-token`);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.equal(typeof body.csrfToken, 'string');
+      assert.equal(body.csrfToken, session.csrfToken);
+    });
+  });
+
+  it('rejects mutating requests without the session CSRF token', async () => {
+    const app = createTestApp();
+
+    await withServer(app, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/auth/write`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({})
+      });
+
+      assert.equal(response.status, 403);
+      assert.deepEqual(await response.json(), { error: 'Invalid CSRF token' });
+    });
+  });
+
+  it('allows mutating requests with the session CSRF token', async () => {
+    const session = {};
+    const app = createTestApp(session);
+
+    await withServer(app, async (baseUrl) => {
+      const tokenResponse = await fetch(`${baseUrl}/api/auth/csrf-token`);
+      const { csrfToken } = await tokenResponse.json();
+
+      const response = await fetch(`${baseUrl}/api/auth/write`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken
+        },
+        body: JSON.stringify({})
+      });
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { ok: true });
+    });
+  });
+
+  it('allows server-to-server requests with the internal service token', async () => {
+    const previousToken = process.env.AUTH_INTERNAL_SERVICE_TOKEN;
+    process.env.AUTH_INTERNAL_SERVICE_TOKEN = 'test-internal-token';
+
+    try {
+      const app = createTestApp();
+
+      await withServer(app, async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/api/auth/write`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Internal-Service-Token': 'test-internal-token'
+          },
+          body: JSON.stringify({})
+        });
+
+        assert.equal(response.status, 200);
+        assert.deepEqual(await response.json(), { ok: true });
+      });
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.AUTH_INTERNAL_SERVICE_TOKEN;
+      } else {
+        process.env.AUTH_INTERNAL_SERVICE_TOKEN = previousToken;
+      }
+    }
+  });
+});

--- a/auth-backend/middleware/csrfProtection.js
+++ b/auth-backend/middleware/csrfProtection.js
@@ -1,0 +1,83 @@
+import crypto from 'node:crypto';
+
+const CSRF_SESSION_KEY = 'csrfToken';
+const CSRF_HEADER_NAME = 'x-csrf-token';
+const INTERNAL_SERVICE_HEADER_NAME = 'x-internal-service-token';
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const DEVELOPMENT_INTERNAL_SERVICE_TOKEN = 'development-internal-service-token';
+
+function getInternalServiceToken() {
+  const configuredToken = (process.env.AUTH_INTERNAL_SERVICE_TOKEN || '').trim();
+
+  if (configuredToken) {
+    return configuredToken;
+  }
+
+  return process.env.NODE_ENV === 'production'
+    ? ''
+    : DEVELOPMENT_INTERNAL_SERVICE_TOKEN;
+}
+
+function safeEqual(left, right) {
+  const leftBuffer = Buffer.from(String(left || ''));
+  const rightBuffer = Buffer.from(String(right || ''));
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function getRequestCsrfToken(req) {
+  return String(req.get(CSRF_HEADER_NAME) || req.body?._csrf || '').trim();
+}
+
+function hasValidInternalServiceToken(req) {
+  const expectedToken = getInternalServiceToken();
+  const providedToken = String(req.get(INTERNAL_SERVICE_HEADER_NAME) || '').trim();
+
+  return Boolean(expectedToken && providedToken && safeEqual(providedToken, expectedToken));
+}
+
+export function ensureCsrfToken(req) {
+  if (!req.session) {
+    throw new Error('Session middleware is required before CSRF protection');
+  }
+
+  if (!req.session[CSRF_SESSION_KEY]) {
+    req.session[CSRF_SESSION_KEY] = crypto.randomBytes(32).toString('base64url');
+  }
+
+  return req.session[CSRF_SESSION_KEY];
+}
+
+export function csrfTokenHandler(req, res) {
+  return res.status(200).json({
+    csrfToken: ensureCsrfToken(req)
+  });
+}
+
+export function csrfProtection(req, res, next) {
+  if (!MUTATING_METHODS.has(req.method) || hasValidInternalServiceToken(req)) {
+    return next();
+  }
+
+  let expectedToken;
+
+  try {
+    expectedToken = ensureCsrfToken(req);
+  } catch (error) {
+    return next(error);
+  }
+
+  const providedToken = getRequestCsrfToken(req);
+
+  if (!providedToken || !safeEqual(providedToken, expectedToken)) {
+    return res.status(403).json({
+      error: 'Invalid CSRF token'
+    });
+  }
+
+  return next();
+}

--- a/auth-backend/package.json
+++ b/auth-backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "nodemon server.js",
     "start": "node server.js",
+    "test": "node --test \"**/*.node-test.mjs\"",
     "create:user": "node scripts/create-user.js",
     "create:admin": "node scripts/create-admin.js",
     "frontend:dev": "cd frontend && npm run dev",

--- a/auth-backend/routes/auth.routes.js
+++ b/auth-backend/routes/auth.routes.js
@@ -7,6 +7,7 @@ import mailService from '../services/mail.service.js';
 import recaptchaService from '../services/recaptcha.service.js';
 import authMessages from '../i18n/messages/auth-messages.js';
 import { inferPreferredLocaleFromRequest, normalizePreferredLocale, translateMessage } from '../i18n/locale.js';
+import { csrfTokenHandler } from '../middleware/csrfProtection.js';
 
 const router = express.Router();
 
@@ -77,6 +78,8 @@ function duplicateEmailResponse(req) {
 function t(req, key) {
   return translateMessage(req, key, authMessages);
 }
+
+router.get('/csrf-token', csrfTokenHandler);
 
 router.post('/login', async (req, res, next) => {
   try {

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,6 +28,20 @@ The contract distinguishes:
 
 All `VITE_*` variables are public frontend variables. They must never contain secrets.
 
+Use service-specific session secrets where the contract provides them. For
+example, `auth-backend` uses `AUTH_SESSION_SECRET` for `auth.sid`, while
+`management-console` uses `MNG_SESSION_SECRET` for `ethicapp.mng.sid`. These
+values do not need to match. `SESSION_SECRET` remains a shared fallback for
+legacy-compatible services, not the preferred production setting.
+
+`AUTH_INTERNAL_SERVICE_TOKEN` is a shared secret between `management-console`
+and `auth-backend`. It allows management-console to make server-to-server auth
+calls that are exempt from browser CSRF checks. Production deployments must set
+the same non-placeholder value in both services. The deployment contract marks
+this variable as required and intentionally provides no default. This token is
+service authentication for internal calls, not a browser CSRF token; do not
+expose it in frontend runtime config or any `VITE_*` variable.
+
 Production images keep frontend bundles environment-neutral. Container entrypoints
 emit public `VITE_*` values into each frontend's `runtime-config.js` when the
 container starts, so deployment repositories should provide those values as

--- a/deploy/env.contract.yml
+++ b/deploy/env.contract.yml
@@ -296,7 +296,7 @@ variables:
     type: secret
     required: true
     secret: true
-    services: [auth-backend, ethicapp, ethicapp-student, management-console]
+    services: [ethicapp, ethicapp-student, management-console]
     phase: runtime
     description: Shared fallback session signing secret. Prefer service-specific secrets where available.
 
@@ -427,6 +427,22 @@ variables:
     services: [management-console]
     phase: runtime
     description: Internal URL used by management-console to call auth-backend.
+
+  AUTH_INTERNAL_SERVICE_TOKEN:
+    type: secret
+    required: true
+    secret: true
+    services: [auth-backend, management-console]
+    phase: runtime
+    description: Shared secret used by management-console for CSRF-exempt server-to-server calls into auth-backend. Must match in both services.
+
+  AUTH_SESSION_SECRET:
+    type: secret
+    required: true
+    secret: true
+    services: [auth-backend]
+    phase: runtime
+    description: Auth backend session signing secret. Falls back to SESSION_SECRET for legacy deployments, but production deployments should provide this service-specific value.
 
   AUTH_COOKIE_NAME:
     type: string
@@ -851,7 +867,7 @@ projections:
     variables:
       - PORT
       - NODE_ENV
-      - SESSION_SECRET
+      - AUTH_SESSION_SECRET
       - SESSION_COOKIE_NAME
       - SESSION_COOKIE_SAMESITE
       - SESSION_COOKIE_SECURE
@@ -859,6 +875,7 @@ projections:
       - AUTH_SESSION_COOKIE_MAX_AGE_MS
       - AUTH_SESSION_TTL_SECONDS
       - AUTH_SESSION_REDIS_PREFIX
+      - AUTH_INTERNAL_SERVICE_TOKEN
       - BCRYPT_SALT_ROUNDS
       - RESET_TOKEN_TTL_MINUTES
       - CREATE_ADMIN
@@ -896,6 +913,7 @@ projections:
       - MNG_SESSION_SECRET
       - SESSION_SECRET
       - AUTH_BACKEND_INTERNAL_BASE_URL
+      - AUTH_INTERNAL_SERVICE_TOKEN
       - ETHICAPP_INTERNAL_BASE_URL
       - VITE_RECAPTCHA_SITE_KEY
   database:

--- a/management-console/.env.example
+++ b/management-console/.env.example
@@ -1,10 +1,22 @@
 MNG_PORT=8504
+
+# Session signing secret for the management console cookie
+# (`ethicapp.mng.sid`). Prefer this service-specific secret in production.
 MNG_SESSION_SECRET=change-this-in-production
+
+# Legacy/shared fallback used only if MNG_SESSION_SECRET is not set.
+# Prefer MNG_SESSION_SECRET for management-console deployments.
 SESSION_SECRET=change-this-in-production
+
 PGHOST=postgresql
 PGPORT=5432
 PGUSER=postgres
 PGPASSWORD=postgres
 PGDATABASE=ethicapp
 AUTH_BACKEND_INTERNAL_BASE_URL=http://auth-backend:8502/api/auth
+
+# Shared service-auth secret for management-console -> auth-backend internal
+# calls. This value must match auth-backend's AUTH_INTERNAL_SERVICE_TOKEN.
+AUTH_INTERNAL_SERVICE_TOKEN=change-this-in-production
+
 ETHICAPP_INTERNAL_BASE_URL=http://ethicapp:8501

--- a/management-console/backend/app.js
+++ b/management-console/backend/app.js
@@ -4,6 +4,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import hydrateSessionFromAuthProxy from './middleware/hydrateSessionFromAuthProxy.js';
+import { csrfProtection } from './middleware/csrfProtection.js';
+import csrfRoutes from './routes/csrf.routes.js';
 import runtimeConfigRoutes from './routes/runtime-config.routes.js';
 import viewRoutes from './routes/view.routes.js';
 import usersRoutes from './routes/users.routes.js';
@@ -35,6 +37,8 @@ app.use(
 app.use(hydrateSessionFromAuthProxy);
 app.use(runtimeConfigRoutes);
 app.use('/mng/assets', express.static(path.join(__dirname, '../frontend/dist/assets')));
+app.use(csrfRoutes);
+app.use('/mng/api', csrfProtection);
 app.use(usersRoutes);
 app.use(viewRoutes);
 

--- a/management-console/backend/middleware/README.md
+++ b/management-console/backend/middleware/README.md
@@ -1,0 +1,17 @@
+# Management console middleware
+
+## CSRF protection
+
+`csrfProtection.js` protects browser-initiated mutating requests under
+`/mng/api` by requiring a session-bound token in `X-CSRF-Token`. The token is
+issued by `GET /mng/api/csrf-token` and stored in the Express session.
+
+CSRF applies to browser requests that automatically carry cookies. Internal
+server-to-server calls from `management-console` to `auth-backend` use explicit
+service authentication instead: `authBackend.service.js` sends
+`X-Internal-Service-Token`, and `auth-backend` validates it against
+`AUTH_INTERNAL_SERVICE_TOKEN`.
+
+Production deployments must set the same `AUTH_INTERNAL_SERVICE_TOKEN` value in
+both `auth-backend` and `management-console`. The development fallback exists
+only to keep local Docker Compose usable when the variable is not set.

--- a/management-console/backend/middleware/__tests__/csrfProtection.node-test.mjs
+++ b/management-console/backend/middleware/__tests__/csrfProtection.node-test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import express from 'express';
+import { describe, it } from 'node:test';
+
+import { csrfProtection, csrfTokenHandler } from '../csrfProtection.js';
+
+async function withServer(app, callback) {
+  const server = app.listen(0, '127.0.0.1');
+
+  await new Promise((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  }
+}
+
+function createTestApp(sessionStore = {}) {
+  const app = express();
+
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.session = sessionStore;
+    next();
+  });
+  app.get('/mng/api/csrf-token', csrfTokenHandler);
+  app.use('/mng/api', csrfProtection);
+  app.get('/mng/api/read', (req, res) => res.json({ ok: true }));
+  app.put('/mng/api/write', (req, res) => res.json({ ok: true }));
+
+  return app;
+}
+
+describe('management-console csrfProtection', () => {
+  it('allows safe methods without a CSRF token', async () => {
+    const app = createTestApp();
+
+    await withServer(app, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/mng/api/read`);
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { ok: true });
+    });
+  });
+
+  it('issues a session-bound CSRF token', async () => {
+    const session = {};
+    const app = createTestApp(session);
+
+    await withServer(app, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/mng/api/csrf-token`);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.equal(typeof body.csrfToken, 'string');
+      assert.equal(body.csrfToken, session.csrfToken);
+    });
+  });
+
+  it('rejects mutating requests without the session CSRF token', async () => {
+    const app = createTestApp();
+
+    await withServer(app, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/mng/api/write`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({})
+      });
+
+      assert.equal(response.status, 403);
+      assert.deepEqual(await response.json(), { error: 'Invalid CSRF token' });
+    });
+  });
+
+  it('allows mutating requests with the session CSRF token', async () => {
+    const session = {};
+    const app = createTestApp(session);
+
+    await withServer(app, async (baseUrl) => {
+      const tokenResponse = await fetch(`${baseUrl}/mng/api/csrf-token`);
+      const { csrfToken } = await tokenResponse.json();
+
+      const response = await fetch(`${baseUrl}/mng/api/write`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken
+        },
+        body: JSON.stringify({})
+      });
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { ok: true });
+    });
+  });
+});

--- a/management-console/backend/middleware/csrfProtection.js
+++ b/management-console/backend/middleware/csrfProtection.js
@@ -1,0 +1,62 @@
+import crypto from 'node:crypto';
+
+const CSRF_SESSION_KEY = 'csrfToken';
+const CSRF_HEADER_NAME = 'x-csrf-token';
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function safeEqual(left, right) {
+  const leftBuffer = Buffer.from(String(left || ''));
+  const rightBuffer = Buffer.from(String(right || ''));
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function getRequestCsrfToken(req) {
+  return String(req.get(CSRF_HEADER_NAME) || req.body?._csrf || '').trim();
+}
+
+export function ensureCsrfToken(req) {
+  if (!req.session) {
+    throw new Error('Session middleware is required before CSRF protection');
+  }
+
+  if (!req.session[CSRF_SESSION_KEY]) {
+    req.session[CSRF_SESSION_KEY] = crypto.randomBytes(32).toString('base64url');
+  }
+
+  return req.session[CSRF_SESSION_KEY];
+}
+
+export function csrfTokenHandler(req, res) {
+  return res.status(200).json({
+    csrfToken: ensureCsrfToken(req)
+  });
+}
+
+export function csrfProtection(req, res, next) {
+  if (!MUTATING_METHODS.has(req.method)) {
+    return next();
+  }
+
+  let expectedToken;
+
+  try {
+    expectedToken = ensureCsrfToken(req);
+  } catch (error) {
+    return next(error);
+  }
+
+  const providedToken = getRequestCsrfToken(req);
+
+  if (!providedToken || !safeEqual(providedToken, expectedToken)) {
+    return res.status(403).json({
+      error: 'Invalid CSRF token'
+    });
+  }
+
+  return next();
+}

--- a/management-console/backend/routes/csrf.routes.js
+++ b/management-console/backend/routes/csrf.routes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+
+import requireManagementRole from '../middleware/requireManagementRole.js';
+import { csrfTokenHandler } from '../middleware/csrfProtection.js';
+
+const router = express.Router();
+
+router.get('/mng/api/csrf-token', requireManagementRole, csrfTokenHandler);
+
+export default router;

--- a/management-console/backend/services/authBackend.service.js
+++ b/management-console/backend/services/authBackend.service.js
@@ -1,8 +1,29 @@
 const AUTH_BACKEND_INTERNAL_BASE_URL =
   process.env.AUTH_BACKEND_INTERNAL_BASE_URL || 'http://auth-backend:8502/api/auth';
+const DEVELOPMENT_INTERNAL_SERVICE_TOKEN = 'development-internal-service-token';
+
+function getInternalServiceToken() {
+  const configuredToken = (process.env.AUTH_INTERNAL_SERVICE_TOKEN || '').trim();
+
+  if (configuredToken) {
+    return configuredToken;
+  }
+
+  return process.env.NODE_ENV === 'production'
+    ? ''
+    : DEVELOPMENT_INTERNAL_SERVICE_TOKEN;
+}
 
 function buildUrl(pathname) {
   return `${AUTH_BACKEND_INTERNAL_BASE_URL.replace(/\/$/, '')}${pathname}`;
+}
+
+function internalServiceHeaders() {
+  const token = getInternalServiceToken();
+
+  return token
+    ? { 'X-Internal-Service-Token': token }
+    : {};
 }
 
 export async function verifyAdminPasswordWithAuthBackend({ password, cookie, language }) {
@@ -11,7 +32,8 @@ export async function verifyAdminPasswordWithAuthBackend({ password, cookie, lan
     headers: {
       'Content-Type': 'application/json',
       Cookie: cookie || '',
-      'Accept-Language': language || 'en-US'
+      'Accept-Language': language || 'en-US',
+      ...internalServiceHeaders()
     },
     body: JSON.stringify({ password })
   });
@@ -30,7 +52,8 @@ export async function triggerForgotPasswordWithAuthBackend({ email, recaptchaTok
     headers: {
       'Content-Type': 'application/json',
       Cookie: cookie || '',
-      'Accept-Language': language || 'en-US'
+      'Accept-Language': language || 'en-US',
+      ...internalServiceHeaders()
     },
     body: JSON.stringify({
       email,

--- a/management-console/frontend/src/api/usersApi.js
+++ b/management-console/frontend/src/api/usersApi.js
@@ -20,6 +20,36 @@ async function parseJson(response) {
   return json;
 }
 
+let csrfTokenPromise = null;
+
+async function getCsrfToken() {
+  if (!csrfTokenPromise) {
+    csrfTokenPromise = fetch('/mng/api/csrf-token', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json'
+      }
+    })
+      .then(parseJson)
+      .then((json) => json.csrfToken)
+      .catch((error) => {
+        csrfTokenPromise = null;
+        throw error;
+      });
+  }
+
+  return csrfTokenPromise;
+}
+
+async function mutatingJsonHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'X-CSRF-Token': await getCsrfToken()
+  };
+}
+
 export async function fetchUsers({ keywords = '', role = '', page = 1 }) {
   const query = toQueryString({ q: keywords, role, page });
   const response = await fetch(`/mng/api/users?${query}`, {
@@ -49,10 +79,7 @@ export async function updateUser(userId, payload) {
   const response = await fetch(`/mng/api/users/${userId}`, {
     method: 'PUT',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json'
-    },
+    headers: await mutatingJsonHeaders(),
     body: JSON.stringify(payload)
   });
 
@@ -63,10 +90,7 @@ export async function triggerPasswordReset(userId, payload) {
   const response = await fetch(`/mng/api/users/${userId}/password-reset`, {
     method: 'POST',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json'
-    },
+    headers: await mutatingJsonHeaders(),
     body: JSON.stringify(payload)
   });
 
@@ -77,10 +101,7 @@ export async function impersonateProfessor(userId, payload) {
   const response = await fetch(`/mng/api/users/${userId}/impersonate-professor`, {
     method: 'POST',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json'
-    },
+    headers: await mutatingJsonHeaders(),
     body: JSON.stringify(payload)
   });
 


### PR DESCRIPTION
## Context

`auth-backend` and `management-console` both rely on cookie-backed sessions for browser requests. Mutating endpoints did not require a per-session CSRF token, and management-console also calls selected auth-backend endpoints server-to-server.

## What changed

- Added custom Express CSRF middleware for `auth-backend` and `management-console` using session-bound random tokens and timing-safe comparison.
- Added token endpoints at `/api/auth/csrf-token` and `/mng/api/csrf-token`.
- Updated the auth frontend Axios client and management frontend fetch client to attach `X-CSRF-Token` on mutating requests.
- Added an `X-Internal-Service-Token` bypass for management-console server-to-server calls into auth-backend, backed by `AUTH_INTERNAL_SERVICE_TOKEN`.
- Documented `AUTH_INTERNAL_SERVICE_TOKEN` in `.env.example`, `deploy/env.contract.yml`, and `deploy/README.md`.
- Added focused Node tests for the new CSRF middleware.

## Risks and limitations

- Production deployments must configure the same non-placeholder `AUTH_INTERNAL_SERVICE_TOKEN` for both `auth-backend` and `management-console`.
- Existing auth frontend lint still fails in unrelated files (`MarkdownArticle.jsx`, `useCookieNotice.js`); this PR does not change those files.
- The visible logout navigation appears to route to the auth SPA rather than calling the logout API; I left that as a separate follow-up so the CSRF change stays focused.

## Verification

- `npm test` in `management-console/backend` passed.
- `npm test` in `auth-backend` passed.
- `npm run frontend:build` in `auth-backend` passed, with existing Vite warnings about `runtime-config.js` and runtime fonts.
- `npm run build` in `management-console/frontend` passed, with existing Vite warnings about `runtime-config.js` and runtime fonts.
- `npm run lint` in `auth-backend/frontend` was attempted and failed on pre-existing issues outside this PR.