### PR TITLE
Add correlation metadata and DB persistence to registry dispatch (#576)

### DIFF
--- a/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
+++ b/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ExternalServicesRegistry } from "../external-services.service.js";
+import { JOB_STATUS, RESULT_STATUS } from "../external-service-jobs.service.js";
+
+const JOB_UUID    = "b1c2d3e4-0000-4000-8000-000000000011";
+const RESULT_UUID = "b1c2d3e4-0000-4000-8000-000000000012";
+
+function makeJobsServiceStub(overrides = {}) {
+    return {
+        createJob:               async () => ({ id: JOB_UUID }),
+        updateJobStatus:         async () => {},
+        createResult:            async () => ({ id: RESULT_UUID, job_id: JOB_UUID }),
+        updateResult:            async () => {},
+        recordProviderReference: async () => {},
+        ...overrides,
+    };
+}
+
+function makeRegistry(jobsServiceOverrides = {}) {
+    const jobsService = makeJobsServiceStub(jobsServiceOverrides);
+    const registry = new ExternalServicesRegistry({ jobsService });
+    registry.initialized = true;
+    registry.services.set("svc-a", { id: "svc-a", enabled: true });
+    return { registry, jobsService };
+}
+
+// ─── _dispatchOneHandler ──────────────────────────────────────────────────────
+
+test("dispatchHook: enriches context with jobId and correlationId", async () => {
+    let capturedContext = null;
+    const { registry } = makeRegistry();
+
+    registry.hookSubscribers.set("phase-started", [
+        {
+            serviceId: "svc-a",
+            handler:   async (ctx) => { capturedContext = ctx; },
+        },
+    ]);
+
+    await registry.dispatchHook("phase-started", { sessionId: 5, phaseId: 10 }, {
+        enabledServiceIds: ["svc-a"],
+    });
+
+    assert.ok(capturedContext, "handler should have been called");
+    assert.equal(capturedContext.jobId, JOB_UUID);
+    assert.equal(capturedContext.correlationId, JOB_UUID);
+    assert.equal(capturedContext.serviceId, "svc-a");
+});
+
+test("dispatchHook: creates job with context fields", async () => {
+    const calls = [];
+    const { registry } = makeRegistry({
+        createJob: async (args) => {
+            calls.push(args);
+            return { id: JOB_UUID };
+        },
+    });
+
+    registry.hookSubscribers.set("phase-started", [
+        { serviceId: "svc-a", handler: async () => {} },
+    ]);
+
+    await registry.dispatchHook(
+        "phase-started",
+        { sessionId: 1, phaseId: 2, questionId: 3, groupId: 4, userId: 5 },
+        { enabledServiceIds: ["svc-a"] }
+    );
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].serviceId, "svc-a");
+    assert.equal(calls[0].hookName, "phase-started");
+    assert.equal(calls[0].sessionId, 1);
+    assert.equal(calls[0].phaseId, 2);
+});
+
+test("dispatchHook: marks job dispatched before calling handler", async () => {
+    const statusCalls = [];
+    let handlerCalledAfterDispatch = false;
+    const { registry } = makeRegistry({
+        updateJobStatus: async (id, status) => {
+            statusCalls.push({ id, status });
+            if (status === JOB_STATUS.DISPATCHED) {
+                handlerCalledAfterDispatch = false;
+            }
+        },
+    });
+
+    registry.hookSubscribers.set("phase-started", [
+        {
+            serviceId: "svc-a",
+            handler:   async () => { handlerCalledAfterDispatch = true; },
+        },
+    ]);
+
+    await registry.dispatchHook("phase-started", {}, { enabledServiceIds: ["svc-a"] });
+
+    const dispatchedCall = statusCalls.find(c => c.status === JOB_STATUS.DISPATCHED);
+    assert.ok(dispatchedCall, "should mark job as dispatched");
+    assert.equal(dispatchedCall.id, JOB_UUID);
+    assert.ok(handlerCalledAfterDispatch, "handler should have been called");
+});
+
+test("dispatchHook: marks job failed when handler throws", async () => {
+    const statusCalls = [];
+    const { registry } = makeRegistry({
+        updateJobStatus: async (id, status) => { statusCalls.push({ id, status }); },
+    });
+
+    registry.hookSubscribers.set("phase-started", [
+        { serviceId: "svc-a", handler: async () => { throw new Error("adapter error"); } },
+    ]);
+
+    const results = await registry.dispatchHook("phase-started", {}, {
+        enabledServiceIds: ["svc-a"],
+    });
+
+    assert.equal(results[0].status, "rejected");
+    const failedCall = statusCalls.find(c => c.status === JOB_STATUS.FAILED);
+    assert.ok(failedCall, "should mark job as failed");
+});
+
+test("dispatchHook: continues if createJob rejects — jobId null in context", async () => {
+    let capturedContext = null;
+    const { registry } = makeRegistry({
+        createJob: async () => { throw new Error("db down"); },
+    });
+
+    registry.hookSubscribers.set("phase-started", [
+        { serviceId: "svc-a", handler: async (ctx) => { capturedContext = ctx; } },
+    ]);
+
+    await registry.dispatchHook("phase-started", {}, { enabledServiceIds: ["svc-a"] });
+
+    assert.ok(capturedContext, "handler should still be called");
+    assert.equal(capturedContext.jobId, null);
+    assert.equal(capturedContext.correlationId, null);
+});
+
+test("dispatchHook: returns [] when enabledServiceIds is empty", async () => {
+    const { registry } = makeRegistry();
+    const result = await registry.dispatchHook("phase-started", {}, {});
+    assert.deepEqual(result, []);
+});
+
+// ─── dispatchServiceHook ──────────────────────────────────────────────────────
+
+test("dispatchServiceHook: creates result record before calling handler", async () => {
+    const createResultCalls = [];
+    const { registry } = makeRegistry({
+        createResult: async (args) => {
+            createResultCalls.push(args);
+            return { id: RESULT_UUID, job_id: JOB_UUID };
+        },
+    });
+
+    registry.hookSubscribers.set("callback-received", [
+        { serviceId: "svc-a", handler: async () => {} },
+    ]);
+
+    await registry.dispatchServiceHook(
+        "callback-received",
+        "svc-a",
+        { correlationId: JOB_UUID, sessionId: 7, requestPayload: { x: 1 } }
+    );
+
+    assert.equal(createResultCalls.length, 1);
+    assert.equal(createResultCalls[0].serviceId, "svc-a");
+    assert.equal(createResultCalls[0].correlationId, JOB_UUID);
+    assert.deepEqual(createResultCalls[0].rawPayload, { x: 1 });
+    assert.equal(createResultCalls[0].sessionId, 7);
+});
+
+test("dispatchServiceHook: enriches handler context with jobId and resultId", async () => {
+    let capturedContext = null;
+    const { registry } = makeRegistry();
+
+    registry.hookSubscribers.set("callback-received", [
+        { serviceId: "svc-a", handler: async (ctx) => { capturedContext = ctx; } },
+    ]);
+
+    await registry.dispatchServiceHook("callback-received", "svc-a", {});
+
+    assert.ok(capturedContext);
+    assert.equal(capturedContext.jobId, JOB_UUID);
+    assert.equal(capturedContext.resultId, RESULT_UUID);
+});
+
+test("dispatchServiceHook: falls back to rawBody when requestPayload absent", async () => {
+    const createResultCalls = [];
+    const { registry } = makeRegistry({
+        createResult: async (args) => {
+            createResultCalls.push(args);
+            return { id: RESULT_UUID, job_id: null };
+        },
+    });
+
+    registry.hookSubscribers.set("callback-received", [
+        { serviceId: "svc-a", handler: async () => {} },
+    ]);
+
+    await registry.dispatchServiceHook(
+        "callback-received",
+        "svc-a",
+        { rawBody: { raw: true } }
+    );
+
+    assert.deepEqual(createResultCalls[0].rawPayload, { raw: true });
+});
+
+test("dispatchServiceHook: throws 404 for unknown service", async () => {
+    const { registry } = makeRegistry();
+    await assert.rejects(
+        () => registry.dispatchServiceHook("callback-received", "unknown-svc", {}),
+        err => err.statusCode === 404
+    );
+});
+
+// ─── recordCallbackResult ─────────────────────────────────────────────────────
+
+test("recordCallbackResult: calls updateResult when context has resultId", async () => {
+    const updateResultCalls = [];
+    const { registry } = makeRegistry({
+        updateResult: async (id, args) => { updateResultCalls.push({ id, ...args }); },
+    });
+
+    await registry.recordCallbackResult({
+        hookName:  "callback-received",
+        serviceId: "svc-a",
+        result:    { score: 42 },
+        context:   { resultId: RESULT_UUID, serviceId: "svc-a" },
+    });
+
+    assert.equal(updateResultCalls.length, 1);
+    assert.equal(updateResultCalls[0].id, RESULT_UUID);
+    assert.equal(updateResultCalls[0].status, RESULT_STATUS.COMPLETED);
+    assert.deepEqual(updateResultCalls[0].adapterResult, { score: 42 });
+});
+
+test("recordCallbackResult: calls updateJobStatus when context has jobId only", async () => {
+    const statusCalls = [];
+    const { registry } = makeRegistry({
+        updateJobStatus: async (id, status) => { statusCalls.push({ id, status }); },
+    });
+
+    await registry.recordCallbackResult({
+        hookName:  "phase-started",
+        serviceId: "svc-a",
+        result:    { done: true },
+        context:   { jobId: JOB_UUID },
+    });
+
+    assert.equal(statusCalls.length, 1);
+    assert.equal(statusCalls[0].id, JOB_UUID);
+    assert.equal(statusCalls[0].status, JOB_STATUS.COMPLETED);
+});
+
+test("recordCallbackResult: appends entry to in-memory results list", async () => {
+    const { registry } = makeRegistry();
+
+    const entry = await registry.recordCallbackResult({
+        hookName:  "phase-started",
+        serviceId: "svc-a",
+        result:    { value: 1 },
+        context:   { sessionId: 3, phaseId: 4 },
+    });
+
+    assert.ok(entry.id);
+    assert.equal(entry.hookName, "phase-started");
+    assert.equal(entry.serviceId, "svc-a");
+    assert.deepEqual(entry.result, { value: 1 });
+    assert.equal(registry.results.length, 1);
+    assert.equal(registry.results[0], entry);
+});
+
+test("recordCallbackResult: caps in-memory list at 100 entries", async () => {
+    const { registry } = makeRegistry();
+
+    for (let i = 0; i < 101; i++) {
+        await registry.recordCallbackResult({
+            hookName:  "h",
+            serviceId: "svc-a",
+            result:    {},
+            context:   {},
+        });
+    }
+
+    assert.equal(registry.results.length, 100);
+});

--- a/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
+++ b/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
@@ -216,6 +216,24 @@ test("dispatchServiceHook: throws 404 for unknown service", async () => {
     );
 });
 
+test("dispatchServiceHook: marks result FAILED when handler throws", async () => {
+    const updateResultCalls = [];
+    const { registry } = makeRegistry({
+        updateResult: async (id, args) => { updateResultCalls.push({ id, ...args }); },
+    });
+
+    registry.hookSubscribers.set("callback-received", [
+        { serviceId: "svc-a", handler: async () => { throw new Error("handler error"); } },
+    ]);
+
+    const results = await registry.dispatchServiceHook("callback-received", "svc-a", {});
+
+    assert.equal(results[0].status, "rejected");
+    assert.equal(updateResultCalls.length, 1);
+    assert.equal(updateResultCalls[0].id, RESULT_UUID);
+    assert.equal(updateResultCalls[0].status, RESULT_STATUS.FAILED);
+});
+
 // ─── recordCallbackResult ─────────────────────────────────────────────────────
 
 test("recordCallbackResult: calls updateResult when context has resultId", async () => {
@@ -237,6 +255,22 @@ test("recordCallbackResult: calls updateResult when context has resultId", async
     assert.deepEqual(updateResultCalls[0].adapterResult, { score: 42 });
 });
 
+test("recordCallbackResult: maps result.status 'failed' to RESULT_STATUS.FAILED", async () => {
+    const updateResultCalls = [];
+    const { registry } = makeRegistry({
+        updateResult: async (id, args) => { updateResultCalls.push({ id, ...args }); },
+    });
+
+    await registry.recordCallbackResult({
+        hookName:  "callback-received",
+        serviceId: "svc-a",
+        result:    { status: "failed", reason: "room not found" },
+        context:   { resultId: RESULT_UUID },
+    });
+
+    assert.equal(updateResultCalls[0].status, RESULT_STATUS.FAILED);
+});
+
 test("recordCallbackResult: calls updateJobStatus when context has jobId only", async () => {
     const statusCalls = [];
     const { registry } = makeRegistry({
@@ -253,6 +287,38 @@ test("recordCallbackResult: calls updateJobStatus when context has jobId only", 
     assert.equal(statusCalls.length, 1);
     assert.equal(statusCalls[0].id, JOB_UUID);
     assert.equal(statusCalls[0].status, JOB_STATUS.COMPLETED);
+});
+
+test("recordCallbackResult: maps result.status 'failed' to JOB_STATUS.FAILED", async () => {
+    const statusCalls = [];
+    const { registry } = makeRegistry({
+        updateJobStatus: async (id, status) => { statusCalls.push({ id, status }); },
+    });
+
+    await registry.recordCallbackResult({
+        hookName:  "phase-started",
+        serviceId: "svc-a",
+        result:    { status: "failed" },
+        context:   { jobId: JOB_UUID },
+    });
+
+    assert.equal(statusCalls[0].status, JOB_STATUS.FAILED);
+});
+
+test("recordCallbackResult: maps result.status 'skipped' to JOB_STATUS.SKIPPED", async () => {
+    const statusCalls = [];
+    const { registry } = makeRegistry({
+        updateJobStatus: async (id, status) => { statusCalls.push({ id, status }); },
+    });
+
+    await registry.recordCallbackResult({
+        hookName:  "phase-started",
+        serviceId: "svc-a",
+        result:    { status: "skipped" },
+        context:   { jobId: JOB_UUID },
+    });
+
+    assert.equal(statusCalls[0].status, JOB_STATUS.SKIPPED);
 });
 
 test("recordCallbackResult: appends entry to in-memory results list", async () => {

--- a/ethicapp/backend/services/external-services.service.js
+++ b/ethicapp/backend/services/external-services.service.js
@@ -281,7 +281,7 @@ export class ExternalServicesRegistry {
             subscriber => subscriber.serviceId === serviceId
         );
 
-        return Promise.allSettled(selectedSubscribers.map(({ handler }) => {
+        return Promise.allSettled(selectedSubscribers.map(async ({ handler }) => {
             const serviceContext = {
                 ...context,
                 serviceId,
@@ -289,14 +289,23 @@ export class ExternalServicesRegistry {
                 resultId: resultRecord?.id     ?? null,
             };
 
-            return handler(serviceContext, {
-                callback: result => this.recordCallbackResult({
-                    hookName,
-                    serviceId,
-                    result,
-                    context: serviceContext,
-                }),
-            });
+            try {
+                return await handler(serviceContext, {
+                    callback: result => this.recordCallbackResult({
+                        hookName,
+                        serviceId,
+                        result,
+                        context: serviceContext,
+                    }),
+                });
+            } catch (err) {
+                if (serviceContext.resultId) {
+                    await this._jobsService
+                        .updateResult(serviceContext.resultId, { status: RESULT_STATUS.FAILED })
+                        .catch(() => null);
+                }
+                throw err;
+            }
         }));
     }
 
@@ -325,17 +334,22 @@ export class ExternalServicesRegistry {
         }
 
         if (context.resultId) {
+            const resultStatus = result?.status === "failed"
+                ? RESULT_STATUS.FAILED
+                : RESULT_STATUS.COMPLETED;
             await this._jobsService
                 .updateResult(context.resultId, {
-                    status:        RESULT_STATUS.COMPLETED,
+                    status:        resultStatus,
                     adapterResult: result,
                 })
                 .catch(err => console.error("[external-services] Failed to persist callback result.", err));
         } else if (context.jobId) {
+            const jobStatus = result?.status === "failed"  ? JOB_STATUS.FAILED
+                : result?.status === "skipped" ? JOB_STATUS.SKIPPED
+                : JOB_STATUS.COMPLETED;
+            const completedAt = jobStatus === JOB_STATUS.COMPLETED ? new Date().toISOString() : undefined;
             await this._jobsService
-                .updateJobStatus(context.jobId, JOB_STATUS.COMPLETED, {
-                    completedAt: new Date().toISOString(),
-                })
+                .updateJobStatus(context.jobId, jobStatus, { completedAt })
                 .catch(err => console.error("[external-services] Failed to update job status.", err));
         }
 

--- a/ethicapp/backend/services/external-services.service.js
+++ b/ethicapp/backend/services/external-services.service.js
@@ -6,6 +6,11 @@ import * as rpg2 from "../db/rest-pg-2.js";
 import { saveChatMessage } from "../helpers/chat-helper.js";
 import { studentNotifications, teacherNotifications } from "../config/socket.config.js";
 import aiAdditionsClient from "./ai-additions-client.service.js";
+import {
+    externalServiceJobsService,
+    JOB_STATUS,
+    RESULT_STATUS,
+} from "./external-service-jobs.service.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,12 +21,13 @@ function isValidHookName(hookName) {
     return typeof hookName === "string" && HOOK_NAME_PATTERN.test(hookName);
 }
 
-class ExternalServicesRegistry {
-    constructor() {
-        this.initialized = false;
-        this.services = new Map();
-        this.hookSubscribers = new Map();
-        this.results = [];
+export class ExternalServicesRegistry {
+    constructor({ jobsService } = {}) {
+        this.initialized      = false;
+        this.services         = new Map();
+        this.hookSubscribers  = new Map();
+        this.results          = [];
+        this._jobsService     = jobsService ?? externalServiceJobsService;
     }
 
     async initialize(manifestPath = process.env.EXTERNAL_SERVICES_MANIFEST || DEFAULT_MANIFEST_PATH) {
@@ -183,6 +189,52 @@ class ExternalServicesRegistry {
         }
     }
 
+    async _dispatchOneHandler({ hookName, serviceId, handler, context, enabledServiceIds }) {
+        const job = await this._jobsService.createJob({
+            serviceId,
+            hookName,
+            sessionId:  context.sessionId  ?? null,
+            phaseId:    context.phaseId    ?? null,
+            questionId: context.questionId ?? null,
+            groupId:    context.groupId    ?? null,
+            userId:     context.userId     ?? null,
+        }).catch(() => null);
+
+        const jobId = job?.id ?? null;
+
+        const serviceContext = {
+            ...context,
+            serviceId,
+            jobId,
+            correlationId:     jobId,
+            enabledServiceIds: Array.from(enabledServiceIds),
+        };
+
+        if (jobId) {
+            await this._jobsService
+                .updateJobStatus(jobId, JOB_STATUS.DISPATCHED, { dispatchedAt: new Date().toISOString() })
+                .catch(() => null);
+        }
+
+        try {
+            return await handler(serviceContext, {
+                callback: result => this.recordCallbackResult({
+                    hookName,
+                    serviceId,
+                    result,
+                    context: serviceContext,
+                }),
+            });
+        } catch (err) {
+            if (jobId) {
+                await this._jobsService
+                    .updateJobStatus(jobId, JOB_STATUS.FAILED)
+                    .catch(() => null);
+            }
+            throw err;
+        }
+    }
+
     async dispatchHook(hookName, context, options = {}) {
         if (!this.initialized) {
             await this.initialize();
@@ -196,22 +248,9 @@ class ExternalServicesRegistry {
         const subscribers = this.hookSubscribers.get(hookName) || [];
         const selectedSubscribers = subscribers.filter(({ serviceId }) => enabledServiceIds.has(serviceId));
 
-        return Promise.allSettled(selectedSubscribers.map(({ serviceId, handler }) => {
-            const serviceContext = {
-                ...context,
-                serviceId,
-                enabledServiceIds: Array.from(enabledServiceIds),
-            };
-
-            return handler(serviceContext, {
-                callback: result => this.recordCallbackResult({
-                    hookName,
-                    serviceId,
-                    result,
-                    context: serviceContext,
-                }),
-            });
-        }));
+        return Promise.allSettled(selectedSubscribers.map(({ serviceId, handler }) =>
+            this._dispatchOneHandler({ hookName, serviceId, handler, context, enabledServiceIds })
+        ));
     }
 
     async dispatchServiceHook(hookName, serviceId, context) {
@@ -225,6 +264,18 @@ class ExternalServicesRegistry {
             throw error;
         }
 
+        const resultRecord = await this._jobsService.createResult({
+            correlationId: context.correlationId ?? null,
+            serviceId,
+            hookName,
+            rawPayload:    context.requestPayload ?? context.rawBody ?? {},
+            sessionId:     context.sessionId  ?? null,
+            phaseId:       context.phaseId    ?? null,
+            questionId:    context.questionId ?? null,
+            groupId:       context.groupId    ?? null,
+            userId:        context.userId     ?? null,
+        }).catch(() => null);
+
         const subscribers = this.hookSubscribers.get(hookName) || [];
         const selectedSubscribers = subscribers.filter(
             subscriber => subscriber.serviceId === serviceId
@@ -234,6 +285,8 @@ class ExternalServicesRegistry {
             const serviceContext = {
                 ...context,
                 serviceId,
+                jobId:    resultRecord?.job_id ?? null,
+                resultId: resultRecord?.id     ?? null,
             };
 
             return handler(serviceContext, {
@@ -269,6 +322,21 @@ class ExternalServicesRegistry {
         this.results.push(entry);
         if (this.results.length > 100) {
             this.results.shift();
+        }
+
+        if (context.resultId) {
+            await this._jobsService
+                .updateResult(context.resultId, {
+                    status:        RESULT_STATUS.COMPLETED,
+                    adapterResult: result,
+                })
+                .catch(err => console.error("[external-services] Failed to persist callback result.", err));
+        } else if (context.jobId) {
+            await this._jobsService
+                .updateJobStatus(context.jobId, JOB_STATUS.COMPLETED, {
+                    completedAt: new Date().toISOString(),
+                })
+                .catch(err => console.error("[external-services] Failed to update job status.", err));
         }
 
         console.info(`[external-services] Callback received from ${serviceId} for ${hookName}.`, entry);


### PR DESCRIPTION
## Summary

- `ExternalServicesRegistry` now imports and uses `ExternalServiceJobsService` (injected via constructor for testability; defaults to the real singleton).
- New `_dispatchOneHandler` method: creates a job record, enriches handler context with `jobId` / `correlationId: jobId`, marks the job `dispatched` before invoking the adapter, and marks it `failed` if the handler throws. `dispatchHook` delegates to this method per subscriber.
- `dispatchServiceHook` calls `createResult` before dispatching so the inbound callback is immediately recorded; wraps each handler in try/catch — if the handler throws before calling `callback(...)`, the result row is updated to `RESULT_STATUS.FAILED` rather than remaining in `callback-received` indefinitely. Passes `jobId` and `resultId` in handler context.
- `recordCallbackResult` persists outcomes to the DB with status derived from `result?.status`: `"failed"` maps to `RESULT_STATUS.FAILED` / `JOB_STATUS.FAILED`, `"skipped"` maps to `JOB_STATUS.SKIPPED`, any other value maps to `COMPLETED`. `completedAt` is only set when the job reaches `COMPLETED`. Always keeps the backward-compatible in-memory results list (capped at 100).
- `ExternalServicesRegistry` is now also a named export to allow injection-based unit testing without touching the singleton.
- 18 new tests in `external-services-dispatch.service.node-test.mjs` cover job creation, context enrichment, dispatch/failure marking, createResult propagation, status mapping for failed/skipped adapter results, handler-throw path in `dispatchServiceHook`, and in-memory list behaviour. All 47 service tests pass.

Closes #576
Part of epic #572.

## Test plan

- [ ] Run `node --test ethicapp/backend/services/__tests__/*.node-test.mjs` — expect 47 pass, 0 fail.
- [ ] Trigger a hook dispatch in a local dev session and verify rows appear in `external_service_jobs` and `external_service_results`.
- [ ] Trigger a dispatch that fails (adapter throws) and verify the job row ends in `failed` status.
- [ ] POST a callback to `/external-services/:id/callback` and verify `external_service_results.adapter_result` is populated after the adapter calls `callback(result)`.
- [ ] POST a callback where the adapter calls `callback({ status: "failed", ... })` and verify the result row ends in `failed` status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)