### PR TITLE
[codex] Document browser session policy

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,6 +65,29 @@ REDIS_CACHE_MAXMEMORY_POLICY=allkeys-lru
 
 Do not use generic `REDIS_HOST`, `REDIS_PORT`, or `REDIS_URL` values in production. The services resolve Redis by role-specific variables only, which avoids accidentally routing session traffic and cache traffic to the same Docker DNS name.
 
+## Browser Sessions
+
+Browser authentication is centralized in `auth-backend` through opaque
+Redis-backed sessions. The role-aware defaults are:
+
+- Administrators: 2-hour idle timeout, 8-hour absolute timeout.
+- Professors: 7-day idle timeout, 30-day absolute timeout.
+- Students: 24-hour idle timeout, 7-day absolute timeout.
+
+Protected browser traffic renews sessions through NGINX `auth_request`, with
+touches throttled by `AUTH_SESSION_TOUCH_INTERVAL_MS` (default 5 minutes).
+Account-sensitive changes increment `users.session_version`, which revokes older
+browser sessions on their next authenticated request.
+
+`management-console` additionally uses a local `ethicapp.mng.sid` cookie for
+console-local state such as CSRF data. Its default lifetime is 2 hours through
+`MNG_SESSION_COOKIE_MAX_AGE_MS`, but the primary authentication decision remains
+the `auth-backend` session checked by NGINX.
+
+For the complete operator-facing session variable list, defaults, and
+revocation semantics, see the Browser Session Policy section in
+[`deploy/README.md`](./deploy/README.md#browser-session-policy).
+
 ## Publishable Images
 
 The repository can build and publish these project images:

--- a/auth-backend/.env.example
+++ b/auth-backend/.env.example
@@ -11,15 +11,26 @@ AUTH_SESSION_SECRET=change-this-in-production
 SESSION_COOKIE_NAME=auth.sid
 SESSION_COOKIE_SAMESITE=lax
 SESSION_COOKIE_SECURE=false
+
+# Opaque auth sessions are stored server-side in Redis. Cookie and Redis TTL
+# defaults match the longest default absolute timeout (professor: 30 days);
+# role-aware policy can invalidate individual sessions earlier.
 AUTH_SESSION_COOKIE_MAX_AGE_MS=2592000000
 AUTH_SESSION_TTL_SECONDS=2592000
 AUTH_SESSION_REDIS_PREFIX=auth:sess:
+
+# Role-aware browser session policy. Idle timeouts slide on protected requests;
+# absolute timeouts do not. Sensitive account changes increment
+# users.session_version and revoke older sessions.
 AUTH_SESSION_ADMIN_IDLE_TIMEOUT_MS=7200000
 AUTH_SESSION_ADMIN_ABSOLUTE_TIMEOUT_MS=28800000
 AUTH_SESSION_PROFESSOR_IDLE_TIMEOUT_MS=604800000
 AUTH_SESSION_PROFESSOR_ABSOLUTE_TIMEOUT_MS=2592000000
 AUTH_SESSION_STUDENT_IDLE_TIMEOUT_MS=86400000
 AUTH_SESSION_STUDENT_ABSOLUTE_TIMEOUT_MS=604800000
+
+# Minimum interval between sliding-session touches; capped internally at half of
+# the role idle timeout.
 AUTH_SESSION_TOUCH_INTERVAL_MS=300000
 
 # Shared service-auth secret for management-console -> auth-backend internal

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,6 +34,53 @@ example, `auth-backend` uses `AUTH_SESSION_SECRET` for `auth.sid`, while
 values do not need to match. `SESSION_SECRET` remains a shared fallback for
 legacy-compatible services, not the preferred production setting.
 
+## Browser Session Policy
+
+Browser authentication uses opaque, Redis-backed Express sessions issued by
+`auth-backend`. The browser receives only the signed `auth.sid` cookie; session
+contents remain server-side in the session Redis store. Production deployments
+should use `REDIS_SESSION_*` for this Redis role and keep it separate from
+`REDIS_CACHE_*`.
+
+`auth-backend` enforces role-aware idle and absolute timeouts:
+
+| Role | Idle timeout variable | Default | Absolute timeout variable | Default |
+| --- | --- | --- | --- | --- |
+| Administrator (`S`) | `AUTH_SESSION_ADMIN_IDLE_TIMEOUT_MS` | `7200000` ms (2 hours) | `AUTH_SESSION_ADMIN_ABSOLUTE_TIMEOUT_MS` | `28800000` ms (8 hours) |
+| Professor (`P`) | `AUTH_SESSION_PROFESSOR_IDLE_TIMEOUT_MS` | `604800000` ms (7 days) | `AUTH_SESSION_PROFESSOR_ABSOLUTE_TIMEOUT_MS` | `2592000000` ms (30 days) |
+| Student (`A`) | `AUTH_SESSION_STUDENT_IDLE_TIMEOUT_MS` | `86400000` ms (24 hours) | `AUTH_SESSION_STUDENT_ABSOLUTE_TIMEOUT_MS` | `604800000` ms (7 days) |
+
+Sessions renew on protected browser traffic through NGINX `auth_request`.
+`auth-backend` updates the session's last-seen timestamp and emits a refreshed
+`Set-Cookie`; NGINX propagates that cookie to the browser. Renewal is throttled
+by `AUTH_SESSION_TOUCH_INTERVAL_MS`, which defaults to `300000` ms (5 minutes)
+and is capped internally at half of the role idle timeout to avoid excessive
+session-store writes.
+
+`AUTH_SESSION_COOKIE_MAX_AGE_MS` and `AUTH_SESSION_TTL_SECONDS` are upper bounds
+for the auth session cookie and Redis key lifetime. Their defaults are
+`2592000000` ms and `2592000` seconds, matching the longest default absolute
+timeout. Role-aware idle and absolute checks can invalidate an auth session
+earlier than those storage-level limits.
+
+Password reset, administrator password rotation, user role changes, disabling a
+user, and similar account-sensitive changes increment `users.session_version`.
+Every authenticated request compares the session's stored version with the
+current user record. A mismatch destroys the old session and returns `401`, so
+existing browser sessions are revoked even if their Redis TTL has not expired.
+
+`management-console` also has its own local application cookie,
+`ethicapp.mng.sid`. This cookie stores management-console-local state such as
+CSRF data and the user identity hydrated from the auth proxy. It is not the
+primary authentication session; authenticated access still depends on
+`auth-backend` and NGINX `auth_request`. Configure this local cookie with:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MNG_SESSION_COOKIE_NAME` | `ethicapp.mng.sid` | Management-console local session cookie name. |
+| `MNG_SESSION_COOKIE_MAX_AGE_MS` | `7200000` ms (2 hours) | Management-console local cookie lifetime. |
+| `MNG_SESSION_SECRET` | no production default | Management-console local session signing secret. |
+
 `AUTH_INTERNAL_SERVICE_TOKEN` is a shared secret between `management-console`
 and `auth-backend`. It allows management-console to make server-to-server auth
 calls that are exempt from browser CSRF checks. Production deployments must set

--- a/deploy/env.contract.yml
+++ b/deploy/env.contract.yml
@@ -574,7 +574,7 @@ variables:
     default: 2592000000
     services: [auth-backend]
     phase: runtime
-    description: Auth backend session cookie maximum age in milliseconds. Defaults to the longest role absolute timeout; role-aware policy may shorten individual sessions.
+    description: Auth backend opaque session cookie upper-bound lifetime in milliseconds. Defaults to the longest role absolute timeout; role-aware idle, absolute, and session-version checks may invalidate sessions earlier.
 
   AUTH_SESSION_TTL_SECONDS:
     type: integer
@@ -583,7 +583,7 @@ variables:
     default: 2592000
     services: [auth-backend]
     phase: runtime
-    description: Redis TTL for auth backend sessions. Defaults to the longest role absolute timeout; role-aware policy may invalidate sessions earlier.
+    description: Redis TTL for auth backend opaque sessions. Defaults to the longest role absolute timeout; role-aware idle, absolute, and session-version checks may invalidate sessions earlier.
 
   AUTH_SESSION_REDIS_PREFIX:
     type: string
@@ -601,7 +601,7 @@ variables:
     default: 7200000
     services: [auth-backend]
     phase: runtime
-    description: Idle timeout in milliseconds for administrator sessions.
+    description: Sliding idle timeout in milliseconds for administrator browser auth sessions.
 
   AUTH_SESSION_ADMIN_ABSOLUTE_TIMEOUT_MS:
     type: integer
@@ -610,7 +610,7 @@ variables:
     default: 28800000
     services: [auth-backend]
     phase: runtime
-    description: Absolute timeout in milliseconds for administrator sessions.
+    description: Non-sliding absolute timeout in milliseconds for administrator browser auth sessions.
 
   AUTH_SESSION_PROFESSOR_IDLE_TIMEOUT_MS:
     type: integer
@@ -619,7 +619,7 @@ variables:
     default: 604800000
     services: [auth-backend]
     phase: runtime
-    description: Idle timeout in milliseconds for professor sessions.
+    description: Sliding idle timeout in milliseconds for professor browser auth sessions.
 
   AUTH_SESSION_PROFESSOR_ABSOLUTE_TIMEOUT_MS:
     type: integer
@@ -628,7 +628,7 @@ variables:
     default: 2592000000
     services: [auth-backend]
     phase: runtime
-    description: Absolute timeout in milliseconds for professor sessions.
+    description: Non-sliding absolute timeout in milliseconds for professor browser auth sessions.
 
   AUTH_SESSION_STUDENT_IDLE_TIMEOUT_MS:
     type: integer
@@ -637,7 +637,7 @@ variables:
     default: 86400000
     services: [auth-backend]
     phase: runtime
-    description: Idle timeout in milliseconds for student sessions.
+    description: Sliding idle timeout in milliseconds for student browser auth sessions.
 
   AUTH_SESSION_STUDENT_ABSOLUTE_TIMEOUT_MS:
     type: integer
@@ -646,7 +646,7 @@ variables:
     default: 604800000
     services: [auth-backend]
     phase: runtime
-    description: Absolute timeout in milliseconds for student sessions.
+    description: Non-sliding absolute timeout in milliseconds for student browser auth sessions.
 
   AUTH_SESSION_TOUCH_INTERVAL_MS:
     type: integer
@@ -997,7 +997,7 @@ variables:
     default: 7200000
     services: [management-console]
     phase: runtime
-    description: Management console local session cookie lifetime in milliseconds.
+    description: Management console local session cookie lifetime in milliseconds. This is separate from the auth-backend browser auth session.
 
   MNG_SESSION_SECRET:
     type: secret

--- a/management-console/.env.example
+++ b/management-console/.env.example
@@ -3,6 +3,9 @@ MNG_PORT=8504
 # Session signing secret for the management console cookie
 # (`ethicapp.mng.sid`). Prefer this service-specific secret in production.
 MNG_SESSION_SECRET=change-this-in-production
+
+# Local management-console cookie lifetime. Authenticated access still depends
+# on auth-backend's `auth.sid` session checked through NGINX auth_request.
 MNG_SESSION_COOKIE_MAX_AGE_MS=7200000
 
 # Legacy/shared fallback used only if MNG_SESSION_SECRET is not set.


### PR DESCRIPTION
## Context

Implements #536. After role-aware timeouts, sliding sessions, session-version revocation, and the management-console local TTL work, operators need one clear deployment-facing explanation of how browser sessions behave.

## What Changed

- Adds a Browser Session Policy section to `deploy/README.md` covering:
  - opaque Redis-backed `auth-backend` sessions,
  - role-specific idle and absolute timeout defaults,
  - sliding renewal through NGINX `auth_request`,
  - `users.session_version` revocation semantics,
  - the separate local `management-console` cookie.
- Adds a shorter browser-session summary to `INSTALL.md` with a link to the full policy.
- Clarifies session variables in `auth-backend/.env.example` and `management-console/.env.example`.
- Tightens `deploy/env.contract.yml` descriptions so the contract distinguishes storage TTLs, sliding idle timeouts, absolute timeouts, and local app cookies.

## Verification

- `git diff --check`

No runtime tests were run because this PR only changes documentation and environment-variable descriptions.