### PR TITLE
Improve case form validation feedback

### DIFF
--- a/ethicapp/backend/controllers/cases.js
+++ b/ethicapp/backend/controllers/cases.js
@@ -685,12 +685,20 @@ router.post("/cases", pdfUpload, async (req, res) => {
     const tagIds = parseTagIds(req.body.tag_ids || req.body.tagIds);
     if (!title || !areCaseAuthorsValid(authors) || hasDuplicateCaseAuthorEmails(authors) || !areTagIdsValid(tagIds)) {
         await removeUploadedFile(req.file);
-        return res.status(400).json({ status: "err", message: "Missing required fields." });
+        return res.status(400).json({
+            status:  "err",
+            message: "Missing required fields.",
+            code:    "CASE_VALIDATION_FAILED",
+        });
     }
     const primaryAuthor = authors[0];
 
     if (!req.file || req.file.mimetype !== "application/pdf") {
-        return res.status(400).json({ status: "err", message: "A PDF file is required." });
+        return res.status(400).json({
+            status:  "err",
+            message: "A PDF file is required.",
+            code:    "CASE_PDF_REQUIRED",
+        });
     }
 
     const normalizedLicenseCode = normalizeLicenseCode(licenseCode ?? licenseCodeCamel, CASE_DEFAULT_LICENSE);
@@ -792,7 +800,11 @@ router.patch("/cases/:id", pdfUpload, async (req, res) => {
     const tagIds = parseTagIds(req.body.tag_ids || req.body.tagIds);
     if (!title || !areCaseAuthorsValid(authors) || hasDuplicateCaseAuthorEmails(authors) || !areTagIdsValid(tagIds)) {
         await removeUploadedFile(req.file);
-        return res.status(400).json({ status: "err", message: "Missing required fields." });
+        return res.status(400).json({
+            status:  "err",
+            message: "Missing required fields.",
+            code:    "CASE_VALIDATION_FAILED",
+        });
     }
     const primaryAuthor = authors[0];
 

--- a/ethicapp/backend/middleware/__tests__/upload.node-test.mjs
+++ b/ethicapp/backend/middleware/__tests__/upload.node-test.mjs
@@ -107,8 +107,9 @@ describe("upload middleware", () => {
 
             assert.equal(response.status, 400);
             assert.deepEqual(await response.json(), {
-                status: "err",
+                status:  "err",
                 message: "Invalid file type.",
+                code:    "INVALID_FILE_TYPE",
             });
         });
 
@@ -131,8 +132,9 @@ describe("upload middleware", () => {
 
             assert.equal(response.status, 400);
             assert.deepEqual(await response.json(), {
-                status: "err",
+                status:  "err",
                 message: "File too large",
+                code:    "FILE_TOO_LARGE",
             });
         });
 
@@ -154,8 +156,9 @@ describe("upload middleware", () => {
 
             assert.equal(response.status, 400);
             assert.deepEqual(await response.json(), {
-                status: "err",
+                status:  "err",
                 message: "Unexpected field",
+                code:    "UNEXPECTED_FILE_FIELD",
             });
         });
 

--- a/ethicapp/backend/middleware/upload.js
+++ b/ethicapp/backend/middleware/upload.js
@@ -35,11 +35,24 @@ function createFileFilter(allowedMimeTypes) {
         if (!allowedMimeTypes.has(file.mimetype)) {
             const error = new Error("Invalid file type.");
             error.status = 400;
+            error.code = "INVALID_FILE_TYPE";
             return callback(error);
         }
 
         return callback(null, true);
     };
+}
+
+function getUploadErrorCode(error) {
+    if (error?.code === "LIMIT_FILE_SIZE") {
+        return "FILE_TOO_LARGE";
+    }
+
+    if (error?.code === "LIMIT_UNEXPECTED_FILE") {
+        return "UNEXPECTED_FILE_FIELD";
+    }
+
+    return error?.code || "UPLOAD_FAILED";
 }
 
 function createUpload(allowedMimeTypes) {
@@ -63,6 +76,7 @@ function withUpload(uploadMiddleware) {
             return res.status(status).json({
                 status: "err",
                 message: error.message || "File upload failed.",
+                code: getUploadErrorCode(error),
             });
         });
     };

--- a/ethicapp/frontend/assets/js/components/case-author-editor.component.js
+++ b/ethicapp/frontend/assets/js/components/case-author-editor.component.js
@@ -18,6 +18,27 @@ const CaseAuthorEditorController = function() {
     vm.onUseCurrentUserChanged = function() {
         vm.applyCurrentUserAsAuthor();
     };
+
+    vm.getFieldValue = function(fieldName) {
+        return String(vm.author?.[fieldName] || "").trim();
+    };
+
+    vm.isFieldMissing = function(fieldName) {
+        return !vm.getFieldValue(fieldName);
+    };
+
+    vm.isEmailInvalid = function() {
+        const email = vm.getFieldValue("authorEmail");
+        return Boolean(email) && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    };
+
+    vm.shouldShowRequiredError = function(fieldName) {
+        return vm.hasAttemptedSubmit && vm.isFieldMissing(fieldName);
+    };
+
+    vm.shouldShowEmailError = function() {
+        return vm.hasAttemptedSubmit && vm.isEmailInvalid();
+    };
 };
 
 const caseAuthorEditorComponent = {
@@ -27,6 +48,7 @@ const caseAuthorEditorComponent = {
         isPrimary:          "<",
         canRemove:          "<",
         isDuplicateEmail:   "<",
+        hasAttemptedSubmit: "<",
         currentUserProfile: "<",
         useCurrentUser:     "=",
         isReadonly:         "<",

--- a/ethicapp/frontend/assets/js/components/case-form-editor.component.js
+++ b/ethicapp/frontend/assets/js/components/case-form-editor.component.js
@@ -21,11 +21,16 @@ const CaseFormEditorController = function() {
 
         vm.hasAttemptedSubmit = true;
         vm.ensureAuthors();
-        if (!form || !form.$valid || vm.hasDuplicateAuthorEmails() || !vm.onSave) {
+        if (!form || !vm.isFormValid(form) || vm.hasDuplicateAuthorEmails() || !vm.onSave) {
             return;
         }
 
+        vm.clearUploadError();
         vm.onSave();
+    };
+
+    vm.isFormValid = function(form) {
+        return form.$valid && !vm.hasMissingRequiredPdf();
     };
 
     vm.shouldShowError = function(control) {
@@ -37,9 +42,31 @@ const CaseFormEditorController = function() {
     };
 
     vm.handlePdfSelected = function(files) {
+        vm.clearUploadError();
         if (vm.onPdfSelected) {
             vm.onPdfSelected({ files });
         }
+    };
+
+    vm.clearUploadError = function() {
+        if (vm.formModel) {
+            vm.formModel.uploadErrorKey = "";
+        }
+    };
+
+    vm.hasMissingRequiredPdf = function() {
+        return vm.isPdfRequired && !vm.formModel?.pdf && !vm.formModel?.currentPdfPath;
+    };
+
+    vm.shouldShowPdfRequiredError = function(control) {
+        return Boolean(
+            (control && vm.shouldShowError(control) && control.$error.required) ||
+            (vm.hasAttemptedSubmit && vm.hasMissingRequiredPdf())
+        );
+    };
+
+    vm.hasUploadError = function() {
+        return Boolean(vm.formModel?.uploadErrorKey);
     };
 
     vm.ensureAuthors = function() {

--- a/ethicapp/frontend/assets/js/controllers/teacher/cases.controller.js
+++ b/ethicapp/frontend/assets/js/controllers/teacher/cases.controller.js
@@ -69,6 +69,7 @@ export function CasesController($scope, $routeParams, $window, $interval, $trans
             commercialSource: "",
             languageCode: LanguageCatalogService.getDefaultLanguageCode(vm.languages, "es_CL"),
             tags: [],
+            uploadErrorKey: "",
         };
     };
     vm.form = vm.createEmptyCaseForm();
@@ -328,16 +329,46 @@ export function CasesController($scope, $routeParams, $window, $interval, $trans
 
     vm.handlePdfSelected = function(files) {
         vm.form.pdf = files && files.length > 0 ? files[0] : null;
+        vm.form.uploadErrorKey = "";
+    };
+
+    vm.getCaseSaveErrorMessageKey = function(error) {
+        switch (error?.data?.code) {
+        case "CASE_PDF_REQUIRED":
+            return "ethical_cases_validation_pdf_required";
+        case "INVALID_FILE_TYPE":
+        case "UNEXPECTED_FILE_FIELD":
+            return "ethical_cases_validation_pdf_type";
+        case "FILE_TOO_LARGE":
+            return "ethical_cases_validation_pdf_too_large";
+        case "CASE_VALIDATION_FAILED":
+            return "ethical_cases_validation_required";
+        default:
+            return "ethical_cases_save_error";
+        }
+    };
+
+    vm.isCaseUploadError = function(messageKey) {
+        return [
+            "ethical_cases_validation_pdf_required",
+            "ethical_cases_validation_pdf_type",
+            "ethical_cases_validation_pdf_too_large",
+        ].includes(messageKey);
     };
 
     vm.createCase = async function() {
         try {
+            vm.form.uploadErrorKey = "";
             await CasesCatalogService.createCase(vm.form);
             vm.showInfoToast(vm.translate("ethical_cases_create_success"));
             $scope.navigateTo("/cases");
         } catch (error) {
             console.error("[CasesController::createCase] Error creating case.", error);
-            vm.showErrorToast(vm.translate("ethical_cases_save_error"));
+            const messageKey = vm.getCaseSaveErrorMessageKey(error);
+            if (vm.isCaseUploadError(messageKey)) {
+                vm.form.uploadErrorKey = messageKey;
+            }
+            vm.showErrorToast(vm.translate(messageKey));
             $scope.$applyAsync();
         }
     };
@@ -349,6 +380,7 @@ export function CasesController($scope, $routeParams, $window, $interval, $trans
         }
 
         try {
+            vm.form.uploadErrorKey = "";
             await CasesCatalogService.updateCase(caseId, vm.form);
             vm.showInfoToast(vm.translate("ethical_cases_update_success"));
             $scope.$applyAsync();
@@ -356,7 +388,10 @@ export function CasesController($scope, $routeParams, $window, $interval, $trans
             console.error("[CasesController::updateCase] Error updating case.", error);
             const messageKey = error?.data?.code === "CASE_USED_BY_LAUNCHED_ACTIVITY"
                 ? "case_cannot_delete_used_by_activity"
-                : "ethical_cases_save_error";
+                : vm.getCaseSaveErrorMessageKey(error);
+            if (vm.isCaseUploadError(messageKey)) {
+                vm.form.uploadErrorKey = messageKey;
+            }
             vm.showErrorToast(vm.translate(messageKey));
             $scope.$applyAsync();
         }

--- a/ethicapp/frontend/assets/locales/en_US.json
+++ b/ethicapp/frontend/assets/locales/en_US.json
@@ -626,6 +626,8 @@
 	"ethical_cases_validation_required": "This field is required.",
 	"ethical_cases_validation_email": "Please enter a valid email address.",
 	"ethical_cases_validation_pdf_required": "A PDF file is required.",
+	"ethical_cases_validation_pdf_type": "The selected file must be a PDF.",
+	"ethical_cases_validation_pdf_too_large": "The PDF cannot exceed 5 MB.",
 	"required_field_note": "* required field",
 	"empty_cases_message": "There are no ethical cases yet, but you can",
 	"empty_cases_link": "create one now",

--- a/ethicapp/frontend/assets/locales/es_CL.json
+++ b/ethicapp/frontend/assets/locales/es_CL.json
@@ -635,6 +635,8 @@
 	"ethical_cases_validation_required": "Este campo es obligatorio.",
 	"ethical_cases_validation_email": "Ingresa un correo electrónico válido.",
 	"ethical_cases_validation_pdf_required": "Debes seleccionar un archivo PDF.",
+	"ethical_cases_validation_pdf_type": "El archivo debe ser un PDF.",
+	"ethical_cases_validation_pdf_too_large": "El PDF no puede superar los 5 MB.",
 	"required_field_note": "* campo obligatorio",
 	"empty_cases_message": "Aún no hay casos, pero puedes",
 	"empty_cases_link": "crear uno ahora",

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/case-author-editor.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/case-author-editor.template.html
@@ -13,7 +13,7 @@
 
         <div class="row">
             <div class="col-sm-4">
-                <div class="form-group case-form-field">
+                <div class="form-group case-form-field" ng-class="{'has-error': $ctrl.shouldShowRequiredError('authorFirstname')}">
                     <label for="caseAuthorFirstname{{$ctrl.authorIndex}}">{{ 'author_firstname' | translate }} <span class="text-danger" aria-hidden="true">*</span></label>
                     <input
                         id="caseAuthorFirstname{{$ctrl.authorIndex}}"
@@ -21,12 +21,16 @@
                         name="authorFirstname{{$ctrl.authorIndex}}"
                         class="form-control"
                         ng-model="$ctrl.author.authorFirstname"
+                        ng-class="{'input-warning': $ctrl.shouldShowRequiredError('authorFirstname')}"
                         ng-readonly="$ctrl.isReadonly || ($ctrl.isPrimary && $ctrl.useCurrentUser)"
                         required>
+                    <p class="help-block text-danger" ng-if="$ctrl.shouldShowRequiredError('authorFirstname')">
+                        {{ 'ethical_cases_validation_required' | translate }}
+                    </p>
                 </div>
             </div>
             <div class="col-sm-4">
-                <div class="form-group case-form-field">
+                <div class="form-group case-form-field" ng-class="{'has-error': $ctrl.shouldShowRequiredError('authorLastname')}">
                     <label for="caseAuthorLastname{{$ctrl.authorIndex}}">{{ 'author_lastname' | translate }} <span class="text-danger" aria-hidden="true">*</span></label>
                     <input
                         id="caseAuthorLastname{{$ctrl.authorIndex}}"
@@ -34,12 +38,16 @@
                         name="authorLastname{{$ctrl.authorIndex}}"
                         class="form-control"
                         ng-model="$ctrl.author.authorLastname"
+                        ng-class="{'input-warning': $ctrl.shouldShowRequiredError('authorLastname')}"
                         ng-readonly="$ctrl.isReadonly || ($ctrl.isPrimary && $ctrl.useCurrentUser)"
                         required>
+                    <p class="help-block text-danger" ng-if="$ctrl.shouldShowRequiredError('authorLastname')">
+                        {{ 'ethical_cases_validation_required' | translate }}
+                    </p>
                 </div>
             </div>
             <div class="col-sm-4">
-                <div class="form-group case-form-field" ng-class="{'has-error': $ctrl.isDuplicateEmail}">
+                <div class="form-group case-form-field" ng-class="{'has-error': $ctrl.isDuplicateEmail || $ctrl.shouldShowRequiredError('authorEmail') || $ctrl.shouldShowEmailError()}">
                     <label for="caseAuthorEmail{{$ctrl.authorIndex}}">{{ 'email' | translate }} <span class="text-danger" aria-hidden="true">*</span></label>
                     <input
                         id="caseAuthorEmail{{$ctrl.authorIndex}}"
@@ -47,8 +55,15 @@
                         name="authorEmail{{$ctrl.authorIndex}}"
                         class="form-control"
                         ng-model="$ctrl.author.authorEmail"
+                        ng-class="{'input-warning': $ctrl.shouldShowRequiredError('authorEmail') || $ctrl.shouldShowEmailError()}"
                         ng-readonly="$ctrl.isReadonly || ($ctrl.isPrimary && $ctrl.useCurrentUser)"
                         required>
+                    <p class="help-block text-danger" ng-if="$ctrl.shouldShowRequiredError('authorEmail')">
+                        {{ 'ethical_cases_validation_required' | translate }}
+                    </p>
+                    <p class="help-block text-danger" ng-if="$ctrl.shouldShowEmailError()">
+                        {{ 'ethical_cases_validation_email' | translate }}
+                    </p>
                     <p class="help-block text-danger" ng-if="$ctrl.isDuplicateEmail">
                         {{ 'ethical_cases_validation_duplicate_author_email' | translate }}
                     </p>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/case-form-editor.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/case-form-editor.template.html
@@ -40,6 +40,7 @@
             is-primary="$index === 0"
             can-remove="$ctrl.formModel.authors.length > 1"
             is-duplicate-email="$ctrl.isDuplicateAuthorEmail(author)"
+            has-attempted-submit="$ctrl.hasAttemptedSubmit"
             current-user-profile="$ctrl.currentUserProfile"
             use-current-user="$ctrl.formModel.isFirstAuthorCurrentUser"
             is-readonly="$ctrl.isLocked()"
@@ -122,11 +123,14 @@
                 class="form-control"
                 accept="application/pdf"
                 ngf-select="$ctrl.handlePdfSelected($files)"
-                ng-class="{'input-warning': $ctrl.shouldShowError(caseForm.pdf)}"
+                ng-class="{'input-warning': $ctrl.shouldShowPdfRequiredError(caseForm.pdf) || $ctrl.hasUploadError()}"
                 ng-disabled="$ctrl.isLocked()"
                 ng-required="$ctrl.isPdfRequired">
-            <p class="help-block text-danger" ng-if="$ctrl.shouldShowError(caseForm.pdf) && caseForm.pdf.$error.required">
+            <p class="help-block text-danger" ng-if="$ctrl.shouldShowPdfRequiredError(caseForm.pdf)">
                 {{ 'ethical_cases_validation_pdf_required' | translate }}
+            </p>
+            <p class="help-block text-danger" ng-if="$ctrl.hasUploadError()">
+                {{ $ctrl.formModel.uploadErrorKey | translate }}
             </p>
         </div>
 


### PR DESCRIPTION
## Context

Closes #514.

The legacy case creation/edit form did not surface all validation failures clearly, especially missing PDFs, missing author fields, and backend upload rejections.

## What changed

- Added visible inline validation feedback for author first name, last name, email, invalid email format, and duplicate email cases.
- Added explicit PDF-required feedback that does not depend solely on the file input validity state.
- Added upload error state to the case form so backend PDF upload failures are shown next to the PDF input.
- Added localized PDF validation messages for invalid file type and oversized files.
- Added stable backend error codes for upload failures and case validation failures:
  - `INVALID_FILE_TYPE`
  - `FILE_TOO_LARGE`
  - `UNEXPECTED_FILE_FIELD`
  - `CASE_PDF_REQUIRED`
  - `CASE_VALIDATION_FAILED`
- Updated upload middleware tests to assert the new error codes.

## Verification

- Manual smoke test confirmed the relevant form validations activate correctly.
- `npm test` in `ethicapp/backend` passed: 26 tests.
- `npx htmlhint ethicapp/frontend/assets/static/views/teacher/fragments/case-form-editor.template.html ethicapp/frontend/assets/static/views/teacher/fragments/case-author-editor.template.html` passed.
- Attempted focused `npx eslint` on touched files, but it reports pre-existing legacy style debt across the same modules; no autofix was applied to avoid an unrelated refactor.