### PR TITLE
[codex] Configure management console session TTL

### DIFF
--- a/deploy/env.contract.yml
+++ b/deploy/env.contract.yml
@@ -990,6 +990,15 @@ variables:
     phase: runtime
     description: Management console session cookie name.
 
+  MNG_SESSION_COOKIE_MAX_AGE_MS:
+    type: integer
+    required: false
+    secret: false
+    default: 7200000
+    services: [management-console]
+    phase: runtime
+    description: Management console local session cookie lifetime in milliseconds.
+
   MNG_SESSION_SECRET:
     type: secret
     required: false
@@ -1126,6 +1135,7 @@ projections:
       - NODE_ENV
       - MNG_PORT
       - MNG_SESSION_COOKIE_NAME
+      - MNG_SESSION_COOKIE_MAX_AGE_MS
       - MNG_SESSION_SECRET
       - SESSION_SECRET
       - AUTH_BACKEND_INTERNAL_BASE_URL

--- a/management-console/.env.example
+++ b/management-console/.env.example
@@ -3,6 +3,7 @@ MNG_PORT=8504
 # Session signing secret for the management console cookie
 # (`ethicapp.mng.sid`). Prefer this service-specific secret in production.
 MNG_SESSION_SECRET=change-this-in-production
+MNG_SESSION_COOKIE_MAX_AGE_MS=7200000
 
 # Legacy/shared fallback used only if MNG_SESSION_SECRET is not set.
 # Prefer MNG_SESSION_SECRET for management-console deployments.

--- a/management-console/backend/app.js
+++ b/management-console/backend/app.js
@@ -3,6 +3,7 @@ import session from 'express-session';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { getManagementSessionCookieMaxAgeMs } from './config/session.js';
 import hydrateSessionFromAuthProxy from './middleware/hydrateSessionFromAuthProxy.js';
 import { csrfProtection } from './middleware/csrfProtection.js';
 import csrfRoutes from './routes/csrf.routes.js';
@@ -31,7 +32,7 @@ app.use(
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 1000 * 60 * 60 * 8
+      maxAge: getManagementSessionCookieMaxAgeMs()
     }
   })
 );

--- a/management-console/backend/config/__tests__/session.node-test.mjs
+++ b/management-console/backend/config/__tests__/session.node-test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+
+import {
+  DEFAULT_MNG_SESSION_COOKIE_MAX_AGE_MS,
+  getManagementSessionCookieMaxAgeMs
+} from '../session.js';
+
+describe('management-console session config', () => {
+  beforeEach(() => {
+    delete process.env.MNG_SESSION_COOKIE_MAX_AGE_MS;
+  });
+
+  it('defaults the local management session cookie to two hours', () => {
+    assert.equal(DEFAULT_MNG_SESSION_COOKIE_MAX_AGE_MS, 2 * 60 * 60 * 1000);
+    assert.equal(getManagementSessionCookieMaxAgeMs(), DEFAULT_MNG_SESSION_COOKIE_MAX_AGE_MS);
+  });
+
+  it('allows environment overrides for the local session cookie lifetime', () => {
+    process.env.MNG_SESSION_COOKIE_MAX_AGE_MS = '60000';
+
+    assert.equal(getManagementSessionCookieMaxAgeMs(), 60000);
+  });
+
+  it('falls back to the default when the configured value is invalid', () => {
+    process.env.MNG_SESSION_COOKIE_MAX_AGE_MS = 'not-a-number';
+
+    assert.equal(getManagementSessionCookieMaxAgeMs(), DEFAULT_MNG_SESSION_COOKIE_MAX_AGE_MS);
+
+    process.env.MNG_SESSION_COOKIE_MAX_AGE_MS = '-1';
+
+    assert.equal(getManagementSessionCookieMaxAgeMs(), DEFAULT_MNG_SESSION_COOKIE_MAX_AGE_MS);
+  });
+});

--- a/management-console/backend/config/session.js
+++ b/management-console/backend/config/session.js
@@ -1,0 +1,20 @@
+const DEFAULT_MNG_SESSION_COOKIE_MAX_AGE_MS = 2 * 60 * 60 * 1000;
+
+function parsePositiveInteger(value, fallback) {
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) && numberValue > 0
+    ? numberValue
+    : fallback;
+}
+
+function getManagementSessionCookieMaxAgeMs() {
+  return parsePositiveInteger(
+    process.env.MNG_SESSION_COOKIE_MAX_AGE_MS,
+    DEFAULT_MNG_SESSION_COOKIE_MAX_AGE_MS
+  );
+}
+
+export {
+  DEFAULT_MNG_SESSION_COOKIE_MAX_AGE_MS,
+  getManagementSessionCookieMaxAgeMs
+};


### PR DESCRIPTION
## Context

Implements #535. The management-console local session cookie previously used a hardcoded 8-hour lifetime, while administrator browser sessions are intended to be shorter and aligned with the auth-backend administrator timeout policy.

## What Changed

- Adds `MNG_SESSION_COOKIE_MAX_AGE_MS` with a default of `7200000` ms (2 hours).
- Uses the configured value in `management-console/backend/app.js`.
- Extracts management session TTL parsing into `management-console/backend/config/session.js`.
- Documents the new variable in `management-console/.env.example` and `deploy/env.contract.yml`.
- Adds focused tests for the default, valid override, and invalid-value fallback.

## Risks / Limitations

- This controls the local management-console session cookie lifetime. Authenticated access still depends on the upstream auth-backend admin session policy enforced by NGINX/auth proxy.
- No explicit separate idle timer was added because the current local management session only needs cookie lifetime configuration for #535.

## Verification

- `npm test` in `management-console/backend` (24/24 passing)
- `git diff --check`