### PR TITLE
[codex] Harden protected upload access control

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     volumes:
       - ./nginx/conf.d/dev.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/static:/usr/share/nginx/html/static:ro
-      - uploads:/var/www/uploads:ro
 
   ethicapp:
     build:

--- a/ethicapp/backend/app.js
+++ b/ethicapp/backend/app.js
@@ -25,10 +25,10 @@ import designs from "./controllers/designs.js";
 import groups from "./controllers/groups.js";
 import group_messages from "./controllers/group-messages.js";
 import cases from "./controllers/cases.js";
+import protectedUploads from "./controllers/protected-uploads.js";
 
 import fs from "fs";
 
-import { uploadsPath } from "./config/uploads.config.js";
 import i18n from "i18n";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -73,13 +73,8 @@ app.use(cors(corsOptions));
 
 // Asset handling
 const assetPath = path.join(__dirname, "../frontend/assets");
-const uploadsAbsolutePath = path.resolve(process.cwd(), uploadsPath);
 app.use(express.static(assetPath));
 app.use(assetVersions("/assets", assetPath));
-
-// Uploads
-app.use("/uploads", express.static(uploadsAbsolutePath));
-app.use("/assets/uploads", express.static(uploadsAbsolutePath));
 
 // view engine setup
 app.set("views", path.join(__dirname, "views"));
@@ -122,6 +117,7 @@ app.use(session({
 
 app.use(hydrateLegacySession);
 app.use(exposeLegacySession);
+app.use("/", requireLegacyAuth, protectedUploads);
 
 // Middleware for handling redis errors
 app.use((req, res, next) => {

--- a/ethicapp/backend/controllers/__tests__/protected-uploads.node-test.mjs
+++ b/ethicapp/backend/controllers/__tests__/protected-uploads.node-test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    getAuthorizedUpload,
+    normalizeRequestedUploadPath,
+} from "../protected-uploads.js";
+
+test("normalizeRequestedUploadPath accepts legacy upload URL shapes", () => {
+    assert.equal(
+        normalizeRequestedUploadPath("/uploads/cases/12/case.pdf"),
+        "cases/12/case.pdf"
+    );
+    assert.equal(
+        normalizeRequestedUploadPath("/uploads/user-profiles/5/user-5-topbar-64.jpg?v=1"),
+        "user-profiles/5/user-5-topbar-64.jpg"
+    );
+});
+
+test("normalizeRequestedUploadPath rejects traversal and malformed paths", () => {
+    assert.equal(normalizeRequestedUploadPath("/uploads/../secret.pdf"), null);
+    assert.equal(normalizeRequestedUploadPath("/uploads/%2e%2e/secret.pdf"), null);
+    assert.equal(normalizeRequestedUploadPath("/uploads/cases/1/%00case.pdf"), null);
+    assert.equal(normalizeRequestedUploadPath("/uploads/%E0%A4%A"), null);
+});
+
+test("getAuthorizedUpload authorizes an ethical case document only when metadata query matches", async () => {
+    const calls = [];
+    const authorized = await getAuthorizedUpload(
+        "cases/7/case.pdf",
+        { uid: 12, role: "A" },
+        async ({ sql, sqlParams }) => {
+            calls.push({ sql, sqlParams });
+            if (sql.includes("FROM ethical_cases c")) {
+                assert.deepEqual(sqlParams[0], [
+                    "uploads/cases/7/case.pdf",
+                    "/uploads/cases/7/case.pdf",
+                    "assets/uploads/cases/7/case.pdf",
+                    "/assets/uploads/cases/7/case.pdf",
+                ]);
+                assert.equal(sqlParams[1], 12);
+                assert.equal(sqlParams[2], "A");
+                return [{ id: 7, pdf_path: "/uploads/cases/7/case.pdf" }];
+            }
+
+            return [];
+        }
+    );
+
+    assert.deepEqual(authorized, { id: 7, pdf_path: "/uploads/cases/7/case.pdf" });
+    assert.equal(calls.length, 1);
+});
+
+test("ethical case authorization keeps shared, imported, and activity-based access paths", async () => {
+    await getAuthorizedUpload(
+        "cases/7/case.pdf",
+        { uid: 12, role: "P" },
+        async ({ sql }) => {
+            if (sql.includes("FROM ethical_cases c")) {
+                assert.match(sql, /d\.creator = \$2 OR d\.public = TRUE/);
+                assert.match(sql, /INNER JOIN activity a ON a\.design = d\.id/);
+                assert.match(sql, /FROM sesusers su/);
+                return [{ id: 7, pdf_path: "/uploads/cases/7/case.pdf" }];
+            }
+
+            return [];
+        }
+    );
+});
+
+test("getAuthorizedUpload allows authenticated users to read registered profile avatars", async () => {
+    const authorized = await getAuthorizedUpload(
+        "user-profiles/99/user-99-topbar-64.jpg",
+        { uid: 12, role: "P" },
+        async ({ sql, sqlParams }) => {
+            if (sql.includes("FROM users")) {
+                assert.deepEqual(sqlParams[0], [
+                    "uploads/user-profiles/99/user-99-topbar-64.jpg",
+                    "/uploads/user-profiles/99/user-99-topbar-64.jpg",
+                    "assets/uploads/user-profiles/99/user-99-topbar-64.jpg",
+                    "/assets/uploads/user-profiles/99/user-99-topbar-64.jpg",
+                ]);
+                assert.equal(sqlParams.length, 1);
+                return [{ id: 99 }];
+            }
+
+            return [];
+        }
+    );
+
+    assert.deepEqual(authorized, { id: 99 });
+});
+
+test("getAuthorizedUpload does not authorize unmatched upload metadata", async () => {
+    let queryCount = 0;
+    const authorized = await getAuthorizedUpload(
+        "cases/99/case.pdf",
+        { uid: 12, role: "P" },
+        async () => {
+            queryCount += 1;
+            return [];
+        }
+    );
+
+    assert.equal(authorized, null);
+    assert.equal(queryCount, 2);
+});
+
+test("getAuthorizedUpload rejects missing authenticated session", async () => {
+    let queryCount = 0;
+    const authorized = await getAuthorizedUpload(
+        "cases/99/case.pdf",
+        {},
+        async () => {
+            queryCount += 1;
+            return [{ id: 99 }];
+        }
+    );
+
+    assert.equal(authorized, null);
+    assert.equal(queryCount, 0);
+});

--- a/ethicapp/backend/controllers/protected-uploads.js
+++ b/ethicapp/backend/controllers/protected-uploads.js
@@ -1,0 +1,187 @@
+"use strict";
+
+import express from "express";
+import fs from "fs";
+import path from "path";
+import * as config from "../config/database.config.js";
+import { uploadsPath } from "../config/uploads.config.js";
+import * as rpg2 from "../db/rest-pg-2.js";
+
+const router = express.Router();
+const uploadsRoot = path.resolve(process.cwd(), uploadsPath);
+
+const UPLOAD_ROUTE_PATTERN = /^\/(?:assets\/)?uploads\/(.+)$/;
+
+function publicPathCandidates(relativePath) {
+    return [
+        `uploads/${relativePath}`,
+        `/uploads/${relativePath}`,
+        `assets/uploads/${relativePath}`,
+        `/assets/uploads/${relativePath}`,
+    ];
+}
+
+function isInsideDirectory(candidatePath, parentDirectory) {
+    const relativePath = path.relative(parentDirectory, candidatePath);
+    return relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+}
+
+export function normalizeRequestedUploadPath(rawPath) {
+    if (!rawPath || typeof rawPath !== "string") {
+        return null;
+    }
+
+    let decodedPath;
+    try {
+        decodedPath = decodeURIComponent(rawPath.split("?")[0]);
+    } catch {
+        return null;
+    }
+
+    if (decodedPath.includes("\0")) {
+        return null;
+    }
+
+    const normalizedPublicPath = decodedPath.replaceAll("\\", "/").replace(/^\/+/, "");
+    const relativePath = normalizedPublicPath.startsWith("assets/uploads/")
+        ? normalizedPublicPath.slice("assets/uploads/".length)
+        : normalizedPublicPath.startsWith("uploads/")
+            ? normalizedPublicPath.slice("uploads/".length)
+            : normalizedPublicPath;
+
+    const normalizedRelativePath = path.posix.normalize(relativePath).replace(/^\/+/, "");
+    if (
+        !normalizedRelativePath ||
+        normalizedRelativePath === "." ||
+        normalizedRelativePath.startsWith("../") ||
+        normalizedRelativePath.includes("/../")
+    ) {
+        return null;
+    }
+
+    return normalizedRelativePath;
+}
+
+function buildAbsoluteUploadPath(relativePath) {
+    const absolutePath = path.resolve(uploadsRoot, relativePath);
+    return isInsideDirectory(absolutePath, uploadsRoot) ? absolutePath : null;
+}
+
+async function queryOne(sql, sqlParams, query = rpg2.execSQL) {
+    const rows = await query({
+        dbcon: config.dbconnString,
+        sql,
+        sqlParams,
+    });
+    return rows[0] || null;
+}
+
+async function findCaseDocument(relativePath, uid, role, query) {
+    return queryOne(`
+        SELECT c.id, c.pdf_path
+        FROM ethical_cases c
+        WHERE c.pdf_path = ANY($1)
+          AND (
+            $3 = 'A'
+            OR c.creator = $2
+            OR EXISTS (
+                SELECT 1
+                FROM designs d
+                WHERE d.case_id = c.id
+                  AND (d.creator = $2 OR d.public = TRUE)
+            )
+            OR EXISTS (
+                SELECT 1
+                FROM designs d
+                INNER JOIN activity a ON a.design = d.id
+                INNER JOIN sessions s ON s.id = a.session
+                WHERE d.case_id = c.id
+                  AND (
+                    s.creator = $2
+                    OR EXISTS (
+                        SELECT 1
+                        FROM sesusers su
+                        WHERE su.sesid = s.id
+                          AND su.uid = $2
+                    )
+                  )
+            )
+          )
+        LIMIT 1;
+    `, [publicPathCandidates(relativePath), uid, role], query);
+}
+
+async function findProfileImage(relativePath, query) {
+    return queryOne(`
+        SELECT id
+        FROM users
+        WHERE (
+            profile_image_path = ANY($1)
+            OR profile_image_topbar_path = ANY($1)
+          )
+        LIMIT 1;
+    `, [publicPathCandidates(relativePath)], query);
+}
+
+export async function getAuthorizedUpload(relativePath, session, query = rpg2.execSQL) {
+    const uid = Number(session?.uid);
+    if (!Number.isSafeInteger(uid) || uid <= 0) {
+        return null;
+    }
+
+    const role = session?.role || "";
+    const resolvers = [
+        () => findCaseDocument(relativePath, uid, role, query),
+        () => findProfileImage(relativePath, query),
+    ];
+
+    for (const resolveMetadata of resolvers) {
+        const metadata = await resolveMetadata();
+        if (metadata) {
+            return metadata;
+        }
+    }
+
+    return null;
+}
+
+export async function serveProtectedUpload(req, res) {
+    const routeMatch = req.path.match(UPLOAD_ROUTE_PATTERN);
+    const relativePath = normalizeRequestedUploadPath(routeMatch ? routeMatch[1] : req.path);
+    const absolutePath = relativePath ? buildAbsoluteUploadPath(relativePath) : null;
+
+    if (!absolutePath) {
+        console.warn("Blocked invalid upload path request", {
+            uid: req.session?.uid,
+            path: req.originalUrl,
+        });
+        return res.status(400).json({ status: "err", message: "Invalid upload path." });
+    }
+
+    try {
+        const authorizedUpload = await getAuthorizedUpload(relativePath, req.session);
+        if (!authorizedUpload) {
+            console.warn("Blocked unauthorized upload request", {
+                uid: req.session?.uid,
+                role: req.session?.role,
+                path: req.originalUrl,
+            });
+            return res.status(404).json({ status: "err", message: "File not found." });
+        }
+
+        await fs.promises.access(absolutePath, fs.constants.R_OK);
+        res.set("Cache-Control", "private, no-store");
+        return res.sendFile(absolutePath);
+    } catch (error) {
+        if (error.code === "ENOENT") {
+            return res.status(404).json({ status: "err", message: "File not found." });
+        }
+
+        console.error("Error serving protected upload:", error);
+        return res.status(500).json({ status: "err", message: "Failed to serve file." });
+    }
+}
+
+router.get(UPLOAD_ROUTE_PATTERN, serveProtectedUpload);
+
+export default router;


### PR DESCRIPTION
## Context

Responds to #519. Uploaded case documents were previously reachable through direct `/uploads/...` and `/assets/uploads/...` static serving, which meant predictable paths such as `/uploads/cases/2/case.pdf` could bypass application-level authorization if guessed or enumerated.

## What changed

- Replaced direct Express static serving for upload paths with a protected upload controller.
- Added path normalization and traversal/null-byte/malformed-encoding rejection before resolving files on disk.
- Authorizes case PDF reads from `ethical_cases.pdf_path` metadata instead of trusting the URL alone.
- Keeps legitimate case access working for:
  - admins,
  - case owners,
  - teachers who own or import a design associated with the case,
  - users accessing a public/shared design associated with the case,
  - students and teachers participating in an activity/session based on the associated design.
- Allows profile avatars to be read by authenticated users when the avatar path is registered in `users.profile_image_path` or `users.profile_image_topbar_path`; avatars are treated as app identity assets rather than protected case documents.
- Removed the development NGINX direct upload volume mount so upload requests cannot be served straight from NGINX.
- Added focused backend tests for path normalization, unauthorized metadata misses, case authorization paths, authenticated avatar access, and missing-session rejection.

## Notes on predictable paths

The stored file paths remain stable and predictable, for example `/uploads/cases/2/case.pdf`. That is intentional for compatibility with existing frontend links. The important change is that these paths are no longer static public files: unauthenticated requests are sent through the login flow, and authenticated requests must match database metadata plus an allowed relationship before the file is streamed.

## Scope decisions

- This intentionally preserves `ethical_cases` as the protected document source for this remediation.
- It does not add new authorization behavior for legacy `documents` or `designs_documents`, per the current remediation direction.
- It does not introduce signed URLs yet; controller-mediated authorization is the conservative first step.

## Verification

- `node --test controllers/__tests__/protected-uploads.node-test.mjs`
- `node --check controllers/protected-uploads.js`
- `node --check app.js`

Manual smoke check noted during implementation: opening a predictable case PDF URL from an incognito window redirects to login instead of serving the file directly.