### PR TITLE
[codex] Expose reCAPTCHA provider to frontend runtime config

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,10 +49,10 @@ RECAPTCHA_ENTERPRISE_API_KEY=change-this-in-production
 VITE_RECAPTCHA_SITE_KEY=your-public-enterprise-site-key
 ```
 
-`VITE_RECAPTCHA_SITE_KEY` is public frontend configuration emitted into
-`runtime-config.js`; it is not a secret. `RECAPTCHA_ENTERPRISE_API_KEY` is
-backend-only secret configuration and should be restricted in Google Cloud to
-the reCAPTCHA Enterprise API when possible.
+`RECAPTCHA_PROVIDER` and `VITE_RECAPTCHA_SITE_KEY` are public frontend
+configuration emitted into `runtime-config.js`; they are not secrets.
+`RECAPTCHA_ENTERPRISE_API_KEY` is backend-only secret configuration and should
+be restricted in Google Cloud to the reCAPTCHA Enterprise API when possible.
 
 Without billing, Google Cloud provides 10,000 reCAPTCHA Enterprise assessments
 per calendar month per Google Cloud project. The modern `CreateAssessment` API

--- a/auth-backend/frontend/src/components/auth/ForgotPasswordForm.jsx
+++ b/auth-backend/frontend/src/components/auth/ForgotPasswordForm.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import TextField from '../common/TextField';
 import { forgotPassword } from '../../api/authApi';
 import RecaptchaField from '../common/RecaptchaField';
-import { recaptchaSiteKey } from '../../config/env';
+import { recaptchaProvider, recaptchaSiteKey } from '../../config/env';
 import { useI18n } from '../../app/i18n-context';
 
 function ForgotPasswordForm() {
@@ -120,6 +120,7 @@ function ForgotPasswordForm() {
       <div className="auth-form-text">{t('forgotPassword.instructions')}</div>
 
       <RecaptchaField
+        provider={recaptchaProvider}
         siteKey={recaptchaSiteKey}
         onChange={(token) => {
           setFormData((current) => ({

--- a/auth-backend/frontend/src/components/auth/RegisterForm.jsx
+++ b/auth-backend/frontend/src/components/auth/RegisterForm.jsx
@@ -5,7 +5,7 @@ import TextField from '../common/TextField';
 import SelectField from '../common/SelectField';
 import { register } from '../../api/authApi';
 import RecaptchaField from '../common/RecaptchaField';
-import { recaptchaSiteKey } from '../../config/env';
+import { recaptchaProvider, recaptchaSiteKey } from '../../config/env';
 import { useI18n } from '../../app/i18n-context';
 import { useRegisterDraft } from '../../app/register-draft-context';
 
@@ -313,6 +313,7 @@ function RegisterForm() {
       />
 
       <RecaptchaField
+        provider={recaptchaProvider}
         siteKey={recaptchaSiteKey}
         onChange={(token) => {
           setRecaptchaToken(token);

--- a/auth-backend/frontend/src/components/common/RecaptchaField.jsx
+++ b/auth-backend/frontend/src/components/common/RecaptchaField.jsx
@@ -1,80 +1,117 @@
 import { useEffect, useRef } from 'react';
 
+const RECAPTCHA_CLASSIC_PROVIDER = 'classic';
+const RECAPTCHA_ENTERPRISE_PROVIDER = 'enterprise';
+const RECAPTCHA_CLASSIC_SCRIPT_URL =
+  'https://www.google.com/recaptcha/api.js?render=explicit';
 const RECAPTCHA_ENTERPRISE_SCRIPT_URL =
   'https://www.google.com/recaptcha/enterprise.js?render=explicit';
 
-let recaptchaLoader;
+const recaptchaLoaders = {};
 
-function waitForRecaptchaEnterpriseApi(resolve, reject) {
+function normalizeProvider(provider) {
+  return provider === RECAPTCHA_ENTERPRISE_PROVIDER
+    ? RECAPTCHA_ENTERPRISE_PROVIDER
+    : RECAPTCHA_CLASSIC_PROVIDER;
+}
+
+function getRecaptchaApi(provider) {
+  const grecaptcha = window.grecaptcha;
+
+  if (provider === RECAPTCHA_ENTERPRISE_PROVIDER) {
+    return grecaptcha?.enterprise || null;
+  }
+
+  return grecaptcha || null;
+}
+
+function getRecaptchaScriptUrl(provider) {
+  return provider === RECAPTCHA_ENTERPRISE_PROVIDER
+    ? RECAPTCHA_ENTERPRISE_SCRIPT_URL
+    : RECAPTCHA_CLASSIC_SCRIPT_URL;
+}
+
+function waitForRecaptchaApi(provider, resolve, reject) {
   const grecaptcha = window.grecaptcha;
 
   if (!grecaptcha) {
-    reject(new Error('reCAPTCHA Enterprise API did not initialize'));
+    reject(new Error('reCAPTCHA API did not initialize'));
     return;
   }
 
   const resolveWhenRenderable = () => {
-    if (typeof window.grecaptcha?.enterprise?.render === 'function') {
+    if (typeof getRecaptchaApi(provider)?.render === 'function') {
       resolve(window.grecaptcha);
       return;
     }
 
-    reject(new Error('reCAPTCHA Enterprise render API is not available'));
+    reject(new Error('reCAPTCHA render API is not available'));
   };
 
-  if (typeof grecaptcha.enterprise?.ready === 'function') {
-    grecaptcha.enterprise.ready(resolveWhenRenderable);
+  const recaptchaApi = getRecaptchaApi(provider);
+  if (typeof recaptchaApi?.ready === 'function') {
+    recaptchaApi.ready(resolveWhenRenderable);
     return;
   }
 
   resolveWhenRenderable();
 }
 
-function loadRecaptchaScript() {
-  if (typeof window.grecaptcha?.enterprise?.render === 'function') {
+function loadRecaptchaScript(provider) {
+  const normalizedProvider = normalizeProvider(provider);
+  const scriptUrl = getRecaptchaScriptUrl(normalizedProvider);
+
+  if (typeof getRecaptchaApi(normalizedProvider)?.render === 'function') {
     return Promise.resolve(window.grecaptcha);
   }
 
-  if (recaptchaLoader) {
-    return recaptchaLoader;
+  if (recaptchaLoaders[normalizedProvider]) {
+    return recaptchaLoaders[normalizedProvider];
   }
 
-  recaptchaLoader = new Promise((resolve, reject) => {
+  recaptchaLoaders[normalizedProvider] = new Promise((resolve, reject) => {
     const existingScript = document.querySelector(
-      `script[src="${RECAPTCHA_ENTERPRISE_SCRIPT_URL}"]`
+      `script[src="${scriptUrl}"]`
     );
 
     if (existingScript) {
       if (window.grecaptcha) {
-        waitForRecaptchaEnterpriseApi(resolve, reject);
+        waitForRecaptchaApi(normalizedProvider, resolve, reject);
         return;
       }
 
       existingScript.addEventListener('load', () => {
-        waitForRecaptchaEnterpriseApi(resolve, reject);
+        waitForRecaptchaApi(normalizedProvider, resolve, reject);
       });
       existingScript.addEventListener('error', () => {
-        reject(new Error('No se pudo cargar reCAPTCHA Enterprise'));
+        reject(new Error('No se pudo cargar reCAPTCHA'));
       });
       return;
     }
 
     const script = document.createElement('script');
-    script.src = RECAPTCHA_ENTERPRISE_SCRIPT_URL;
+    script.src = scriptUrl;
     script.async = true;
     script.defer = true;
-    script.onload = () => waitForRecaptchaEnterpriseApi(resolve, reject);
-    script.onerror = () => reject(new Error('No se pudo cargar reCAPTCHA Enterprise'));
+    script.onload = () => waitForRecaptchaApi(normalizedProvider, resolve, reject);
+    script.onerror = () => reject(new Error('No se pudo cargar reCAPTCHA'));
 
     document.head.appendChild(script);
   });
 
-  return recaptchaLoader;
+  return recaptchaLoaders[normalizedProvider];
 }
 
-function RecaptchaField({ siteKey, onChange, resetCounter = 0, error = '' }) {
+function RecaptchaField({
+  provider = RECAPTCHA_CLASSIC_PROVIDER,
+  siteKey,
+  onChange,
+  resetCounter = 0,
+  error = ''
+}) {
   const containerRef = useRef(null);
   const widgetIdRef = useRef(null);
+  const normalizedProvider = normalizeProvider(provider);
 
   useEffect(() => {
     let isMounted = true;
@@ -84,13 +121,14 @@ function RecaptchaField({ siteKey, onChange, resetCounter = 0, error = '' }) {
         return;
       }
 
-      const grecaptcha = await loadRecaptchaScript();
+      const grecaptcha = await loadRecaptchaScript(normalizedProvider);
       if (!isMounted || !grecaptcha) {
         return;
       }
 
+      const recaptchaApi = getRecaptchaApi(normalizedProvider);
       if (widgetIdRef.current === null) {
-        widgetIdRef.current = grecaptcha.enterprise.render(containerRef.current, {
+        widgetIdRef.current = recaptchaApi.render(containerRef.current, {
           sitekey: siteKey,
           callback: (token) => onChange(token),
           'expired-callback': () => onChange(''),
@@ -106,15 +144,16 @@ function RecaptchaField({ siteKey, onChange, resetCounter = 0, error = '' }) {
     return () => {
       isMounted = false;
     };
-  }, [onChange, siteKey]);
+  }, [normalizedProvider, onChange, siteKey]);
 
   useEffect(() => {
-    if (widgetIdRef.current === null || !window.grecaptcha?.enterprise) {
+    const recaptchaApi = getRecaptchaApi(normalizedProvider);
+    if (widgetIdRef.current === null || !recaptchaApi) {
       return;
     }
 
-    window.grecaptcha.enterprise.reset(widgetIdRef.current);
-  }, [resetCounter]);
+    recaptchaApi.reset(widgetIdRef.current);
+  }, [normalizedProvider, resetCounter]);
 
   if (!siteKey) {
     return null;

--- a/auth-backend/frontend/src/config/env.js
+++ b/auth-backend/frontend/src/config/env.js
@@ -23,4 +23,9 @@ const recaptchaSiteKey = (
   ''
 ).trim();
 
-export { authApiBaseUrl, recaptchaSiteKey };
+const recaptchaProvider = (
+  runtimeConfig.recaptchaProvider ||
+  'classic'
+).trim().toLowerCase();
+
+export { authApiBaseUrl, recaptchaProvider, recaptchaSiteKey };

--- a/auth-backend/scripts/write-runtime-config.js
+++ b/auth-backend/scripts/write-runtime-config.js
@@ -4,6 +4,7 @@ import path from 'node:path';
 const config = {
   authPublicUrl: process.env.VITE_AUTH_PUBLIC_URL || '',
   authApiBaseUrl: process.env.VITE_AUTH_API_BASE_URL || '',
+  recaptchaProvider: process.env.RECAPTCHA_PROVIDER || '',
   recaptchaSiteKey: process.env.VITE_RECAPTCHA_SITE_KEY || ''
 };
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -41,9 +41,9 @@ RECAPTCHA_ENTERPRISE_API_KEY=change-this-in-production
 VITE_RECAPTCHA_SITE_KEY=your-public-enterprise-site-key
 ```
 
-`VITE_RECAPTCHA_SITE_KEY` is public runtime frontend configuration.
-`RECAPTCHA_ENTERPRISE_API_KEY` is a backend-only secret and should be restricted
-to the reCAPTCHA Enterprise API where possible.
+`RECAPTCHA_PROVIDER` and `VITE_RECAPTCHA_SITE_KEY` are public runtime frontend
+configuration. `RECAPTCHA_ENTERPRISE_API_KEY` is a backend-only secret and
+should be restricted to the reCAPTCHA Enterprise API where possible.
 
 Without billing, reCAPTCHA Enterprise allows 10,000 assessments per calendar
 month per Google Cloud project. The `CreateAssessment` API fails closed with

--- a/deploy/env.contract.yml
+++ b/deploy/env.contract.yml
@@ -1035,7 +1035,7 @@ variables:
     default: enterprise
     services: [shared, auth-backend, management-console]
     phase: runtime
-    description: reCAPTCHA verification provider. Use enterprise for new deployments; classic is retained only for transition or rollback through the legacy siteverify endpoint.
+    description: reCAPTCHA verification provider emitted into frontend runtime config. Use enterprise for new deployments; classic is retained only for transition or rollback through the legacy siteverify endpoint.
 
   RECAPTCHA_ENTERPRISE_PROJECT_ID:
     type: string
@@ -1332,6 +1332,7 @@ projections:
       - AUTH_PUBLIC_URL
       - VITE_AUTH_PUBLIC_URL
       - VITE_AUTH_API_BASE_URL
+      - RECAPTCHA_PROVIDER
       - VITE_RECAPTCHA_SITE_KEY
   ethicapp-student/.env:
     service: ethicapp-student
@@ -1357,6 +1358,7 @@ projections:
       - AUTH_BACKEND_INTERNAL_BASE_URL
       - AUTH_INTERNAL_SERVICE_TOKEN
       - ETHICAPP_INTERNAL_BASE_URL
+      - RECAPTCHA_PROVIDER
       - VITE_RECAPTCHA_SITE_KEY
   management-console-student-anonymization/.env:
     service: management-console-student-anonymization

--- a/management-console/backend/routes/runtime-config.routes.js
+++ b/management-console/backend/routes/runtime-config.routes.js
@@ -11,6 +11,7 @@ const runtimeConfigPath = path.join(__dirname, '../../frontend/dist/runtime-conf
 
 function buildRuntimeConfigScript() {
   const config = {
+    recaptchaProvider: process.env.RECAPTCHA_PROVIDER || '',
     recaptchaSiteKey: process.env.VITE_RECAPTCHA_SITE_KEY || ''
   };
 

--- a/management-console/frontend/src/components/common/RecaptchaField.jsx
+++ b/management-console/frontend/src/components/common/RecaptchaField.jsx
@@ -1,93 +1,139 @@
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
 
+const RECAPTCHA_CLASSIC_PROVIDER = 'classic';
+const RECAPTCHA_ENTERPRISE_PROVIDER = 'enterprise';
+const RECAPTCHA_CLASSIC_SCRIPT_URL =
+  'https://www.google.com/recaptcha/api.js?render=explicit';
 const RECAPTCHA_ENTERPRISE_SCRIPT_URL =
   'https://www.google.com/recaptcha/enterprise.js?render=explicit';
 
-let recaptchaLoader;
+const recaptchaLoaders = {};
 
-function waitForRecaptchaEnterpriseApi(resolve, reject) {
+function normalizeProvider(provider) {
+  return provider === RECAPTCHA_ENTERPRISE_PROVIDER
+    ? RECAPTCHA_ENTERPRISE_PROVIDER
+    : RECAPTCHA_CLASSIC_PROVIDER;
+}
+
+function getRecaptchaApi(provider) {
+  const grecaptcha = window.grecaptcha;
+
+  if (provider === RECAPTCHA_ENTERPRISE_PROVIDER) {
+    return grecaptcha?.enterprise || null;
+  }
+
+  return grecaptcha || null;
+}
+
+function getRecaptchaScriptUrl(provider) {
+  return provider === RECAPTCHA_ENTERPRISE_PROVIDER
+    ? RECAPTCHA_ENTERPRISE_SCRIPT_URL
+    : RECAPTCHA_CLASSIC_SCRIPT_URL;
+}
+
+function waitForRecaptchaApi(provider, resolve, reject) {
   const grecaptcha = window.grecaptcha;
 
   if (!grecaptcha) {
-    reject(new Error('reCAPTCHA Enterprise API did not initialize'));
+    reject(new Error('reCAPTCHA API did not initialize'));
     return;
   }
 
   const resolveWhenRenderable = () => {
-    if (typeof window.grecaptcha?.enterprise?.render === 'function') {
+    if (typeof getRecaptchaApi(provider)?.render === 'function') {
       resolve(window.grecaptcha);
       return;
     }
 
-    reject(new Error('reCAPTCHA Enterprise render API is not available'));
+    reject(new Error('reCAPTCHA render API is not available'));
   };
 
-  if (typeof grecaptcha.enterprise?.ready === 'function') {
-    grecaptcha.enterprise.ready(resolveWhenRenderable);
+  const recaptchaApi = getRecaptchaApi(provider);
+  if (typeof recaptchaApi?.ready === 'function') {
+    recaptchaApi.ready(resolveWhenRenderable);
     return;
   }
 
   resolveWhenRenderable();
 }
 
-function loadRecaptchaScript() {
-  if (typeof window.grecaptcha?.enterprise?.render === 'function') {
-    console.debug('[management-console] reCAPTCHA Enterprise API already available');
+function loadRecaptchaScript(provider) {
+  const normalizedProvider = normalizeProvider(provider);
+  const scriptUrl = getRecaptchaScriptUrl(normalizedProvider);
+
+  if (typeof getRecaptchaApi(normalizedProvider)?.render === 'function') {
+    console.debug(
+      `[management-console] reCAPTCHA ${normalizedProvider} API already available`
+    );
     return Promise.resolve(window.grecaptcha);
   }
 
-  if (recaptchaLoader) {
-    console.debug('[management-console] reusing pending reCAPTCHA Enterprise loader');
-    return recaptchaLoader;
+  if (recaptchaLoaders[normalizedProvider]) {
+    console.debug(
+      `[management-console] reusing pending reCAPTCHA ${normalizedProvider} loader`
+    );
+    return recaptchaLoaders[normalizedProvider];
   }
 
-  recaptchaLoader = new Promise((resolve, reject) => {
+  recaptchaLoaders[normalizedProvider] = new Promise((resolve, reject) => {
     const existingScript = document.querySelector(
-      `script[src="${RECAPTCHA_ENTERPRISE_SCRIPT_URL}"]`
+      `script[src="${scriptUrl}"]`
     );
 
     if (existingScript) {
-      console.debug('[management-console] waiting for existing reCAPTCHA Enterprise script');
+      console.debug(
+        `[management-console] waiting for existing reCAPTCHA ${normalizedProvider} script`
+      );
       if (window.grecaptcha) {
-        waitForRecaptchaEnterpriseApi(resolve, reject);
+        waitForRecaptchaApi(normalizedProvider, resolve, reject);
         return;
       }
 
       existingScript.addEventListener('load', () => {
-        console.debug('[management-console] existing reCAPTCHA Enterprise script loaded');
-        waitForRecaptchaEnterpriseApi(resolve, reject);
+        console.debug(
+          `[management-console] existing reCAPTCHA ${normalizedProvider} script loaded`
+        );
+        waitForRecaptchaApi(normalizedProvider, resolve, reject);
       });
       existingScript.addEventListener('error', () => {
-        console.warn('[management-console] existing reCAPTCHA Enterprise script failed to load');
-        reject(new Error('Unable to load reCAPTCHA Enterprise'));
+        console.warn(
+          `[management-console] existing reCAPTCHA ${normalizedProvider} script failed to load`
+        );
+        reject(new Error('Unable to load reCAPTCHA'));
       });
       return;
     }
 
     const script = document.createElement('script');
-    script.src = RECAPTCHA_ENTERPRISE_SCRIPT_URL;
+    script.src = scriptUrl;
     script.async = true;
     script.defer = true;
     script.onload = () => {
-      console.debug('[management-console] reCAPTCHA Enterprise script loaded');
-      waitForRecaptchaEnterpriseApi(resolve, reject);
+      console.debug(`[management-console] reCAPTCHA ${normalizedProvider} script loaded`);
+      waitForRecaptchaApi(normalizedProvider, resolve, reject);
     };
     script.onerror = () => {
-      console.warn('[management-console] reCAPTCHA Enterprise script failed to load');
-      reject(new Error('Unable to load reCAPTCHA Enterprise'));
+      console.warn(`[management-console] reCAPTCHA ${normalizedProvider} script failed to load`);
+      reject(new Error('Unable to load reCAPTCHA'));
     };
 
-    console.debug('[management-console] loading reCAPTCHA Enterprise script');
+    console.debug(`[management-console] loading reCAPTCHA ${normalizedProvider} script`);
     document.head.appendChild(script);
   });
 
-  return recaptchaLoader;
+  return recaptchaLoaders[normalizedProvider];
 }
 
-function RecaptchaField({ siteKey, onChange, resetCounter = 0 }) {
+function RecaptchaField({
+  provider = RECAPTCHA_CLASSIC_PROVIDER,
+  siteKey,
+  onChange,
+  resetCounter = 0
+}) {
   const containerRef = useRef(null);
   const widgetIdRef = useRef(null);
+  const normalizedProvider = normalizeProvider(provider);
 
   useEffect(() => {
     let isMounted = true;
@@ -106,7 +152,7 @@ function RecaptchaField({ siteKey, onChange, resetCounter = 0 }) {
         return;
       }
 
-      const grecaptcha = await loadRecaptchaScript();
+      const grecaptcha = await loadRecaptchaScript(normalizedProvider);
       if (!isMounted || !grecaptcha) {
         console.warn('[management-console] reCAPTCHA field stopped before render', {
           isMounted,
@@ -115,9 +161,10 @@ function RecaptchaField({ siteKey, onChange, resetCounter = 0 }) {
         return;
       }
 
+      const recaptchaApi = getRecaptchaApi(normalizedProvider);
       if (widgetIdRef.current === null) {
         console.debug('[management-console] rendering reCAPTCHA widget');
-        widgetIdRef.current = grecaptcha.enterprise.render(containerRef.current, {
+        widgetIdRef.current = recaptchaApi.render(containerRef.current, {
           sitekey: siteKey,
           callback: (token) => onChange(token),
           'expired-callback': () => onChange(''),
@@ -137,15 +184,16 @@ function RecaptchaField({ siteKey, onChange, resetCounter = 0 }) {
     return () => {
       isMounted = false;
     };
-  }, [onChange, siteKey]);
+  }, [normalizedProvider, onChange, siteKey]);
 
   useEffect(() => {
-    if (widgetIdRef.current === null || !window.grecaptcha?.enterprise) {
+    const recaptchaApi = getRecaptchaApi(normalizedProvider);
+    if (widgetIdRef.current === null || !recaptchaApi) {
       return;
     }
 
-    window.grecaptcha.enterprise.reset(widgetIdRef.current);
-  }, [resetCounter]);
+    recaptchaApi.reset(widgetIdRef.current);
+  }, [normalizedProvider, resetCounter]);
 
   if (!siteKey) {
     console.warn('[management-console] reCAPTCHA field hidden because site key is not configured');
@@ -157,6 +205,10 @@ function RecaptchaField({ siteKey, onChange, resetCounter = 0 }) {
 
 RecaptchaField.propTypes = {
   onChange: PropTypes.func.isRequired,
+  provider: PropTypes.oneOf([
+    RECAPTCHA_CLASSIC_PROVIDER,
+    RECAPTCHA_ENTERPRISE_PROVIDER
+  ]),
   resetCounter: PropTypes.number,
   siteKey: PropTypes.string.isRequired
 };

--- a/management-console/frontend/src/config/env.js
+++ b/management-console/frontend/src/config/env.js
@@ -1,4 +1,8 @@
 export const APP_BASE_PATH = '/mng';
+export const recaptchaProvider = (
+  window.__MNG_RUNTIME_CONFIG__?.recaptchaProvider ||
+  'classic'
+).trim().toLowerCase();
 export const recaptchaSiteKey = (
   window.__MNG_RUNTIME_CONFIG__?.recaptchaSiteKey ||
   import.meta.env.VITE_RECAPTCHA_SITE_KEY ||

--- a/management-console/frontend/src/pages/UserShowPage.jsx
+++ b/management-console/frontend/src/pages/UserShowPage.jsx
@@ -12,7 +12,7 @@ import {
   updateUser
 } from '../api/usersApi.js';
 import RecaptchaField from '../components/common/RecaptchaField.jsx';
-import { recaptchaSiteKey } from '../config/env.js';
+import { recaptchaProvider, recaptchaSiteKey } from '../config/env.js';
 
 function UserShowPage() {
   const { id } = useParams();
@@ -325,6 +325,7 @@ function UserShowPage() {
 
                 <Col md={12} className="d-flex justify-content-center">
                   <RecaptchaField
+                    provider={recaptchaProvider}
                     siteKey={recaptchaSiteKey}
                     resetCounter={recaptchaResetCounter}
                     onChange={setRecaptchaToken}

--- a/management-console/scripts/write-runtime-config.mjs
+++ b/management-console/scripts/write-runtime-config.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const config = {
+  recaptchaProvider: process.env.RECAPTCHA_PROVIDER || '',
   recaptchaSiteKey: process.env.VITE_RECAPTCHA_SITE_KEY || ''
 };
 


### PR DESCRIPTION
## Context

Follow-up to #562, #563, #564, and #565.

The backend can still verify classic reCAPTCHA tokens through `RECAPTCHA_PROVIDER=classic`, but after the frontend Enterprise migration the browser always loaded `enterprise.js`. That meant classic backend verification could still be configured while the frontend widget might fail with classic, non-Enterprise site keys.

## What changed

- Exposes `RECAPTCHA_PROVIDER` through auth-backend and management-console runtime config.
- Auth and management frontends now default to `classic` when no provider is emitted, preserving existing deployments.
- `RecaptchaField` now chooses the browser script and API surface by provider:
  - `classic`: `api.js` with `grecaptcha.render/reset/ready`
  - `enterprise`: `enterprise.js` with `grecaptcha.enterprise.render/reset/ready`
- Register, forgot-password, and management sensitive-action fallback pass the configured provider into their reCAPTCHA widgets.
- The management runtime-config fallback route also emits `recaptchaProvider`.
- Deployment docs and contract descriptions now state that `RECAPTCHA_PROVIDER` is public runtime frontend config, not a secret.

## Verification

- `cd auth-backend/frontend && npm run build` passed.
- `cd management-console/frontend && npm run build` passed.
- `cd auth-backend/frontend && npx eslint src/components/common/RecaptchaField.jsx src/components/auth/RegisterForm.jsx src/components/auth/ForgotPasswordForm.jsx src/config/env.js` passed.
- `cd management-console/backend && npm test` passed: 40/40.
- Runtime config writer smoke checks confirmed `recaptchaProvider` is emitted for auth and management.
- `ruby -e "require 'yaml'; YAML.load_file('deploy/env.contract.yml')"` passed.
- `git diff --check` passed.

## Notes

This keeps production environments on classic reCAPTCHA functional while operators prepare Enterprise keys. To stay on classic, set `RECAPTCHA_PROVIDER=classic` explicitly together with the existing classic secret/site keys.