### PR TITLE
[codex] migrate legacy logout to CSRF POST flow

### DIFF
--- a/auth-backend/frontend/src/api/authApi.js
+++ b/auth-backend/frontend/src/api/authApi.js
@@ -54,3 +54,8 @@ export async function resetPassword(payload) {
   const response = await authApiClient.post('/reset-password', payload);
   return response.data;
 }
+
+export async function logout() {
+  const response = await authApiClient.post('/logout');
+  return response.data;
+}

--- a/auth-backend/frontend/src/pages/LogoutPage.jsx
+++ b/auth-backend/frontend/src/pages/LogoutPage.jsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+import { logout } from '../api/authApi';
+import LoginPage from './LoginPage';
+
+function LogoutPage() {
+  useEffect(() => {
+    let active = true;
+
+    async function endSession() {
+      try {
+        await logout();
+      } catch (error) {
+        console.error('Unable to complete logout:', error);
+      } finally {
+        if (active) {
+          window.location.replace('/auth/login');
+        }
+      }
+    }
+
+    endSession();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return <LoginPage />;
+}
+
+export default LogoutPage;

--- a/auth-backend/frontend/src/router/index.jsx
+++ b/auth-backend/frontend/src/router/index.jsx
@@ -4,6 +4,7 @@ import LoginPage from '../pages/LoginPage';
 import RegisterPage from '../pages/RegisterPage';
 import ForgotPasswordPage from '../pages/ForgotPasswordPage';
 import ResetPasswordPage from '../pages/ResetPasswordPage';
+import LogoutPage from '../pages/LogoutPage';
 
 import NotFoundPage from '../pages/NotFoundPage';
 import PrivacyPolicyPage from '../pages/PrivacyPolicyPage';
@@ -20,7 +21,7 @@ const router = createBrowserRouter([
   },
   {
     path: '/logout',
-    element: <LoginPage />
+    element: <LogoutPage />
   },  
   {
     path: '/register',

--- a/ethicapp/backend/views/home.ejs
+++ b/ethicapp/backend/views/home.ejs
@@ -39,7 +39,7 @@
       </div>
       <strong class="margin-right-8"><a href="#!/profile" style="color: white;"> {{ vm.getDisplayName() || ('profile' | translate) }}
         </a></strong>
-      <a href="logout" class="text-white ml-2" title="{{'exitEthicapp' | translate}}">
+      <a href="/logout" class="text-white ml-2" title="{{'exitEthicapp' | translate}}">
         <i class="fa fa-sign-out fa-2x"></i>
       </a>
     </div>


### PR DESCRIPTION
## Context

Closes #521.

Legacy EthicApp and management-console expose logout as a navigation action through `/logout`. NGINX redirects that path to `/auth/logout`, but the auth SPA previously rendered the login page without calling the logout API. That meant the visible logout path did not reliably destroy the auth session and could not benefit from the CSRF-protected `POST /api/auth/logout` flow.

## What changed

- Added an auth frontend `LogoutPage` for `/auth/logout`.
- Added `logout()` to the auth API client, using `POST /api/auth/logout`; the existing Axios interceptor attaches `X-CSRF-Token`.
- Updated the auth router so `/auth/logout` runs the logout flow and then redirects to `/auth/login`.
- Normalized the legacy teacher topbar link from relative `logout` to `/logout` so it consistently enters the NGINX compatibility redirect.

## Notes

- `GET /api/auth/logout` remains available as compatibility for now; this PR migrates the visible legacy navigation path away from mutating GET behavior.
- The branch includes the CSRF middleware foundation because the logout hardening depends on `/api/auth/csrf-token` and the CSRF-aware auth API client.

## Verification

- `npm run frontend:build` in `auth-backend` passed, with existing Vite warnings about `runtime-config.js` and runtime fonts.

## Manual verification to run

- Click logout from the legacy teacher topbar and confirm the browser requests `GET /api/auth/csrf-token`, then `POST /api/auth/logout` with `X-CSRF-Token`.
- Confirm the user lands on `/auth/login` and `auth.sid` is cleared.
- Click logout from management-console and confirm it follows the same safe `/auth/logout` flow.