### PR TITLE
[codex] Add Enterprise reCAPTCHA backend verification

### DIFF
--- a/auth-backend/routes/auth.routes.js
+++ b/auth-backend/routes/auth.routes.js
@@ -881,7 +881,8 @@ router.post('/register', async (req, res) => {
 
     const isHuman = await recaptchaService.verifyRecaptchaToken({
       token: recaptchaToken,
-      remoteIp: req.ip
+      remoteIp: req.ip,
+      userAgent: req.get('user-agent') || ''
     });
 
     if (!isHuman) {
@@ -1293,7 +1294,8 @@ router.post('/forgot', async (req, res) => {
 
     const isHuman = await recaptchaService.verifyRecaptchaToken({
       token: recaptchaToken,
-      remoteIp: req.ip
+      remoteIp: req.ip,
+      userAgent: req.get('user-agent') || ''
     });
 
     if (!isHuman) {

--- a/auth-backend/services/recaptcha.service.js
+++ b/auth-backend/services/recaptcha.service.js
@@ -1,32 +1,57 @@
-const RECAPTCHA_ENABLED = process.env.RECAPTCHA_ENABLED === 'true';
-const RECAPTCHA_SECRET_KEY = process.env.RECAPTCHA_SECRET_KEY || '';
-const RECAPTCHA_VERIFY_URL =
-  process.env.RECAPTCHA_VERIFY_URL || 'https://www.google.com/recaptcha/api/siteverify';
+const DEFAULT_CLASSIC_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
+const RECAPTCHA_PROVIDER_CLASSIC = 'classic';
+const RECAPTCHA_PROVIDER_ENTERPRISE = 'enterprise';
 
-async function verifyRecaptchaToken({ token, remoteIp }) {
-  if (!RECAPTCHA_ENABLED) {
-    return true;
+function isRecaptchaEnabled() {
+  return process.env.RECAPTCHA_ENABLED === 'true';
+}
+
+function getRecaptchaProvider() {
+  return (process.env.RECAPTCHA_PROVIDER || RECAPTCHA_PROVIDER_CLASSIC)
+    .trim()
+    .toLowerCase();
+}
+
+function getEnterpriseAssessmentUrl() {
+  const projectId = process.env.RECAPTCHA_ENTERPRISE_PROJECT_ID || '';
+  const apiKey = process.env.RECAPTCHA_ENTERPRISE_API_KEY || '';
+
+  if (!projectId) {
+    throw new Error(
+      'reCAPTCHA Enterprise is enabled but RECAPTCHA_ENTERPRISE_PROJECT_ID is not configured'
+    );
   }
 
-  if (!RECAPTCHA_SECRET_KEY) {
+  if (!apiKey) {
+    throw new Error(
+      'reCAPTCHA Enterprise is enabled but RECAPTCHA_ENTERPRISE_API_KEY is not configured'
+    );
+  }
+
+  const encodedProjectId = encodeURIComponent(projectId);
+  const encodedApiKey = encodeURIComponent(apiKey);
+  return `https://recaptchaenterprise.googleapis.com/v1/projects/${encodedProjectId}/assessments?key=${encodedApiKey}`;
+}
+
+async function verifyClassicRecaptchaToken({ token, remoteIp }) {
+  const secretKey = process.env.RECAPTCHA_SECRET_KEY || '';
+  const verifyUrl = process.env.RECAPTCHA_VERIFY_URL || DEFAULT_CLASSIC_VERIFY_URL;
+
+  if (!secretKey) {
     throw new Error(
       'reCAPTCHA is enabled but RECAPTCHA_SECRET_KEY is not configured'
     );
   }
 
-  if (!token) {
-    return false;
-  }
-
   const params = new URLSearchParams();
-  params.append('secret', RECAPTCHA_SECRET_KEY);
+  params.append('secret', secretKey);
   params.append('response', token);
 
   if (remoteIp) {
     params.append('remoteip', remoteIp);
   }
 
-  const response = await fetch(RECAPTCHA_VERIFY_URL, {
+  const response = await fetch(verifyUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
@@ -35,16 +60,86 @@ async function verifyRecaptchaToken({ token, remoteIp }) {
   });
 
   if (!response.ok) {
-    throw new Error(`reCAPTCHA verification failed with status ${response.status}`);
+    throw new Error(
+      `reCAPTCHA verification failed with status ${response.status}`
+    );
   }
 
   const body = await response.json();
   return body.success === true;
 }
 
+async function verifyEnterpriseRecaptchaToken({ token, remoteIp, userAgent }) {
+  const siteKey = process.env.VITE_RECAPTCHA_SITE_KEY || '';
+
+  if (!siteKey) {
+    throw new Error(
+      'reCAPTCHA Enterprise is enabled but VITE_RECAPTCHA_SITE_KEY is not configured'
+    );
+  }
+
+  const event = {
+    token,
+    siteKey
+  };
+
+  if (userAgent) {
+    event.userAgent = userAgent;
+  }
+
+  if (remoteIp) {
+    event.userIpAddress = remoteIp;
+  }
+
+  const response = await fetch(getEnterpriseAssessmentUrl(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    },
+    body: JSON.stringify({ event })
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `reCAPTCHA Enterprise assessment failed with status ${response.status}`
+    );
+  }
+
+  const body = await response.json();
+  return body.tokenProperties?.valid === true;
+}
+
+async function verifyRecaptchaToken({ token, remoteIp, userAgent }) {
+  if (!isRecaptchaEnabled()) {
+    return true;
+  }
+
+  if (!token) {
+    return false;
+  }
+
+  const provider = getRecaptchaProvider();
+
+  if (provider === RECAPTCHA_PROVIDER_ENTERPRISE) {
+    return verifyEnterpriseRecaptchaToken({ token, remoteIp, userAgent });
+  }
+
+  if (provider === RECAPTCHA_PROVIDER_CLASSIC) {
+    return verifyClassicRecaptchaToken({ token, remoteIp });
+  }
+
+  throw new Error(`Unsupported reCAPTCHA provider: ${provider}`);
+}
+
 const recaptchaService = {
-  verifyRecaptchaToken
+  verifyRecaptchaToken,
+  verifyClassicRecaptchaToken,
+  verifyEnterpriseRecaptchaToken
 };
 
-export { verifyRecaptchaToken };
+export {
+  verifyClassicRecaptchaToken,
+  verifyEnterpriseRecaptchaToken,
+  verifyRecaptchaToken
+};
 export default recaptchaService;

--- a/auth-backend/services/recaptcha.service.node-test.mjs
+++ b/auth-backend/services/recaptcha.service.node-test.mjs
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, mock, test } from 'node:test';
+
+import {
+  verifyRecaptchaToken
+} from './recaptcha.service.js';
+
+const RECAPTCHA_ENV_KEYS = [
+  'RECAPTCHA_ENABLED',
+  'RECAPTCHA_PROVIDER',
+  'RECAPTCHA_SECRET_KEY',
+  'RECAPTCHA_VERIFY_URL',
+  'RECAPTCHA_ENTERPRISE_PROJECT_ID',
+  'RECAPTCHA_ENTERPRISE_API_KEY',
+  'VITE_RECAPTCHA_SITE_KEY'
+];
+
+const originalEnv = Object.fromEntries(
+  RECAPTCHA_ENV_KEYS.map((key) => [key, process.env[key]])
+);
+
+function resetRecaptchaEnv(overrides = {}) {
+  for (const key of RECAPTCHA_ENV_KEYS) {
+    if (originalEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalEnv[key];
+    }
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    process.env[key] = value;
+  }
+}
+
+function mockFetchJson(body, { ok = true, status = 200 } = {}) {
+  const fetchMock = mock.method(globalThis, 'fetch', async () => ({
+    ok,
+    status,
+    json: async () => body
+  }));
+
+  return fetchMock;
+}
+
+describe('recaptcha service', () => {
+  afterEach(() => {
+    resetRecaptchaEnv();
+    mock.restoreAll();
+  });
+
+  test('returns valid when reCAPTCHA is disabled', async () => {
+    resetRecaptchaEnv({ RECAPTCHA_ENABLED: 'false' });
+    const fetchMock = mockFetchJson({});
+
+    const result = await verifyRecaptchaToken({
+      token: '',
+      remoteIp: '127.0.0.1'
+    });
+
+    assert.equal(result, true);
+    assert.equal(fetchMock.mock.calls.length, 0);
+  });
+
+  test('returns invalid for missing tokens before requiring provider config', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise'
+    });
+    const fetchMock = mockFetchJson({});
+
+    const result = await verifyRecaptchaToken({
+      token: '',
+      remoteIp: '127.0.0.1'
+    });
+
+    assert.equal(result, false);
+    assert.equal(fetchMock.mock.calls.length, 0);
+  });
+
+  test('verifies classic tokens with the siteverify endpoint', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'classic',
+      RECAPTCHA_SECRET_KEY: 'classic-secret',
+      RECAPTCHA_VERIFY_URL: 'https://captcha.example.test/siteverify'
+    });
+    const fetchMock = mockFetchJson({ success: true });
+
+    const result = await verifyRecaptchaToken({
+      token: 'classic-token',
+      remoteIp: '127.0.0.1'
+    });
+
+    assert.equal(result, true);
+    assert.equal(fetchMock.mock.calls.length, 1);
+    assert.equal(fetchMock.mock.calls[0].arguments[0], 'https://captcha.example.test/siteverify');
+    assert.equal(fetchMock.mock.calls[0].arguments[1].method, 'POST');
+    assert.equal(
+      fetchMock.mock.calls[0].arguments[1].headers['Content-Type'],
+      'application/x-www-form-urlencoded'
+    );
+
+    const params = new URLSearchParams(fetchMock.mock.calls[0].arguments[1].body);
+    assert.equal(params.get('secret'), 'classic-secret');
+    assert.equal(params.get('response'), 'classic-token');
+    assert.equal(params.get('remoteip'), '127.0.0.1');
+  });
+
+  test('verifies Enterprise tokens with CreateAssessment', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise',
+      RECAPTCHA_ENTERPRISE_PROJECT_ID: 'ethicapp-project',
+      RECAPTCHA_ENTERPRISE_API_KEY: 'enterprise-api-key',
+      VITE_RECAPTCHA_SITE_KEY: 'enterprise-site-key'
+    });
+    const fetchMock = mockFetchJson({
+      tokenProperties: {
+        valid: true
+      }
+    });
+
+    const result = await verifyRecaptchaToken({
+      token: 'enterprise-token',
+      remoteIp: '127.0.0.1',
+      userAgent: 'recaptcha-test-agent'
+    });
+
+    assert.equal(result, true);
+    assert.equal(fetchMock.mock.calls.length, 1);
+    assert.equal(
+      fetchMock.mock.calls[0].arguments[0],
+      'https://recaptchaenterprise.googleapis.com/v1/projects/ethicapp-project/assessments?key=enterprise-api-key'
+    );
+    assert.equal(fetchMock.mock.calls[0].arguments[1].method, 'POST');
+    assert.equal(
+      fetchMock.mock.calls[0].arguments[1].headers['Content-Type'],
+      'application/json; charset=utf-8'
+    );
+    assert.deepEqual(JSON.parse(fetchMock.mock.calls[0].arguments[1].body), {
+      event: {
+        token: 'enterprise-token',
+        siteKey: 'enterprise-site-key',
+        userAgent: 'recaptcha-test-agent',
+        userIpAddress: '127.0.0.1'
+      }
+    });
+  });
+
+  test('rejects invalid Enterprise token properties', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise',
+      RECAPTCHA_ENTERPRISE_PROJECT_ID: 'ethicapp-project',
+      RECAPTCHA_ENTERPRISE_API_KEY: 'enterprise-api-key',
+      VITE_RECAPTCHA_SITE_KEY: 'enterprise-site-key'
+    });
+    mockFetchJson({
+      tokenProperties: {
+        valid: false,
+        invalidReason: 'EXPIRED'
+      }
+    });
+
+    const result = await verifyRecaptchaToken({
+      token: 'expired-token',
+      remoteIp: '127.0.0.1'
+    });
+
+    assert.equal(result, false);
+  });
+
+  test('throws on Enterprise HTTP errors', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise',
+      RECAPTCHA_ENTERPRISE_PROJECT_ID: 'ethicapp-project',
+      RECAPTCHA_ENTERPRISE_API_KEY: 'enterprise-api-key',
+      VITE_RECAPTCHA_SITE_KEY: 'enterprise-site-key'
+    });
+    mockFetchJson({}, { ok: false, status: 429 });
+
+    await assert.rejects(
+      verifyRecaptchaToken({
+        token: 'enterprise-token',
+        remoteIp: '127.0.0.1'
+      }),
+      /reCAPTCHA Enterprise assessment failed with status 429/
+    );
+  });
+
+  test('throws when Enterprise configuration is incomplete', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise',
+      RECAPTCHA_ENTERPRISE_PROJECT_ID: 'ethicapp-project',
+      VITE_RECAPTCHA_SITE_KEY: 'enterprise-site-key'
+    });
+
+    await assert.rejects(
+      verifyRecaptchaToken({
+        token: 'enterprise-token',
+        remoteIp: '127.0.0.1'
+      }),
+      /RECAPTCHA_ENTERPRISE_API_KEY is not configured/
+    );
+  });
+});

--- a/management-console/backend/routes/__tests__/users.routes.node-test.mjs
+++ b/management-console/backend/routes/__tests__/users.routes.node-test.mjs
@@ -302,7 +302,8 @@ describe('management-console user routes', () => {
           'X-Forwarded-Proto': 'https',
           'X-Forwarded-Host': 'platform.ethicapp.info',
           'X-Forwarded-Port': '443',
-          'Accept-Language': 'es-CL'
+          'Accept-Language': 'es-CL',
+          'User-Agent': 'management-console-test'
         },
         body: JSON.stringify({
           admin_password: 'admin-secret',
@@ -321,7 +322,8 @@ describe('management-console user routes', () => {
     assert.deepEqual(calls.recaptcha, [
       {
         token: 'test-recaptcha-token',
-        remoteIp: '127.0.0.1'
+        remoteIp: '127.0.0.1',
+        userAgent: 'management-console-test'
       }
     ]);
     assert.deepEqual(calls.password, [

--- a/management-console/backend/routes/users.routes.js
+++ b/management-console/backend/routes/users.routes.js
@@ -59,7 +59,8 @@ export function createUsersRouter({
 
     const isHuman = await verifyRecaptchaTokenService({
       token: recaptchaToken,
-      remoteIp: req.ip
+      remoteIp: req.ip,
+      userAgent: req.get('user-agent') || ''
     });
 
     if (!isHuman) {

--- a/management-console/backend/services/recaptcha.service.js
+++ b/management-console/backend/services/recaptcha.service.js
@@ -1,30 +1,57 @@
-const RECAPTCHA_ENABLED = process.env.RECAPTCHA_ENABLED === 'true';
-const RECAPTCHA_SECRET_KEY = process.env.RECAPTCHA_SECRET_KEY || '';
-const RECAPTCHA_VERIFY_URL =
-  process.env.RECAPTCHA_VERIFY_URL || 'https://www.google.com/recaptcha/api/siteverify';
+const DEFAULT_CLASSIC_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
+const RECAPTCHA_PROVIDER_CLASSIC = 'classic';
+const RECAPTCHA_PROVIDER_ENTERPRISE = 'enterprise';
 
-export async function verifyRecaptchaToken({ token, remoteIp }) {
-  if (!RECAPTCHA_ENABLED) {
-    return true;
+function isRecaptchaEnabled() {
+  return process.env.RECAPTCHA_ENABLED === 'true';
+}
+
+function getRecaptchaProvider() {
+  return (process.env.RECAPTCHA_PROVIDER || RECAPTCHA_PROVIDER_CLASSIC)
+    .trim()
+    .toLowerCase();
+}
+
+function getEnterpriseAssessmentUrl() {
+  const projectId = process.env.RECAPTCHA_ENTERPRISE_PROJECT_ID || '';
+  const apiKey = process.env.RECAPTCHA_ENTERPRISE_API_KEY || '';
+
+  if (!projectId) {
+    throw new Error(
+      'reCAPTCHA Enterprise is enabled but RECAPTCHA_ENTERPRISE_PROJECT_ID is not configured'
+    );
   }
 
-  if (!RECAPTCHA_SECRET_KEY) {
-    throw new Error('reCAPTCHA is enabled but RECAPTCHA_SECRET_KEY is not configured');
+  if (!apiKey) {
+    throw new Error(
+      'reCAPTCHA Enterprise is enabled but RECAPTCHA_ENTERPRISE_API_KEY is not configured'
+    );
   }
 
-  if (!token) {
-    return false;
+  const encodedProjectId = encodeURIComponent(projectId);
+  const encodedApiKey = encodeURIComponent(apiKey);
+  return `https://recaptchaenterprise.googleapis.com/v1/projects/${encodedProjectId}/assessments?key=${encodedApiKey}`;
+}
+
+export async function verifyClassicRecaptchaToken({ token, remoteIp }) {
+  const secretKey = process.env.RECAPTCHA_SECRET_KEY || '';
+  const verifyUrl = process.env.RECAPTCHA_VERIFY_URL || DEFAULT_CLASSIC_VERIFY_URL;
+
+  if (!secretKey) {
+    throw new Error(
+      'reCAPTCHA is enabled but RECAPTCHA_SECRET_KEY is not configured'
+    );
   }
 
   const params = new URLSearchParams();
-  params.append('secret', RECAPTCHA_SECRET_KEY);
+  params.append('secret', secretKey);
   params.append('response', token);
 
   if (remoteIp) {
     params.append('remoteip', remoteIp);
   }
 
-  const response = await fetch(RECAPTCHA_VERIFY_URL, {
+  const response = await fetch(verifyUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
@@ -33,9 +60,73 @@ export async function verifyRecaptchaToken({ token, remoteIp }) {
   });
 
   if (!response.ok) {
-    throw new Error(`reCAPTCHA verification failed with status ${response.status}`);
+    throw new Error(
+      `reCAPTCHA verification failed with status ${response.status}`
+    );
   }
 
   const body = await response.json();
   return body.success === true;
+}
+
+export async function verifyEnterpriseRecaptchaToken({ token, remoteIp, userAgent }) {
+  const siteKey = process.env.VITE_RECAPTCHA_SITE_KEY || '';
+
+  if (!siteKey) {
+    throw new Error(
+      'reCAPTCHA Enterprise is enabled but VITE_RECAPTCHA_SITE_KEY is not configured'
+    );
+  }
+
+  const event = {
+    token,
+    siteKey
+  };
+
+  if (userAgent) {
+    event.userAgent = userAgent;
+  }
+
+  if (remoteIp) {
+    event.userIpAddress = remoteIp;
+  }
+
+  const response = await fetch(getEnterpriseAssessmentUrl(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    },
+    body: JSON.stringify({ event })
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `reCAPTCHA Enterprise assessment failed with status ${response.status}`
+    );
+  }
+
+  const body = await response.json();
+  return body.tokenProperties?.valid === true;
+}
+
+export async function verifyRecaptchaToken({ token, remoteIp, userAgent }) {
+  if (!isRecaptchaEnabled()) {
+    return true;
+  }
+
+  if (!token) {
+    return false;
+  }
+
+  const provider = getRecaptchaProvider();
+
+  if (provider === RECAPTCHA_PROVIDER_ENTERPRISE) {
+    return verifyEnterpriseRecaptchaToken({ token, remoteIp, userAgent });
+  }
+
+  if (provider === RECAPTCHA_PROVIDER_CLASSIC) {
+    return verifyClassicRecaptchaToken({ token, remoteIp });
+  }
+
+  throw new Error(`Unsupported reCAPTCHA provider: ${provider}`);
 }

--- a/management-console/backend/services/recaptcha.service.node-test.mjs
+++ b/management-console/backend/services/recaptcha.service.node-test.mjs
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+import {
+  verifyRecaptchaToken
+} from './recaptcha.service.js';
+
+const RECAPTCHA_ENV_KEYS = [
+  'RECAPTCHA_ENABLED',
+  'RECAPTCHA_PROVIDER',
+  'RECAPTCHA_SECRET_KEY',
+  'RECAPTCHA_VERIFY_URL',
+  'RECAPTCHA_ENTERPRISE_PROJECT_ID',
+  'RECAPTCHA_ENTERPRISE_API_KEY',
+  'VITE_RECAPTCHA_SITE_KEY'
+];
+
+const originalEnv = Object.fromEntries(
+  RECAPTCHA_ENV_KEYS.map((key) => [key, process.env[key]])
+);
+
+function resetRecaptchaEnv(overrides = {}) {
+  for (const key of RECAPTCHA_ENV_KEYS) {
+    if (originalEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalEnv[key];
+    }
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    process.env[key] = value;
+  }
+}
+
+function mockFetchJson(body, { ok = true, status = 200 } = {}) {
+  const fetchMock = mock.method(globalThis, 'fetch', async () => ({
+    ok,
+    status,
+    json: async () => body
+  }));
+
+  return fetchMock;
+}
+
+describe('recaptcha service', () => {
+  afterEach(() => {
+    resetRecaptchaEnv();
+    mock.restoreAll();
+  });
+
+  it('returns valid when reCAPTCHA is disabled', async () => {
+    resetRecaptchaEnv({ RECAPTCHA_ENABLED: 'false' });
+    const fetchMock = mockFetchJson({});
+
+    const result = await verifyRecaptchaToken({
+      token: '',
+      remoteIp: '127.0.0.1'
+    });
+
+    assert.equal(result, true);
+    assert.equal(fetchMock.mock.calls.length, 0);
+  });
+
+  it('returns invalid for missing tokens before requiring provider config', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise'
+    });
+    const fetchMock = mockFetchJson({});
+
+    const result = await verifyRecaptchaToken({
+      token: '',
+      remoteIp: '127.0.0.1'
+    });
+
+    assert.equal(result, false);
+    assert.equal(fetchMock.mock.calls.length, 0);
+  });
+
+  it('verifies classic tokens with the siteverify endpoint', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'classic',
+      RECAPTCHA_SECRET_KEY: 'classic-secret',
+      RECAPTCHA_VERIFY_URL: 'https://captcha.example.test/siteverify'
+    });
+    const fetchMock = mockFetchJson({ success: true });
+
+    const result = await verifyRecaptchaToken({
+      token: 'classic-token',
+      remoteIp: '127.0.0.1'
+    });
+
+    assert.equal(result, true);
+    assert.equal(fetchMock.mock.calls.length, 1);
+    assert.equal(fetchMock.mock.calls[0].arguments[0], 'https://captcha.example.test/siteverify');
+    assert.equal(fetchMock.mock.calls[0].arguments[1].method, 'POST');
+    assert.equal(
+      fetchMock.mock.calls[0].arguments[1].headers['Content-Type'],
+      'application/x-www-form-urlencoded'
+    );
+
+    const params = new URLSearchParams(fetchMock.mock.calls[0].arguments[1].body);
+    assert.equal(params.get('secret'), 'classic-secret');
+    assert.equal(params.get('response'), 'classic-token');
+    assert.equal(params.get('remoteip'), '127.0.0.1');
+  });
+
+  it('verifies Enterprise tokens with CreateAssessment', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise',
+      RECAPTCHA_ENTERPRISE_PROJECT_ID: 'ethicapp-project',
+      RECAPTCHA_ENTERPRISE_API_KEY: 'enterprise-api-key',
+      VITE_RECAPTCHA_SITE_KEY: 'enterprise-site-key'
+    });
+    const fetchMock = mockFetchJson({
+      tokenProperties: {
+        valid: true
+      }
+    });
+
+    const result = await verifyRecaptchaToken({
+      token: 'enterprise-token',
+      remoteIp: '127.0.0.1',
+      userAgent: 'recaptcha-test-agent'
+    });
+
+    assert.equal(result, true);
+    assert.equal(fetchMock.mock.calls.length, 1);
+    assert.equal(
+      fetchMock.mock.calls[0].arguments[0],
+      'https://recaptchaenterprise.googleapis.com/v1/projects/ethicapp-project/assessments?key=enterprise-api-key'
+    );
+    assert.equal(fetchMock.mock.calls[0].arguments[1].method, 'POST');
+    assert.equal(
+      fetchMock.mock.calls[0].arguments[1].headers['Content-Type'],
+      'application/json; charset=utf-8'
+    );
+    assert.deepEqual(JSON.parse(fetchMock.mock.calls[0].arguments[1].body), {
+      event: {
+        token: 'enterprise-token',
+        siteKey: 'enterprise-site-key',
+        userAgent: 'recaptcha-test-agent',
+        userIpAddress: '127.0.0.1'
+      }
+    });
+  });
+
+  it('rejects invalid Enterprise token properties', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise',
+      RECAPTCHA_ENTERPRISE_PROJECT_ID: 'ethicapp-project',
+      RECAPTCHA_ENTERPRISE_API_KEY: 'enterprise-api-key',
+      VITE_RECAPTCHA_SITE_KEY: 'enterprise-site-key'
+    });
+    mockFetchJson({
+      tokenProperties: {
+        valid: false,
+        invalidReason: 'EXPIRED'
+      }
+    });
+
+    const result = await verifyRecaptchaToken({
+      token: 'expired-token',
+      remoteIp: '127.0.0.1'
+    });
+
+    assert.equal(result, false);
+  });
+
+  it('throws on Enterprise HTTP errors', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise',
+      RECAPTCHA_ENTERPRISE_PROJECT_ID: 'ethicapp-project',
+      RECAPTCHA_ENTERPRISE_API_KEY: 'enterprise-api-key',
+      VITE_RECAPTCHA_SITE_KEY: 'enterprise-site-key'
+    });
+    mockFetchJson({}, { ok: false, status: 429 });
+
+    await assert.rejects(
+      verifyRecaptchaToken({
+        token: 'enterprise-token',
+        remoteIp: '127.0.0.1'
+      }),
+      /reCAPTCHA Enterprise assessment failed with status 429/
+    );
+  });
+
+  it('throws when Enterprise configuration is incomplete', async () => {
+    resetRecaptchaEnv({
+      RECAPTCHA_ENABLED: 'true',
+      RECAPTCHA_PROVIDER: 'enterprise',
+      RECAPTCHA_ENTERPRISE_PROJECT_ID: 'ethicapp-project',
+      VITE_RECAPTCHA_SITE_KEY: 'enterprise-site-key'
+    });
+
+    await assert.rejects(
+      verifyRecaptchaToken({
+        token: 'enterprise-token',
+        remoteIp: '127.0.0.1'
+      }),
+      /RECAPTCHA_ENTERPRISE_API_KEY is not configured/
+    );
+  });
+});


### PR DESCRIPTION
## Context

Closes #560.

`auth-backend` and `management-console` currently validate reCAPTCHA tokens through the classic `siteverify` endpoint. This PR adds the backend side of the Enterprise migration while keeping the classic path available during rollout.

## What changed

- Added `RECAPTCHA_PROVIDER=enterprise` support in both backend reCAPTCHA services.
- Kept `classic` as the default provider for transition compatibility.
- Added Enterprise `CreateAssessment` calls using:
  - `RECAPTCHA_ENTERPRISE_PROJECT_ID`
  - `RECAPTCHA_ENTERPRISE_API_KEY`
  - `VITE_RECAPTCHA_SITE_KEY`
- Treats Enterprise tokens as valid only when `tokenProperties.valid === true`.
- Passes request `User-Agent` into reCAPTCHA verification for register, forgot-password, and management sensitive-action fallback flows.
- Added focused Node tests for disabled mode, missing token, classic verification, Enterprise success, Enterprise invalid token, Enterprise HTTP errors, and incomplete config.

## Notes

Enterprise non-OK responses currently fail closed by throwing, including quota `429 Resource Exhausted`. That matches the issue's explicit callout and should be documented/configured in the deployment follow-up.

## Verification

- `cd auth-backend && npm test` passed: 51/51.
- `cd management-console/backend && npm test` passed: 40/40.

The local sandbox blocks test servers with `listen EPERM`, so the full backend test suites were run outside the sandbox after approval.