### PR TITLE
External services: add persistence service for job/result lifecycle

### DIFF
--- a/ethicapp/backend/services/__tests__/external-service-jobs.service.node-test.mjs
+++ b/ethicapp/backend/services/__tests__/external-service-jobs.service.node-test.mjs
@@ -119,14 +119,22 @@ test("recordProviderReference: sets provider_reference on job", async () => {
 // ─── createResult ─────────────────────────────────────────────────────────────
 
 test("createResult: matching correlationId — resolves job, updates job status", async () => {
+    const jobRow    = {
+        id:          JOB_UUID,
+        session_id:  null,
+        phase_id:    null,
+        question_id: null,
+        group_id:    null,
+        user_id:     null,
+    };
     const resultRow = {
         id:             RESULT_UUID,
         job_id:         JOB_UUID,
         correlation_id: JOB_UUID,
         status:         RESULT_STATUS.CALLBACK_RECEIVED,
     };
-    // call 1: job lookup; call 2: insert result; call 3: update job status
-    const db  = makeDbQueue([{ id: JOB_UUID }], [resultRow], []);
+    // call 0: job lookup; call 1: insert result; call 2: update job status
+    const db  = makeDbQueue([jobRow], [resultRow], []);
     const svc = new ExternalServiceJobsService({ dbQuery: db });
 
     const result = await svc.createResult({
@@ -139,9 +147,10 @@ test("createResult: matching correlationId — resolves job, updates job status"
     assert.equal(result.job_id, JOB_UUID);
     assert.equal(db.calls.length, 3);
 
-    // call 0: SELECT job
-    assert.ok(db.calls[0].sql.includes("SELECT id FROM external_service_jobs"));
+    // call 0: SELECT includes service_id guard
+    assert.ok(db.calls[0].sql.includes("service_id = $2"));
     assert.equal(db.calls[0].params[0], JOB_UUID);
+    assert.equal(db.calls[0].params[1], "polyadic-devils-advocate");
 
     // call 1: INSERT result with callback-received status
     assert.ok(db.calls[1].sql.includes("INSERT INTO external_service_results"));
@@ -152,6 +161,85 @@ test("createResult: matching correlationId — resolves job, updates job status"
     assert.equal(db.calls[2].params[1], JOB_STATUS.CALLBACK_RECEIVED);
 });
 
+test("createResult: propagates job context to result when caller omits it", async () => {
+    const jobRow    = {
+        id:          JOB_UUID,
+        session_id:  10,
+        phase_id:    20,
+        question_id: 30,
+        group_id:    40,
+        user_id:     99,
+    };
+    const resultRow = {
+        id:     RESULT_UUID,
+        job_id: JOB_UUID,
+        status: RESULT_STATUS.CALLBACK_RECEIVED,
+    };
+    const db  = makeDbQueue([jobRow], [resultRow], []);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.createResult({
+        correlationId: JOB_UUID,
+        serviceId:     "polyadic-devils-advocate",
+        rawPayload:    {},
+    });
+
+    // INSERT params: $6=sessionId, $7=phaseId, $8=questionId, $9=groupId, $10=userId
+    const insertParams = db.calls[1].params;
+    assert.equal(insertParams[5],  10);
+    assert.equal(insertParams[6],  20);
+    assert.equal(insertParams[7],  30);
+    assert.equal(insertParams[8],  40);
+    assert.equal(insertParams[9],  99);
+});
+
+test("createResult: caller-provided context takes precedence over job context", async () => {
+    const jobRow    = {
+        id:          JOB_UUID,
+        session_id:  10,
+        phase_id:    20,
+        question_id: null,
+        group_id:    null,
+        user_id:     null,
+    };
+    const resultRow = {
+        id:     RESULT_UUID,
+        job_id: JOB_UUID,
+        status: RESULT_STATUS.CALLBACK_RECEIVED,
+    };
+    const db  = makeDbQueue([jobRow], [resultRow], []);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.createResult({
+        correlationId: JOB_UUID,
+        serviceId:     "polyadic-devils-advocate",
+        rawPayload:    {},
+        sessionId:     99,
+    });
+
+    // Caller passed sessionId=99; job has session_id=10. Caller wins.
+    assert.equal(db.calls[1].params[5], 99);
+    // phaseId not passed by caller; falls back to job's phase_id=20.
+    assert.equal(db.calls[1].params[6], 20);
+});
+
+test("createResult: cross-service correlationId — unknown-correlation, no job update", async () => {
+    // Job lookup returns empty when service_id doesn't match, even if UUID exists elsewhere.
+    const resultRow = { id: RESULT_UUID, job_id: null, status: RESULT_STATUS.UNKNOWN_CORRELATION };
+    const db  = makeDbQueue([], [resultRow]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const result = await svc.createResult({
+        correlationId: JOB_UUID,
+        serviceId:     "argumentation-tutor-system",
+        rawPayload:    {},
+    });
+
+    assert.equal(result.status, RESULT_STATUS.UNKNOWN_CORRELATION);
+    assert.equal(db.calls.length, 2);
+    assert.equal(db.calls[0].params[1], "argumentation-tutor-system");
+});
+
 test("createResult: unknown correlationId — unknown-correlation, no job update", async () => {
     const resultRow = {
         id:             RESULT_UUID,
@@ -159,7 +247,7 @@ test("createResult: unknown correlationId — unknown-correlation, no job update
         correlation_id: "unknown-id",
         status:         RESULT_STATUS.UNKNOWN_CORRELATION,
     };
-    // call 1: job lookup returns nothing; call 2: insert result
+    // call 0: job lookup returns nothing; call 1: insert result
     const db  = makeDbQueue([], [resultRow]);
     const svc = new ExternalServiceJobsService({ dbQuery: db });
 

--- a/ethicapp/backend/services/__tests__/external-service-jobs.service.node-test.mjs
+++ b/ethicapp/backend/services/__tests__/external-service-jobs.service.node-test.mjs
@@ -1,0 +1,294 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    ExternalServiceJobsService,
+    JOB_STATUS,
+    RESULT_STATUS,
+} from "../external-service-jobs.service.js";
+
+const JOB_UUID    = "a1b2c3d4-0000-4000-8000-000000000001";
+const RESULT_UUID = "a1b2c3d4-0000-4000-8000-000000000002";
+
+// Returns a fake dbQuery that serves responses in call order and records calls.
+function makeDbQueue(...responses) {
+    const calls = [];
+    let   index = 0;
+    async function db(sql, params) {
+        calls.push({ sql, params });
+        const r = responses[index++];
+        return Array.isArray(r) ? r : [];
+    }
+    db.calls = calls;
+    return db;
+}
+
+// ─── createJob ───────────────────────────────────────────────────────────────
+
+test("createJob: inserts with pending status and returns first row", async () => {
+    const expected = {
+        id:         JOB_UUID,
+        service_id: "polyadic-devils-advocate",
+        hook_name:  "chat-message-received",
+        status:     JOB_STATUS.PENDING,
+    };
+    const db  = makeDbQueue([expected]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const result = await svc.createJob({
+        serviceId: "polyadic-devils-advocate",
+        hookName:  "chat-message-received",
+        sessionId: 10,
+        phaseId:   20,
+    });
+
+    assert.equal(result.id, JOB_UUID);
+    assert.equal(result.status, JOB_STATUS.PENDING);
+
+    const { sql, params } = db.calls[0];
+    assert.ok(sql.includes("INSERT INTO external_service_jobs"));
+    assert.equal(params[0], "polyadic-devils-advocate");
+    assert.equal(params[1], "chat-message-received");
+    assert.equal(params[2], JOB_STATUS.PENDING);
+    assert.equal(params[3], 10);
+    assert.equal(params[4], 20);
+});
+
+test("createJob: returns null when db returns empty rows", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const result = await svc.createJob({ serviceId: "svc", hookName: "hook" });
+    assert.equal(result, null);
+});
+
+// ─── updateJobStatus ──────────────────────────────────────────────────────────
+
+test("updateJobStatus: dispatched — includes dispatched_at param", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const ts = new Date().toISOString();
+    await svc.updateJobStatus(JOB_UUID, JOB_STATUS.DISPATCHED, { dispatchedAt: ts });
+
+    const { sql, params } = db.calls[0];
+    assert.ok(sql.includes("UPDATE external_service_jobs"));
+    assert.ok(sql.includes("dispatched_at"));
+    assert.equal(params[0], JOB_UUID);
+    assert.equal(params[1], JOB_STATUS.DISPATCHED);
+    assert.equal(params[2], ts);
+});
+
+test("updateJobStatus: completed — includes completed_at param", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const ts = new Date().toISOString();
+    await svc.updateJobStatus(JOB_UUID, JOB_STATUS.COMPLETED, { completedAt: ts });
+
+    const { sql, params } = db.calls[0];
+    assert.ok(sql.includes("completed_at"));
+    assert.equal(params[2], ts);
+});
+
+test("updateJobStatus: no optional timestamps — sql omits timestamp columns", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.updateJobStatus(JOB_UUID, JOB_STATUS.FAILED);
+
+    const { sql, params } = db.calls[0];
+    assert.ok(!sql.includes("dispatched_at"));
+    assert.ok(!sql.includes("completed_at"));
+    assert.equal(params.length, 2);
+});
+
+// ─── recordProviderReference ─────────────────────────────────────────────────
+
+test("recordProviderReference: sets provider_reference on job", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.recordProviderReference(JOB_UUID, "provider-job-42");
+
+    const { sql, params } = db.calls[0];
+    assert.ok(sql.includes("provider_reference"));
+    assert.equal(params[0], JOB_UUID);
+    assert.equal(params[1], "provider-job-42");
+});
+
+// ─── createResult ─────────────────────────────────────────────────────────────
+
+test("createResult: matching correlationId — resolves job, updates job status", async () => {
+    const resultRow = {
+        id:             RESULT_UUID,
+        job_id:         JOB_UUID,
+        correlation_id: JOB_UUID,
+        status:         RESULT_STATUS.CALLBACK_RECEIVED,
+    };
+    // call 1: job lookup; call 2: insert result; call 3: update job status
+    const db  = makeDbQueue([{ id: JOB_UUID }], [resultRow], []);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const result = await svc.createResult({
+        correlationId: JOB_UUID,
+        serviceId:     "polyadic-devils-advocate",
+        rawPayload:    { room: "r1", evaluations: [] },
+    });
+
+    assert.equal(result.status, RESULT_STATUS.CALLBACK_RECEIVED);
+    assert.equal(result.job_id, JOB_UUID);
+    assert.equal(db.calls.length, 3);
+
+    // call 0: SELECT job
+    assert.ok(db.calls[0].sql.includes("SELECT id FROM external_service_jobs"));
+    assert.equal(db.calls[0].params[0], JOB_UUID);
+
+    // call 1: INSERT result with callback-received status
+    assert.ok(db.calls[1].sql.includes("INSERT INTO external_service_results"));
+    assert.equal(db.calls[1].params[4], RESULT_STATUS.CALLBACK_RECEIVED);
+
+    // call 2: UPDATE job to callback-received
+    assert.ok(db.calls[2].sql.includes("UPDATE external_service_jobs"));
+    assert.equal(db.calls[2].params[1], JOB_STATUS.CALLBACK_RECEIVED);
+});
+
+test("createResult: unknown correlationId — unknown-correlation, no job update", async () => {
+    const resultRow = {
+        id:             RESULT_UUID,
+        job_id:         null,
+        correlation_id: "unknown-id",
+        status:         RESULT_STATUS.UNKNOWN_CORRELATION,
+    };
+    // call 1: job lookup returns nothing; call 2: insert result
+    const db  = makeDbQueue([], [resultRow]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const result = await svc.createResult({
+        correlationId: "unknown-id",
+        serviceId:     "polyadic-devils-advocate",
+        rawPayload:    { data: 1 },
+    });
+
+    assert.equal(result.status, RESULT_STATUS.UNKNOWN_CORRELATION);
+    assert.equal(result.job_id, null);
+    assert.equal(db.calls.length, 2);
+    assert.equal(db.calls[1].params[4], RESULT_STATUS.UNKNOWN_CORRELATION);
+});
+
+test("createResult: null correlationId — skips job lookup, unknown-correlation", async () => {
+    const resultRow = {
+        id:     RESULT_UUID,
+        job_id: null,
+        status: RESULT_STATUS.UNKNOWN_CORRELATION,
+    };
+    const db  = makeDbQueue([resultRow]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.createResult({
+        correlationId: null,
+        serviceId:     "argumentation-tutor-system",
+        rawPayload:    {},
+    });
+
+    // Only the INSERT call; no SELECT because correlationId is null
+    assert.equal(db.calls.length, 1);
+    assert.ok(db.calls[0].sql.includes("INSERT INTO external_service_results"));
+});
+
+// ─── updateResult ─────────────────────────────────────────────────────────────
+
+test("updateResult: sets status, sanitizedPayload, and adapterResult", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const sanitized = { summary: "Good argument." };
+    const outcome   = { published: true };
+    await svc.updateResult(RESULT_UUID, {
+        status:           RESULT_STATUS.COMPLETED,
+        sanitizedPayload: sanitized,
+        adapterResult:    outcome,
+    });
+
+    const { sql, params } = db.calls[0];
+    assert.ok(sql.includes("UPDATE external_service_results"));
+    assert.ok(sql.includes("sanitized_payload"));
+    assert.ok(sql.includes("adapter_result"));
+    assert.equal(params[0], RESULT_UUID);
+    assert.equal(params[1], RESULT_STATUS.COMPLETED);
+    assert.deepEqual(params[2], sanitized);
+    assert.deepEqual(params[3], outcome);
+});
+
+test("updateResult: omits sanitizedPayload and adapterResult when not provided", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.updateResult(RESULT_UUID, { status: RESULT_STATUS.FAILED });
+
+    const { sql, params } = db.calls[0];
+    assert.ok(!sql.includes("sanitized_payload"));
+    assert.ok(!sql.includes("adapter_result"));
+    assert.equal(params.length, 2);
+});
+
+// ─── queryRecentJobs ──────────────────────────────────────────────────────────
+
+test("queryRecentJobs: no filters — no WHERE clause, limit 50", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.queryRecentJobs();
+
+    const { sql, params } = db.calls[0];
+    assert.ok(!sql.includes("WHERE"));
+    assert.equal(params[0], 50);
+});
+
+test("queryRecentJobs: serviceId and status filters — WHERE clause present", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.queryRecentJobs({ serviceId: "polyadic-devils-advocate", status: "pending" });
+
+    const { sql, params } = db.calls[0];
+    assert.ok(sql.includes("WHERE"));
+    assert.ok(sql.includes("service_id"));
+    assert.ok(sql.includes("status"));
+    assert.equal(params[0], "polyadic-devils-advocate");
+    assert.equal(params[1], "pending");
+});
+
+test("queryRecentJobs: caps limit at 200", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.queryRecentJobs({ limit: 9999 });
+
+    const { params } = db.calls[0];
+    assert.equal(params[params.length - 1], 200);
+});
+
+// ─── queryRecentResults ───────────────────────────────────────────────────────
+
+test("queryRecentResults: sessionId filter — WHERE clause present", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.queryRecentResults({ sessionId: 42 });
+
+    const { sql, params } = db.calls[0];
+    assert.ok(sql.includes("WHERE"));
+    assert.ok(sql.includes("session_id"));
+    assert.equal(params[0], 42);
+});
+
+test("queryRecentResults: no filters — no WHERE clause, default limit 50", async () => {
+    const db  = makeDbQueue([]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    await svc.queryRecentResults();
+
+    const { sql, params } = db.calls[0];
+    assert.ok(!sql.includes("WHERE"));
+    assert.equal(params[0], 50);
+});

--- a/ethicapp/backend/services/external-service-jobs.service.js
+++ b/ethicapp/backend/services/external-service-jobs.service.js
@@ -113,12 +113,21 @@ export class ExternalServiceJobsService {
 
         if (correlationId) {
             const matchRows = await this._db(
-                "SELECT id FROM external_service_jobs WHERE id::text = $1",
-                [correlationId]
+                `SELECT id, session_id, phase_id, question_id, group_id, user_id
+                 FROM external_service_jobs
+                 WHERE id::text = $1 AND service_id = $2`,
+                [correlationId, serviceId]
             );
             if (matchRows.length > 0) {
-                jobId        = matchRows[0].id;
+                const job    = matchRows[0];
+                jobId        = job.id;
                 resultStatus = RESULT_STATUS.CALLBACK_RECEIVED;
+                // Propagate job context to result when caller did not provide it.
+                sessionId    = sessionId  ?? job.session_id;
+                phaseId      = phaseId    ?? job.phase_id;
+                questionId   = questionId ?? job.question_id;
+                groupId      = groupId    ?? job.group_id;
+                userId       = userId     ?? job.user_id;
             }
         }
 

--- a/ethicapp/backend/services/external-service-jobs.service.js
+++ b/ethicapp/backend/services/external-service-jobs.service.js
@@ -1,0 +1,260 @@
+import pkg from "pg";
+import { dbconnString } from "../config/database.config.js";
+
+const { Pool } = pkg;
+
+export const JOB_STATUS = Object.freeze({
+    PENDING:           "pending",
+    DISPATCHED:        "dispatched",
+    CALLBACK_RECEIVED: "callback-received",
+    COMPLETED:         "completed",
+    FAILED:            "failed",
+    SKIPPED:           "skipped",
+    EXPIRED:           "expired",
+});
+
+export const RESULT_STATUS = Object.freeze({
+    CALLBACK_RECEIVED:   "callback-received",
+    COMPLETED:           "completed",
+    FAILED:              "failed",
+    UNKNOWN_CORRELATION: "unknown-correlation",
+});
+
+let _pool = null;
+
+function getPool() {
+    if (!_pool) {
+        _pool = new Pool({ connectionString: dbconnString });
+    }
+    return _pool;
+}
+
+async function poolQuery(sql, params = []) {
+    const result = await getPool().query(sql, params);
+    return result.rows;
+}
+
+export class ExternalServiceJobsService {
+    constructor({ dbQuery } = {}) {
+        this._db = dbQuery || poolQuery;
+    }
+
+    async createJob({
+        serviceId,
+        hookName,
+        sessionId       = null,
+        phaseId         = null,
+        questionId      = null,
+        groupId         = null,
+        userId          = null,
+        outboundPayload = null,
+    }) {
+        const rows = await this._db(
+            `INSERT INTO external_service_jobs
+                 (service_id, hook_name, status,
+                  session_id, phase_id, question_id, group_id, user_id,
+                  outbound_payload)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+             RETURNING id, service_id, hook_name, status,
+                       session_id, phase_id, question_id, group_id, user_id,
+                       created_at`,
+            [
+                serviceId, hookName, JOB_STATUS.PENDING,
+                sessionId, phaseId, questionId, groupId, userId,
+                outboundPayload,
+            ]
+        );
+        return rows[0] || null;
+    }
+
+    async updateJobStatus(jobId, status, { dispatchedAt, completedAt } = {}) {
+        const clauses = ["status = $2", "updated_at = now()"];
+        const params  = [jobId, status];
+
+        if (dispatchedAt !== undefined) {
+            params.push(dispatchedAt);
+            clauses.push(`dispatched_at = $${params.length}`);
+        }
+        if (completedAt !== undefined) {
+            params.push(completedAt);
+            clauses.push(`completed_at = $${params.length}`);
+        }
+
+        await this._db(
+            `UPDATE external_service_jobs
+             SET ${clauses.join(", ")}
+             WHERE id = $1`,
+            params
+        );
+    }
+
+    async recordProviderReference(jobId, providerReference) {
+        await this._db(
+            `UPDATE external_service_jobs
+             SET provider_reference = $2, updated_at = now()
+             WHERE id = $1`,
+            [jobId, providerReference]
+        );
+    }
+
+    async createResult({
+        correlationId = null,
+        serviceId,
+        hookName      = "callback-received",
+        rawPayload,
+        sessionId     = null,
+        phaseId       = null,
+        questionId    = null,
+        groupId       = null,
+        userId        = null,
+    }) {
+        let jobId        = null;
+        let resultStatus = RESULT_STATUS.UNKNOWN_CORRELATION;
+
+        if (correlationId) {
+            const matchRows = await this._db(
+                "SELECT id FROM external_service_jobs WHERE id::text = $1",
+                [correlationId]
+            );
+            if (matchRows.length > 0) {
+                jobId        = matchRows[0].id;
+                resultStatus = RESULT_STATUS.CALLBACK_RECEIVED;
+            }
+        }
+
+        const rows = await this._db(
+            `INSERT INTO external_service_results
+                 (job_id, correlation_id, service_id, hook_name, status,
+                  session_id, phase_id, question_id, group_id, user_id,
+                  raw_payload)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+             RETURNING id, job_id, correlation_id, service_id, hook_name,
+                       status, received_at`,
+            [
+                jobId, correlationId, serviceId, hookName, resultStatus,
+                sessionId, phaseId, questionId, groupId, userId,
+                rawPayload ?? {},
+            ]
+        );
+
+        const result = rows[0] || null;
+
+        if (result && jobId) {
+            await this._db(
+                `UPDATE external_service_jobs
+                 SET status = $2, updated_at = now()
+                 WHERE id = $1`,
+                [jobId, JOB_STATUS.CALLBACK_RECEIVED]
+            );
+        }
+
+        return result;
+    }
+
+    async updateResult(resultId, {
+        status,
+        sanitizedPayload = undefined,
+        adapterResult    = undefined,
+    }) {
+        const clauses = ["status = $2", "processed_at = now()"];
+        const params  = [resultId, status];
+
+        if (sanitizedPayload !== undefined) {
+            params.push(sanitizedPayload);
+            clauses.push(`sanitized_payload = $${params.length}`);
+        }
+        if (adapterResult !== undefined) {
+            params.push(adapterResult);
+            clauses.push(`adapter_result = $${params.length}`);
+        }
+
+        await this._db(
+            `UPDATE external_service_results
+             SET ${clauses.join(", ")}
+             WHERE id = $1`,
+            params
+        );
+    }
+
+    async queryRecentJobs({
+        serviceId = null,
+        sessionId = null,
+        phaseId   = null,
+        status    = null,
+        limit     = 50,
+    } = {}) {
+        const conditions = [];
+        const params     = [];
+
+        if (serviceId != null) {
+            params.push(serviceId);
+            conditions.push(`service_id = $${params.length}`);
+        }
+        if (sessionId != null) {
+            params.push(sessionId);
+            conditions.push(`session_id = $${params.length}`);
+        }
+        if (phaseId != null) {
+            params.push(phaseId);
+            conditions.push(`phase_id = $${params.length}`);
+        }
+        if (status != null) {
+            params.push(status);
+            conditions.push(`status = $${params.length}`);
+        }
+
+        const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+        params.push(Math.min(Number(limit) || 50, 200));
+
+        return this._db(
+            `SELECT id, service_id, hook_name, status,
+                    session_id, phase_id, question_id, group_id, user_id,
+                    provider_reference, created_at, updated_at,
+                    dispatched_at, completed_at
+             FROM external_service_jobs
+             ${where}
+             ORDER BY created_at DESC
+             LIMIT $${params.length}`,
+            params
+        );
+    }
+
+    async queryRecentResults({
+        serviceId = null,
+        sessionId = null,
+        status    = null,
+        limit     = 50,
+    } = {}) {
+        const conditions = [];
+        const params     = [];
+
+        if (serviceId != null) {
+            params.push(serviceId);
+            conditions.push(`service_id = $${params.length}`);
+        }
+        if (sessionId != null) {
+            params.push(sessionId);
+            conditions.push(`session_id = $${params.length}`);
+        }
+        if (status != null) {
+            params.push(status);
+            conditions.push(`status = $${params.length}`);
+        }
+
+        const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+        params.push(Math.min(Number(limit) || 50, 200));
+
+        return this._db(
+            `SELECT id, job_id, correlation_id, service_id, hook_name, status,
+                    session_id, phase_id, question_id, group_id, user_id,
+                    received_at, processed_at
+             FROM external_service_results
+             ${where}
+             ORDER BY received_at DESC
+             LIMIT $${params.length}`,
+            params
+        );
+    }
+}
+
+export const externalServiceJobsService = new ExternalServiceJobsService();


### PR DESCRIPTION
## Context

Part of #572. Adds the service layer that owns all durable writes and queries against the `external_service_jobs` and `external_service_results` tables introduced in #574. Registry dispatch, inbound callbacks, and inspection endpoints will call this service instead of writing SQL directly.

Closes #575.

## What Changed

### New service — `ethicapp/backend/services/external-service-jobs.service.js`

`ExternalServiceJobsService` accepts an optional `dbQuery` constructor parameter for dependency injection (same pattern as `AiAdditionsClient`). The singleton export uses the `pg.Pool` backed by `dbconnString` for production.

#### Status vocabulary

Two frozen objects exported for use by callers:

```js
JOB_STATUS    // pending | dispatched | callback-received | completed | failed | skipped | expired
RESULT_STATUS // callback-received | completed | failed | unknown-correlation
```

#### API surface

| Method | Description |
|---|---|
| `createJob({ serviceId, hookName, sessionId?, phaseId?, questionId?, groupId?, userId?, outboundPayload? })` | Inserts a new job row with `status=pending`. Returns the inserted row including `id` (UUID), which is the correlation id to pass to providers. |
| `updateJobStatus(jobId, status, { dispatchedAt?, completedAt? })` | Transitions job status and writes the appropriate timestamp column. Timestamp params are optional and only added to the SET clause when provided. |
| `recordProviderReference(jobId, providerReference)` | Stores an opaque provider-side job id on a job row. |
| `createResult({ correlationId?, serviceId, hookName?, rawPayload, ... })` | Resolves `correlationId` against `external_service_jobs` scoped by `service_id`. Inserts a result row with `callback-received` status if matched, or `unknown-correlation` if not. Also updates the matched job's status to `callback-received`. |
| `updateResult(resultId, { status, sanitizedPayload?, adapterResult? })` | Writes adapter outcome fields and sets `processed_at`. Only includes provided optional columns in the SET clause. |
| `queryRecentJobs({ serviceId?, sessionId?, phaseId?, status?, limit? })` | Dynamic WHERE with optional filters; hard limit cap of 200. |
| `queryRecentResults({ serviceId?, sessionId?, status?, limit? })` | Dynamic WHERE with optional filters; hard limit cap of 200. |

#### `correlationId` resolution in `createResult`

Uses `WHERE id::text = $1 AND service_id = $2` to match the provider-supplied `correlationId` string against the UUID PK while enforcing adapter isolation: a callback from `argumentation-tutor-system` cannot resolve or update a job that belongs to `polyadic-devils-advocate`, even if it sends a valid UUID. Unrecognized or absent `correlationId` values produce a result row with `job_id = null` and `status = unknown-correlation`, preserving auditability.

When a job is resolved, its `session_id`, `phase_id`, `question_id`, `group_id`, and `user_id` are propagated to the result row as fallback values (via `??`). The inbound unified callback typically carries only `serviceId`, `correlationId`, and `payload`, so without this propagation a correlated result would have all context columns `NULL` and `queryRecentResults({ sessionId })` would not find it. Caller-supplied context takes precedence over the job's values.

### New tests — `services/__tests__/external-service-jobs.service.node-test.mjs`

19 focused unit tests using a `makeDbQueue` helper that serves deterministic per-call responses and captures `{ sql, params }` for structural assertions. No real PostgreSQL required.

Covered cases:

- `createJob`: correct INSERT, pending status, null return on empty rows
- `updateJobStatus`: dispatched sets `dispatched_at`; completed sets `completed_at`; no optional timestamps → no extra SET clauses
- `recordProviderReference`: correct UPDATE with `provider_reference`
- `createResult`: matching `correlationId` → 3 DB calls (SELECT + INSERT + UPDATE job), `service_id` guard in SELECT params; job context propagated to result when caller omits it; caller-supplied context takes precedence over job context; cross-service `correlationId` → `unknown-correlation`; unknown `correlationId` → 2 calls, `unknown-correlation`; null `correlationId` → 1 call (no SELECT), `unknown-correlation`
- `updateResult`: all optional fields included / all omitted
- `queryRecentJobs`: no WHERE on empty filters; correct WHERE + params on filters; limit capped at 200
- `queryRecentResults`: session filter; no WHERE on empty filters

## Out of Scope

- Registry integration (wire `createJob` / `createResult` into dispatch and callback flows) — next sub-issue
- Inspection endpoint changes — later sub-issue
- `EXTERNAL.md` limitation updates — deferred to registry integration PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)