### PR TITLE
[codex] Add session version revocation

### DIFF
--- a/auth-backend/middleware/__tests__/sessionPolicy.node-test.mjs
+++ b/auth-backend/middleware/__tests__/sessionPolicy.node-test.mjs
@@ -6,6 +6,7 @@ import {
   getDefaultAuthSessionMaxAgeMs,
   getDefaultAuthSessionTtlSeconds,
   getRoleSessionPolicy,
+  getUserSessionVersion,
   initializeSessionPolicy
 } from '../sessionPolicy.js';
 
@@ -94,10 +95,11 @@ describe('auth-backend session policy', () => {
       }
     };
 
-    initializeSessionPolicy(req, 'S', 1000);
+    initializeSessionPolicy(req, 'S', 1000, 3);
 
     assert.deepEqual(req.session.authPolicy, {
       role: 'S',
+      sessionVersion: 3,
       createdAt: 1000,
       lastSeenAt: 1000
     });
@@ -106,11 +108,12 @@ describe('auth-backend session policy', () => {
 
   it('updates lastSeenAt and cookie lifetime for a valid session', () => {
     const req = {
-      user: { role: 'S' },
+      user: { role: 'S', sessionVersion: 4 },
       session: {
         cookie: {},
         authPolicy: {
           role: 'S',
+          sessionVersion: 4,
           createdAt: 1000,
           lastSeenAt: 1000
         }
@@ -125,17 +128,55 @@ describe('auth-backend session policy', () => {
     assert.equal(nextCalled, true);
     assert.equal(res.ended, false);
     assert.equal(req.session.authPolicy.lastSeenAt, 1000 + HOUR_MS);
+    assert.equal(req.session.authPolicy.sessionVersion, 4);
     assert.equal(req.session.cookie.maxAge, 2 * HOUR_MS);
+  });
+
+  it('normalizes user session version from known user shapes', () => {
+    assert.equal(getUserSessionVersion({ sessionVersion: 7 }), 7);
+    assert.equal(getUserSessionVersion({ session_version: 8 }), 8);
+    assert.equal(getUserSessionVersion({}), 1);
+  });
+
+  it('expires sessions when stored session version differs from the current user version', () => {
+    let destroyed = false;
+    const req = {
+      user: { role: 'S', sessionVersion: 5 },
+      session: {
+        cookie: {},
+        authPolicy: {
+          role: 'S',
+          sessionVersion: 4,
+          createdAt: 1000,
+          lastSeenAt: 1000
+        },
+        destroy(callback) {
+          destroyed = true;
+          callback();
+        }
+      }
+    };
+
+    const { nextCalled, res } = runMiddleware({
+      req,
+      nowMs: 1000 + HOUR_MS
+    });
+
+    assert.equal(nextCalled, false);
+    assert.equal(destroyed, true);
+    assert.equal(res.statusCode, 401);
+    assert.equal(res.ended, true);
   });
 
   it('expires sessions that exceed idle timeout', () => {
     let destroyed = false;
     const req = {
-      user: { role: 'S' },
+      user: { role: 'S', sessionVersion: 1 },
       session: {
         cookie: {},
         authPolicy: {
           role: 'S',
+          sessionVersion: 1,
           createdAt: 1000,
           lastSeenAt: 1000
         },
@@ -164,11 +205,12 @@ describe('auth-backend session policy', () => {
   it('expires sessions that exceed absolute timeout even when recently active', () => {
     let destroyed = false;
     const req = {
-      user: { role: 'S' },
+      user: { role: 'S', sessionVersion: 1 },
       session: {
         cookie: {},
         authPolicy: {
           role: 'S',
+          sessionVersion: 1,
           createdAt: 1000,
           lastSeenAt: 1000 + (7 * HOUR_MS)
         },

--- a/auth-backend/middleware/sessionPolicy.js
+++ b/auth-backend/middleware/sessionPolicy.js
@@ -80,7 +80,12 @@ function getDefaultAuthSessionTtlSeconds() {
   return Math.ceil(getDefaultAuthSessionMaxAgeMs() / 1000);
 }
 
-function initializeSessionPolicy(req, role, nowMs = Date.now()) {
+function getUserSessionVersion(user) {
+  const sessionVersion = Number(user?.sessionVersion ?? user?.session_version ?? 1);
+  return Number.isInteger(sessionVersion) && sessionVersion > 0 ? sessionVersion : 1;
+}
+
+function initializeSessionPolicy(req, role, nowMs = Date.now(), sessionVersion = 1) {
   if (!req.session) {
     return;
   }
@@ -89,6 +94,7 @@ function initializeSessionPolicy(req, role, nowMs = Date.now()) {
 
   req.session.authPolicy = {
     role: String(role || ''),
+    sessionVersion,
     createdAt: nowMs,
     lastSeenAt: nowMs
   };
@@ -129,12 +135,19 @@ function createSessionPolicyMiddleware({ nowProvider = Date.now } = {}) {
     }
 
     const role = req.user.role || req.user.roleCode || '';
+    const currentSessionVersion = getUserSessionVersion(req.user);
     const nowMs = nowProvider();
     const policy = getRoleSessionPolicy(role);
 
     if (!req.session.authPolicy) {
-      initializeSessionPolicy(req, role, nowMs);
+      initializeSessionPolicy(req, role, nowMs, currentSessionVersion);
       return next();
+    }
+
+    const storedSessionVersion = Number(req.session.authPolicy.sessionVersion || currentSessionVersion);
+
+    if (storedSessionVersion !== currentSessionVersion) {
+      return clearExpiredSession(req, res);
     }
 
     if (sessionExpired(req.session.authPolicy, policy, nowMs)) {
@@ -147,6 +160,7 @@ function createSessionPolicyMiddleware({ nowProvider = Date.now } = {}) {
     req.session.authPolicy = {
       ...req.session.authPolicy,
       role: String(role || ''),
+      sessionVersion: currentSessionVersion,
       lastSeenAt: nowMs
     };
 
@@ -164,5 +178,6 @@ export {
   getDefaultAuthSessionMaxAgeMs,
   getDefaultAuthSessionTtlSeconds,
   getRoleSessionPolicy,
+  getUserSessionVersion,
   initializeSessionPolicy
 };

--- a/auth-backend/routes/auth.routes.js
+++ b/auth-backend/routes/auth.routes.js
@@ -279,7 +279,8 @@ router.post('/login', async (req, res, next) => {
           auth_provider,
           active,
           email_confirmed,
-          password_bcrypt
+          password_bcrypt,
+          session_version
         FROM users
         WHERE active = true
           AND email_confirmed = true
@@ -310,6 +311,7 @@ router.post('/login', async (req, res, next) => {
         role: user.role,
         email: user.mail,
         auth_provider: user.auth_provider || 'local',
+        sessionVersion: Number(user.session_version || 1),
         is_active: user.active && user.email_confirmed
       },
       function (err) {
@@ -317,7 +319,7 @@ router.post('/login', async (req, res, next) => {
           return next(err);
         }
 
-        initializeSessionPolicy(req, user.role);
+        initializeSessionPolicy(req, user.role, Date.now(), Number(user.session_version || 1));
 
         const redirectTo = getPostLoginRedirect(user.role);
 
@@ -397,7 +399,8 @@ router.post('/admin/change-password', async (req, res) => {
     await db.query(
       `
         UPDATE users
-        SET password_bcrypt = $1
+        SET password_bcrypt = $1,
+            session_version = session_version + 1
         WHERE id = $2
       `,
       [newPasswordHash, req.user.id]
@@ -1366,7 +1369,8 @@ router.post('/reset-password', async (req, res) => {
           UPDATE users
           SET password_bcrypt = $1,
               active = CASE WHEN email_confirmed = false THEN true ELSE active END,
-              email_confirmed = true
+              email_confirmed = true,
+              session_version = session_version + 1
           WHERE id = $2
         `,
         [passwordBcrypt, user.id]

--- a/auth-backend/routes/auth.routes.node-test.mjs
+++ b/auth-backend/routes/auth.routes.node-test.mjs
@@ -482,6 +482,7 @@ describe('Auth Routes', () => {
     assert.deepStrictEqual(deleteCall.arguments[1], ['person@example.com']);
     assert.match(updateCall.arguments[0], /active = CASE WHEN email_confirmed = false THEN true ELSE active END/);
     assert.match(updateCall.arguments[0], /email_confirmed = true/);
+    assert.match(updateCall.arguments[0], /session_version = session_version \+ 1/);
   });
 
   test('POST /admin/change-password - updates administrator password after current password verification', async () => {
@@ -520,6 +521,7 @@ describe('Auth Routes', () => {
     assert.ok(updateCall);
     assert.strictEqual(await bcrypt.compare('FreshPassword123!@', updateCall.arguments[1][0]), true);
     assert.strictEqual(updateCall.arguments[1][1], 7);
+    assert.match(updateCall.arguments[0], /session_version = session_version \+ 1/);
   });
 
   test('POST /admin/change-password - rejects weak new passwords before database access', async () => {

--- a/auth-backend/scripts/create-admin.js
+++ b/auth-backend/scripts/create-admin.js
@@ -55,7 +55,8 @@ Optional:
             password_bcrypt = $6,
             auth_provider = 'local',
             active = true,
-            email_confirmed = true
+            email_confirmed = true,
+            session_version = session_version + 1
         WHERE mail = $7
       `,
       [firstname, lastname, fullName, rut, sex, hash, email]

--- a/auth-backend/services/user.service.js
+++ b/auth-backend/services/user.service.js
@@ -15,14 +15,15 @@ function mapUser(row) {
     isActive: row.active !== false && row.email_confirmed !== false,
     emailConfirmed: row.email_confirmed !== false,
     authProvider: row.auth_provider || 'local',
-    passwordHash: row.password_bcrypt
+    passwordHash: row.password_bcrypt,
+    sessionVersion: Number(row.session_version || 1)
   };
 }
 
 async function findById(id) {
   const result = await query(
     `
-      SELECT id, name, rut, mail, sex, role, preferred_locale, active, email_confirmed, auth_provider, password_bcrypt
+      SELECT id, name, rut, mail, sex, role, preferred_locale, active, email_confirmed, auth_provider, password_bcrypt, session_version
       FROM users
       WHERE id = $1
       LIMIT 1
@@ -38,7 +39,7 @@ async function findByLogin(login) {
 
   const result = await query(
     `
-      SELECT id, name, rut, mail, sex, role, preferred_locale, active, email_confirmed, auth_provider, password_bcrypt
+      SELECT id, name, rut, mail, sex, role, preferred_locale, active, email_confirmed, auth_provider, password_bcrypt, session_version
       FROM users
       WHERE lower(mail) = $1 OR lower(rut) = $1
       LIMIT 1
@@ -54,7 +55,7 @@ async function findByEmail(email) {
 
   const result = await query(
     `
-      SELECT id, name, rut, mail, sex, role, preferred_locale, active, email_confirmed, auth_provider, password_bcrypt
+      SELECT id, name, rut, mail, sex, role, preferred_locale, active, email_confirmed, auth_provider, password_bcrypt, session_version
       FROM users
       WHERE lower(mail) = $1
       LIMIT 1
@@ -153,7 +154,8 @@ async function updatePasswordByEmail(email, password) {
     `
       UPDATE users
       SET password_bcrypt = $2,
-          auth_provider = 'local'
+          auth_provider = 'local',
+          session_version = session_version + 1
       WHERE lower(mail) = lower($1)
     `,
     [email, passwordHash]

--- a/database/migrations/V11__user_session_version.sql
+++ b/database/migrations/V11__user_session_version.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS session_version integer NOT NULL DEFAULT 1;

--- a/management-console/backend/services/user.service.js
+++ b/management-console/backend/services/user.service.js
@@ -183,6 +183,7 @@ export async function updateUserById(userId, payload) {
     ? payload.active === true || payload.active === 'true' || payload.active === 'on'
     : currentUser.active !== false;
   const isRoleChanged = (currentUser.role || '') !== role;
+  const isActiveChanged = (currentUser.active !== false) !== active;
   const validTransition =
     (currentUser.role === 'A' && role === 'P') ||
     (currentUser.role === 'P' && role === 'A') ||
@@ -219,11 +220,25 @@ export async function updateUserById(userId, payload) {
           mail = $5,
           role = $6,
           active = $7,
-          email_confirmed = CASE WHEN $7 = true THEN true ELSE email_confirmed END
+          email_confirmed = CASE WHEN $7 = true THEN true ELSE email_confirmed END,
+          session_version = CASE
+            WHEN $9 = true THEN session_version + 1
+            ELSE session_version
+          END
       WHERE id = $8
       RETURNING id, firstname, lastname, sex, mail, role, active, email_confirmed
     `,
-    [firstname, lastname, fullName, sex, email, role, active, normalizedId]
+    [
+      firstname,
+      lastname,
+      fullName,
+      sex,
+      email,
+      role,
+      active,
+      normalizedId,
+      isRoleChanged || isActiveChanged
+    ]
   );
 
   const row = updateResult.rows[0];


### PR DESCRIPTION
## Context

Closes #533.

Sessions are opaque and Redis-backed, but before this change there was no user-level session version to invalidate existing sessions after sensitive account changes. Role changes, account disablement, and password changes should invalidate previously issued sessions instead of letting them continue under stale assumptions.

## What changed

- Added `users.session_version` via Flyway migration `V11__user_session_version.sql`.
- Loaded `session_version` into auth-backend user objects.
- Stored `sessionVersion` in auth session policy metadata.
- Invalidated sessions when stored `sessionVersion` differs from the current database value.
- Incremented `session_version` on sensitive changes:
  - administrator own-password change,
  - password reset completion,
  - password updates through auth user service,
  - admin bootstrap/reconciliation script,
  - management-console role changes,
  - management-console active/inactive changes.
- Added focused tests for session-version normalization and invalidation.
- Added route test assertions that password changes bump `session_version`.

## Impact

Existing sessions are invalidated after sensitive account changes once `session_version` increments. Sessions that predate the new metadata are initialized with the current version on first valid request, avoiding a blanket logout at deploy time.

## Verification

- `cd auth-backend && npm test`
- `cd management-console/backend && npm test`
- `git diff --check`