### PR TITLE
Expand student anonymization coverage

### DIFF
--- a/deploy/student-anonymization-data-map.md
+++ b/deploy/student-anonymization-data-map.md
@@ -1,0 +1,90 @@
+# Student Anonymization Data Map
+
+This document records the student-linked personal data fields reviewed for the
+scheduled anonymization process. It is intended to support privacy reviews and
+to keep the operational job aligned with the schema.
+
+The anonymization job is owned by `management-console` because it is a platform
+administration task. Legacy EthicApp remains the passive owner of several
+affected pedagogical tables.
+
+## Manual Inventory Query
+
+Run this query against PostgreSQL to list tables that reference `users` and the
+candidate text-like columns in those tables:
+
+```sql
+WITH user_refs AS (
+    SELECT
+        tc.table_schema,
+        tc.table_name,
+        kcu.column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.table_schema = kcu.table_schema
+    JOIN information_schema.constraint_column_usage ccu
+      ON ccu.constraint_name = tc.constraint_name
+     AND ccu.table_schema = tc.table_schema
+    WHERE tc.constraint_type = 'FOREIGN KEY'
+      AND ccu.table_name = 'users'
+),
+text_columns AS (
+    SELECT
+        table_schema,
+        table_name,
+        string_agg(
+            column_name || ' ' || data_type,
+            ', '
+            ORDER BY ordinal_position
+        ) AS text_columns
+    FROM information_schema.columns
+    WHERE data_type IN (
+        'text',
+        'character varying',
+        'character',
+        'inet',
+        'jsonb'
+    )
+    GROUP BY table_schema, table_name
+)
+SELECT
+    ur.table_name,
+    string_agg(ur.column_name, ', ' ORDER BY ur.column_name) AS user_ref_columns,
+    tc.text_columns
+FROM user_refs ur
+LEFT JOIN text_columns tc
+  ON tc.table_schema = ur.table_schema
+ AND tc.table_name = ur.table_name
+GROUP BY ur.table_name, tc.text_columns
+ORDER BY ur.table_name;
+```
+
+## Coverage Decisions
+
+| Table and fields | Production reachability | Decision | Current coverage |
+| --- | --- | --- | --- |
+| `users.name`, `users.firstname`, `users.lastname`, `users.mail`, `users.rut` | Core account profile for student login and activity membership. | In scope. Replace with deterministic anonymous values. | Covered by the job. |
+| `users.pass`, `users.password_bcrypt`, `users.active`, `users.email_confirmed`, `users.session_version`, `users.anonymized_at`, `users.anonymization_run_id` | Core account and session state. | In scope. Disable account, clear credentials, invalidate sessions, and mark run metadata. | Covered by the job. |
+| `users.sex`, `users.last_login_at` | Demographic and activity metadata. | In scope. Clear during anonymization. | Covered by the job. |
+| `users.profile_image_path`, `users.profile_image_topbar_path` | Teacher/student profile image references served through protected uploads. | In scope for database references. Null stored paths. | Covered by the job. File deletion is tracked separately. |
+| `differential_selection.comment` | Active semantic-differential student justification text. | In scope. Replace free text with the placeholder. | Covered by the job. |
+| `differential_chat.content` | Active semantic-differential group chat text. | In scope. Replace free text with the placeholder. | Covered by the job. |
+| `chat.content` | Active ranking and group chat text through `group-messages` and student session views. | In scope. Replace free text with the placeholder. | Covered by the job. |
+| `actor_selection.description` | Active role/actor selection justification text through phase and activity routes. | In scope. Replace free text with the placeholder. | Covered by the job. |
+| `sesusers.device` | Session join metadata supplied by student clients. | In scope. Clear because it can identify a device or client context. | Covered by the job. |
+| `pass_reset.mail`, `pass_reset.token` | Password reset records keyed by email. | In scope. Delete rows for the original student email before changing it. | Covered by the job. |
+| `teamusers.uid`, `teamusers.anon_mask` | Pedagogical membership and anonymous display mask. | Retain. No free-text data; the FK points to an anonymized inactive user. | No action needed. |
+| `jigsaw_users.userid` | Pedagogical role assignment. | Retain. No free-text data; the FK points to an anonymized inactive user. | No action needed. |
+| `activity_report_exports.actor_user_id`, `activity_report_exports.effective_user_id`, `activity_report_exports.ip_address`, `activity_report_exports.user_agent`, `activity_report_exports.content_sha256`, `activity_report_exports.metadata` | Audit trail for report export actions. Current production flows are teacher/admin export operations, not student-generated answers. | Out of first student anonymization job. Requires a separate audit-retention policy if operator metadata minimization is desired. | Not covered by the job. |
+| `user_passkeys.*` | WebAuthn credentials for management-console administrator users. | Out of scope. The table is not used for students. | Not covered by the job. Revisit if student passkeys are introduced. |
+
+## Remaining Follow-Ups
+
+- Issue #552: purge orphaned profile image files after database paths are nulled, if the
+  deployment's storage-minimization policy requires physical deletion from the
+  uploads volume.
+- Issue #553: define a separate retention/minimization policy for
+  `activity_report_exports`, because those rows are audit records for report
+  exports and include operator/network metadata rather than student-generated
+  response text.

--- a/deploy/student-anonymization-maintenance-runbook.md
+++ b/deploy/student-anonymization-maintenance-runbook.md
@@ -3,6 +3,9 @@
 This runbook is the repository-owned command contract for the student
 anonymization maintenance window.
 
+The field-level coverage map is maintained in
+`deploy/student-anonymization-data-map.md`.
+
 The intended recurring windows are January 1 and July 1, but deployments must
 not hard-code those dates in this repository. Operators or deployment
 repositories should configure the actual schedule before deployment with:
@@ -110,7 +113,7 @@ scripts/student-anonymization-maintenance.sh execute
 The confirmation variable is required to avoid accidental destructive
 execution. The real run anonymizes eligible student accounts, deactivates them,
 invalidates sessions through `session_version`, anonymizes current free-text
-student responses, and writes audit rows.
+student responses and student-provided device metadata, and writes audit rows.
 
 ## Post-Run Checks
 

--- a/management-console/backend/helpers/__tests__/student-anonymization-helper.node-test.mjs
+++ b/management-console/backend/helpers/__tests__/student-anonymization-helper.node-test.mjs
@@ -124,13 +124,16 @@ test("runStudentAnonymization dry-run records skipped events without changing da
     assert.equal(pool.client.calls.some(call => call.sql.includes("UPDATE users SET")), false);
     assert.equal(pool.client.calls.some(call => call.sql.includes("UPDATE differential_selection")), false);
     assert.equal(pool.client.calls.some(call => call.sql.includes("UPDATE differential_chat")), false);
+    assert.equal(pool.client.calls.some(call => call.sql.includes("UPDATE chat")), false);
+    assert.equal(pool.client.calls.some(call => call.sql.includes("UPDATE actor_selection")), false);
+    assert.equal(pool.client.calls.some(call => call.sql.includes("UPDATE sesusers")), false);
     assert.equal(
         pool.client.calls.filter(call => call.sql.includes("'Dry run: account would be anonymized.'")).length,
         2
     );
 });
 
-test("runStudentAnonymization anonymizes account, free-text answers, and stale reset tokens", async () => {
+test("runStudentAnonymization anonymizes account, free-text data, session devices, and stale reset tokens", async () => {
     const pool = new FakePool(createQueryHandler({
         candidates: [{ id: 5, mail: "student5@example.test" }],
     }));
@@ -161,10 +164,15 @@ test("runStudentAnonymization anonymizes account, free-text answers, and stale r
     ]);
     assert.match(userUpdate.sql, /active = false/);
     assert.match(userUpdate.sql, /email_confirmed = false/);
+    assert.match(userUpdate.sql, /sex = NULL/);
+    assert.match(userUpdate.sql, /last_login_at = NULL/);
     assert.match(userUpdate.sql, /session_version = session_version \+ 1/);
 
     assert.ok(pool.client.calls.some(call => call.sql.includes("UPDATE differential_selection SET comment = $1")));
     assert.ok(pool.client.calls.some(call => call.sql.includes("UPDATE differential_chat SET content = $1")));
+    assert.ok(pool.client.calls.some(call => call.sql.includes("UPDATE chat SET content = $1")));
+    assert.ok(pool.client.calls.some(call => call.sql.includes("UPDATE actor_selection SET description = $1")));
+    assert.ok(pool.client.calls.some(call => call.sql.includes("UPDATE sesusers SET device = NULL")));
     assert.ok(pool.client.calls.some(call => call.sql.includes("DELETE FROM pass_reset")));
     assert.ok(pool.client.calls.some(call => call.sql === "COMMIT"));
 });

--- a/management-console/backend/helpers/student-anonymization-helper.js
+++ b/management-console/backend/helpers/student-anonymization-helper.js
@@ -232,6 +232,36 @@ async function anonymizeStudentAccount(pool, runId, user, options) {
                 [options.placeholderText, user.id]
             );
 
+            const rankingChatResult = await client.query(
+                `
+                    UPDATE chat
+                    SET content = $1
+                    WHERE uid = $2
+                      AND content IS NOT NULL
+                `,
+                [options.placeholderText, user.id]
+            );
+
+            const actorSelectionResult = await client.query(
+                `
+                    UPDATE actor_selection
+                    SET description = $1
+                    WHERE uid = $2
+                      AND description IS NOT NULL
+                `,
+                [options.placeholderText, user.id]
+            );
+
+            const sessionDeviceResult = await client.query(
+                `
+                    UPDATE sesusers
+                    SET device = NULL
+                    WHERE uid = $1
+                      AND device IS NOT NULL
+                `,
+                [user.id]
+            );
+
             const passwordResetResult = await client.query(
                 `
                     DELETE FROM pass_reset
@@ -248,8 +278,10 @@ async function anonymizeStudentAccount(pool, runId, user, options) {
                         lastname = $3,
                         mail = $4,
                         rut = $5,
+                        sex = NULL,
                         pass = '',
                         password_bcrypt = NULL,
+                        last_login_at = NULL,
                         active = false,
                         email_confirmed = false,
                         profile_image_path = NULL,
@@ -274,6 +306,9 @@ async function anonymizeStudentAccount(pool, runId, user, options) {
                 "Account anonymized.",
                 `differential_selection comments updated: ${differentialSelectionResult.rowCount || 0}.`,
                 `differential_chat messages updated: ${differentialChatResult.rowCount || 0}.`,
+                `chat messages updated: ${rankingChatResult.rowCount || 0}.`,
+                `actor_selection descriptions updated: ${actorSelectionResult.rowCount || 0}.`,
+                `session device values cleared: ${sessionDeviceResult.rowCount || 0}.`,
                 `password reset tokens deleted: ${passwordResetResult.rowCount || 0}.`,
             ].join(" ");
 


### PR DESCRIPTION
## Context

Closes #546.

The scheduled student anonymization work needed a documented data map for student-linked personal and free-text fields, plus job coverage for active fields beyond the initial semantic-differential tables.

## What changed

- Added `deploy/student-anonymization-data-map.md` with the reviewed schema inventory query, field decisions, first-job coverage, and out-of-scope rationale.
- Expanded the management-console anonymization job to sanitize:
  - `chat.content`
  - `actor_selection.description`
  - `sesusers.device`
  - `users.sex`
  - `users.last_login_at`
- Updated anonymization event messages with the new row counters.
- Updated focused helper tests for the expanded coverage and dry-run behavior.
- Linked the maintenance runbook to the field-level data map.
- Opened follow-up issues for storage/audit items that should remain separate from the first student anonymization job: #552 and #553.

## Risks and limitations

- The job still keeps pedagogical relationship rows such as `teamusers` and `jigsaw_users`; those rows only retain links to the anonymized inactive user.
- Physical deletion of orphaned profile image files is intentionally not part of this PR and is tracked in #552.
- `activity_report_exports` retention/minimization is intentionally separate from student-generated data anonymization and is tracked in #553.

## Verification

- `node --test helpers/__tests__/student-anonymization-helper.node-test.mjs`
- `npm test` in `management-console/backend` passed outside the sandbox because route tests bind to `127.0.0.1`.
- Manual SQL inventory query is documented in the data map; local PostgreSQL was not running when checked with `docker compose ps postgresql`.