### PR TITLE
External services: add PostgreSQL schema for jobs and callback results (V15)

### DIFF
--- a/database/migrations/V15__external_service_jobs.sql
+++ b/database/migrations/V15__external_service_jobs.sql
@@ -1,0 +1,126 @@
+-- External-service job and callback result tracking.
+--
+-- Design notes:
+--
+-- external_service_jobs represents one outbound dispatch unit of work: EthicApp
+-- calling an adapter for a specific hook. The job id (UUID) is the single
+-- stable correlation identifier sent to external providers in outbound requests.
+-- There is no separate correlationId column; job.id IS the correlation id.
+--
+-- external_service_results represents one inbound callback. correlation_id
+-- stores the raw value returned by the provider. job_id is the resolved FK
+-- (set when correlation_id matches a known job). Both columns are nullable and
+-- stored independently so unrecognized or uncorrelated callbacks remain auditable.
+--
+-- Status vocabulary:
+--
+--   Jobs:    pending | dispatched | callback-received | completed | failed | skipped | expired
+--   Results: callback-received | completed | failed | unknown-correlation
+--
+-- Jobs progress from pending → dispatched → callback-received → completed/failed.
+-- skipped: adapter determined at dispatch time that no provider call was needed.
+-- expired: job timed out before a callback arrived.
+-- unknown-correlation: result arrived with a correlation_id that matched no job.
+
+CREATE TABLE IF NOT EXISTS external_service_jobs (
+    id                 uuid        NOT NULL DEFAULT gen_random_uuid(),
+    service_id         text        NOT NULL,
+    hook_name          text        NOT NULL,
+    status             text        NOT NULL DEFAULT 'pending'
+                           CONSTRAINT external_service_jobs_status_check
+                           CHECK (status IN (
+                               'pending',
+                               'dispatched',
+                               'callback-received',
+                               'completed',
+                               'failed',
+                               'skipped',
+                               'expired'
+                           )),
+    session_id         integer     NULL,
+    phase_id           integer     NULL,
+    question_id        integer     NULL,
+    group_id           integer     NULL,
+    user_id            integer     NULL,
+    outbound_payload   jsonb       NULL,
+    provider_reference text        NULL,
+    created_at         timestamptz NOT NULL DEFAULT now(),
+    updated_at         timestamptz NOT NULL DEFAULT now(),
+    dispatched_at      timestamptz NULL,
+    completed_at       timestamptz NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_service_jobs_service_id
+    ON external_service_jobs(service_id);
+
+CREATE INDEX IF NOT EXISTS idx_external_service_jobs_status
+    ON external_service_jobs(status);
+
+CREATE INDEX IF NOT EXISTS idx_external_service_jobs_created_at
+    ON external_service_jobs(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_external_service_jobs_session_id
+    ON external_service_jobs(session_id)
+    WHERE session_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_external_service_jobs_phase_id
+    ON external_service_jobs(phase_id)
+    WHERE phase_id IS NOT NULL;
+
+-- Partial index for active (non-terminal) jobs: supports background polling
+-- or expiry sweeps without scanning completed/failed/skipped rows.
+CREATE INDEX IF NOT EXISTS idx_external_service_jobs_active
+    ON external_service_jobs(service_id, created_at)
+    WHERE status IN ('pending', 'dispatched', 'callback-received');
+
+
+CREATE TABLE IF NOT EXISTS external_service_results (
+    id                 uuid        NOT NULL DEFAULT gen_random_uuid(),
+    job_id             uuid        NULL
+                           CONSTRAINT external_service_results_job_id_fkey
+                           REFERENCES external_service_jobs(id),
+    correlation_id     text        NULL,
+    service_id         text        NOT NULL,
+    hook_name          text        NOT NULL DEFAULT 'callback-received',
+    status             text        NOT NULL DEFAULT 'callback-received'
+                           CONSTRAINT external_service_results_status_check
+                           CHECK (status IN (
+                               'callback-received',
+                               'completed',
+                               'failed',
+                               'unknown-correlation'
+                           )),
+    session_id         integer     NULL,
+    phase_id           integer     NULL,
+    question_id        integer     NULL,
+    group_id           integer     NULL,
+    user_id            integer     NULL,
+    raw_payload        jsonb       NOT NULL DEFAULT '{}'::jsonb,
+    sanitized_payload  jsonb       NULL,
+    adapter_result     jsonb       NULL,
+    received_at        timestamptz NOT NULL DEFAULT now(),
+    processed_at       timestamptz NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_service_results_job_id
+    ON external_service_results(job_id)
+    WHERE job_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_external_service_results_correlation_id
+    ON external_service_results(correlation_id)
+    WHERE correlation_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_external_service_results_service_id
+    ON external_service_results(service_id);
+
+CREATE INDEX IF NOT EXISTS idx_external_service_results_status
+    ON external_service_results(status);
+
+CREATE INDEX IF NOT EXISTS idx_external_service_results_received_at
+    ON external_service_results(received_at);
+
+CREATE INDEX IF NOT EXISTS idx_external_service_results_session_id
+    ON external_service_results(session_id)
+    WHERE session_id IS NOT NULL;


### PR DESCRIPTION
## Context

Part of #572. Adds the durable PostgreSQL foundation for external-service job and callback result tracking. Later sub-issues (registry changes, persistence service, inspection endpoints) build on this schema without needing to modify it.

Closes #574.

## What Changed

A single Flyway migration — `database/migrations/V15__external_service_jobs.sql` — creates two tables.

### `external_service_jobs`

One row per outbound hook dispatch. The job `id` (UUID) is the single stable correlation identifier that EthicApp will include in provider requests. There is no separate `correlationId` column; `job.id` IS the correlation id. This avoids a two-key model where both ids would need to be kept in sync while carrying the same semantic meaning.

| Column | Type | Notes |
|---|---|---|
| `id` | `uuid` PK | `gen_random_uuid()`, serves as the provider-facing correlation id |
| `service_id` | `text NOT NULL` | matches manifest service id |
| `hook_name` | `text NOT NULL` | e.g. `student-response-submitted` |
| `status` | `text NOT NULL` | see status vocabulary below |
| `session_id / phase_id / question_id / group_id / user_id` | `integer NULL` | EthicApp dispatch context |
| `outbound_payload` | `jsonb NULL` | minimal outbound metadata or full payload |
| `provider_reference` | `text NULL` | opaque provider-side job id, if returned |
| `created_at / updated_at / dispatched_at / completed_at` | `timestamptz` | lifecycle timestamps |

### `external_service_results`

One row per inbound callback at `POST /external-services/callbacks`. Stores the raw provider-supplied `correlation_id` and resolves `job_id` via FK when the id is recognized. Both are nullable so uncorrelated or late callbacks remain auditable without a matching job.

| Column | Type | Notes |
|---|---|---|
| `id` | `uuid` PK | `gen_random_uuid()` |
| `job_id` | `uuid NULL` → FK `external_service_jobs.id` | resolved from `correlation_id`; null for unknown-correlation results |
| `correlation_id` | `text NULL` | raw value sent by the provider |
| `service_id / hook_name` | `text NOT NULL` | from callback body |
| `status` | `text NOT NULL` | see status vocabulary below |
| `session_id / phase_id / question_id / group_id / user_id` | `integer NULL` | EthicApp context at receive time |
| `raw_payload` | `jsonb NOT NULL` | verbatim provider callback body |
| `sanitized_payload` | `jsonb NULL` | adapter-normalized payload |
| `adapter_result` | `jsonb NULL` | adapter processing outcome |
| `received_at / processed_at` | `timestamptz` | callback lifecycle timestamps |

### Status vocabulary

**Jobs**: `pending` → `dispatched` → `callback-received` → `completed` / `failed` / `skipped` / `expired`

**Results**: `callback-received` → `completed` / `failed` / `unknown-correlation`

Both sets are enforced with `CHECK` constraints.

### Indexes

| Index | Purpose |
|---|---|
| `idx_external_service_jobs_service_id` | filter by service |
| `idx_external_service_jobs_status` | filter by status |
| `idx_external_service_jobs_created_at` | time range queries |
| `idx_external_service_jobs_session_id` (partial, NOT NULL) | filter by session |
| `idx_external_service_jobs_phase_id` (partial, NOT NULL) | filter by phase |
| `idx_external_service_jobs_active` (partial, non-terminal statuses) | expiry sweep / polling without scanning terminal rows |
| `idx_external_service_results_job_id` (partial, NOT NULL) | FK join |
| `idx_external_service_results_correlation_id` (partial, NOT NULL) | inbound callback matching |
| `idx_external_service_results_service_id` | filter by service |
| `idx_external_service_results_status` | filter by status |
| `idx_external_service_results_received_at` | time range queries |
| `idx_external_service_results_session_id` (partial, NOT NULL) | filter by session |

## Validation

Migration applied and validated against PostgreSQL 16 via Flyway:

```
Migrating schema "public" to version "15 - external service jobs"
Successfully applied 15 migrations to schema "public", now at version v15
Successfully validated 15 migrations
```

Schema introspection confirmed all columns, CHECK constraints, FK, and indexes are present.

## Out of Scope for This PR

- Registry changes to generate job records on dispatch
- Persistence service (insert/update jobs and results)
- Inspection endpoints backed by PostgreSQL
- Adapter changes to carry `correlationId` in outbound calls
- `EXTERNAL.md` limitation updates (deferred to the PR that wires up the persistence layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)