### PR TITLE
Enforce callback correlation and persist inbound results (#577)

### DIFF
--- a/ethicapp/backend/controllers/__tests__/external-services.node-test.mjs
+++ b/ethicapp/backend/controllers/__tests__/external-services.node-test.mjs
@@ -115,7 +115,7 @@ test("processCallback: 202 with correlationStatus 'unknown' for unrecognized cor
 
 // ─── duplicate callback ───────────────────────────────────────────────────────
 
-test("processCallback: 202 with isDuplicate true for already-completed job", async () => {
+test("processCallback: 202 with isDuplicate true and dispatched 0 for completed job", async () => {
     const { status, body } = await processCallback({
         serviceId:     "svc-a",
         eventType:     "result",
@@ -125,7 +125,7 @@ test("processCallback: 202 with isDuplicate true for already-completed job", asy
         registry:      makeRegistry({
             dispatchServiceHook: async () => ({
                 resultRecord: { id: RESULT_UUID, job_id: JOB_UUID, is_duplicate: true },
-                outcomes:     [{ status: "fulfilled", value: undefined }],
+                outcomes:     [],
             }),
         }),
     });
@@ -133,6 +133,7 @@ test("processCallback: 202 with isDuplicate true for already-completed job", asy
     assert.equal(status, 202);
     assert.equal(body.result.correlationStatus, "matched");
     assert.equal(body.result.isDuplicate,        true);
+    assert.equal(body.result.dispatched,         0);
 });
 
 // ─── adapter failure / skipped ────────────────────────────────────────────────
@@ -173,6 +174,31 @@ test("processCallback: 202 with dispatched 0 when no subscribers match", async (
 
     assert.equal(status, 202);
     assert.equal(body.result.dispatched, 0);
+});
+
+test("processCallback: passes rawBody to registry when payload is null", async () => {
+    let capturedCtx = null;
+    const rawBody = { serviceId: "svc-a", eventType: "result", nested: { x: 1 } };
+
+    await processCallback({
+        serviceId:     "svc-a",
+        eventType:     "result",
+        correlationId: null,
+        payload:       null,
+        rawBody,
+        auth:          {},
+        registry:      makeRegistry({
+            dispatchServiceHook: async (_hook, _svc, ctx) => {
+                capturedCtx = ctx;
+                return {
+                    resultRecord: { id: RESULT_UUID, job_id: null, is_duplicate: false },
+                    outcomes:     [],
+                };
+            },
+        }),
+    });
+
+    assert.deepEqual(capturedCtx?.rawBody, rawBody);
 });
 
 // ─── internal error ───────────────────────────────────────────────────────────

--- a/ethicapp/backend/controllers/__tests__/external-services.node-test.mjs
+++ b/ethicapp/backend/controllers/__tests__/external-services.node-test.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { processCallback } from "../external-services.js";
+
+const JOB_UUID    = "c1d2e3f4-0000-4000-8000-000000000021";
+const RESULT_UUID = "c1d2e3f4-0000-4000-8000-000000000022";
+
+function makeRegistry(overrides = {}) {
+    return {
+        initialize:              async () => {},
+        authorizeCallbackCaller: () => {},
+        dispatchServiceHook:     async () => ({
+            resultRecord: { id: RESULT_UUID, job_id: JOB_UUID, is_duplicate: false },
+            outcomes:     [{ status: "fulfilled", value: undefined }],
+        }),
+        ...overrides,
+    };
+}
+
+// ─── input validation ─────────────────────────────────────────────────────────
+
+test("processCallback: 400 when serviceId is absent", async () => {
+    const { status, body } = await processCallback({
+        serviceId:     "",
+        eventType:     "result",
+        correlationId: null,
+        payload:       null,
+        auth:          {},
+        registry:      makeRegistry(),
+    });
+
+    assert.equal(status, 400);
+    assert.equal(body.status, "err");
+});
+
+// ─── authorization ────────────────────────────────────────────────────────────
+
+test("processCallback: 403 when authorizeCallbackCaller throws", async () => {
+    const err = new Error("Not authorized");
+    err.statusCode = 403;
+
+    const { status, body } = await processCallback({
+        serviceId: "svc-a",
+        eventType: "result",
+        auth:      {},
+        registry:  makeRegistry({
+            authorizeCallbackCaller: () => { throw err; },
+        }),
+    });
+
+    assert.equal(status, 403);
+    assert.equal(body.status, "err");
+});
+
+// ─── valid correlation ────────────────────────────────────────────────────────
+
+test("processCallback: 202 with correlationStatus 'matched' for known correlationId", async () => {
+    const { status, body } = await processCallback({
+        serviceId:     "svc-a",
+        eventType:     "result",
+        correlationId: JOB_UUID,
+        payload:       { score: 10 },
+        auth:          {},
+        registry:      makeRegistry(),
+    });
+
+    assert.equal(status, 202);
+    assert.equal(body.result.correlationStatus, "matched");
+    assert.equal(body.result.resultId,          RESULT_UUID);
+    assert.equal(body.result.isDuplicate,        false);
+    assert.equal(body.result.correlationId,     JOB_UUID);
+    assert.equal(body.result.dispatched,         1);
+});
+
+// ─── missing / unknown correlation ────────────────────────────────────────────
+
+test("processCallback: 202 with correlationStatus 'unknown' for missing correlationId", async () => {
+    const { status, body } = await processCallback({
+        serviceId:     "svc-a",
+        eventType:     "result",
+        correlationId: null,
+        payload:       {},
+        auth:          {},
+        registry:      makeRegistry({
+            dispatchServiceHook: async () => ({
+                resultRecord: { id: RESULT_UUID, job_id: null, is_duplicate: false },
+                outcomes:     [],
+            }),
+        }),
+    });
+
+    assert.equal(status, 202);
+    assert.equal(body.result.correlationStatus, "unknown");
+    assert.equal(body.result.resultId,          RESULT_UUID);
+});
+
+test("processCallback: 202 with correlationStatus 'unknown' for unrecognized correlationId", async () => {
+    const { status, body } = await processCallback({
+        serviceId:     "svc-a",
+        eventType:     "result",
+        correlationId: "aaaaaaaa-0000-0000-0000-000000000000",
+        payload:       {},
+        auth:          {},
+        registry:      makeRegistry({
+            dispatchServiceHook: async () => ({
+                resultRecord: { id: RESULT_UUID, job_id: null, is_duplicate: false },
+                outcomes:     [],
+            }),
+        }),
+    });
+
+    assert.equal(status, 202);
+    assert.equal(body.result.correlationStatus, "unknown");
+});
+
+// ─── duplicate callback ───────────────────────────────────────────────────────
+
+test("processCallback: 202 with isDuplicate true for already-completed job", async () => {
+    const { status, body } = await processCallback({
+        serviceId:     "svc-a",
+        eventType:     "result",
+        correlationId: JOB_UUID,
+        payload:       {},
+        auth:          {},
+        registry:      makeRegistry({
+            dispatchServiceHook: async () => ({
+                resultRecord: { id: RESULT_UUID, job_id: JOB_UUID, is_duplicate: true },
+                outcomes:     [{ status: "fulfilled", value: undefined }],
+            }),
+        }),
+    });
+
+    assert.equal(status, 202);
+    assert.equal(body.result.correlationStatus, "matched");
+    assert.equal(body.result.isDuplicate,        true);
+});
+
+// ─── adapter failure / skipped ────────────────────────────────────────────────
+
+test("processCallback: 202 even when all adapter handlers are rejected", async () => {
+    const { status, body } = await processCallback({
+        serviceId:     "svc-a",
+        eventType:     "result",
+        correlationId: JOB_UUID,
+        payload:       {},
+        auth:          {},
+        registry:      makeRegistry({
+            dispatchServiceHook: async () => ({
+                resultRecord: { id: RESULT_UUID, job_id: JOB_UUID, is_duplicate: false },
+                outcomes:     [{ status: "rejected", reason: new Error("adapter error") }],
+            }),
+        }),
+    });
+
+    assert.equal(status, 202);
+    assert.equal(body.result.dispatched, 1);
+});
+
+test("processCallback: 202 with dispatched 0 when no subscribers match", async () => {
+    const { status, body } = await processCallback({
+        serviceId:     "svc-a",
+        eventType:     "result",
+        correlationId: null,
+        payload:       {},
+        auth:          {},
+        registry:      makeRegistry({
+            dispatchServiceHook: async () => ({
+                resultRecord: { id: RESULT_UUID, job_id: null, is_duplicate: false },
+                outcomes:     [],
+            }),
+        }),
+    });
+
+    assert.equal(status, 202);
+    assert.equal(body.result.dispatched, 0);
+});
+
+// ─── internal error ───────────────────────────────────────────────────────────
+
+test("processCallback: 500 on unexpected dispatchServiceHook error", async () => {
+    const { status, body } = await processCallback({
+        serviceId: "svc-a",
+        eventType: "result",
+        auth:      {},
+        registry:  makeRegistry({
+            dispatchServiceHook: async () => { throw new Error("unexpected"); },
+        }),
+    });
+
+    assert.equal(status, 500);
+    assert.equal(body.status, "err");
+});

--- a/ethicapp/backend/controllers/external-services.js
+++ b/ethicapp/backend/controllers/external-services.js
@@ -5,32 +5,27 @@ import { callbackAuthMiddleware } from "../middleware/external-services-callback
 
 const router = express.Router();
 
-router.post("/external-services/callbacks", callbackAuthMiddleware, async (req, res) => {
-    const serviceId = typeof req.body?.serviceId === "string" ? req.body.serviceId.trim() : "";
-    const eventType = typeof req.body?.eventType === "string" ? req.body.eventType.trim() : "result";
-    const correlationId = req.body?.correlationId ?? null;
-    const payload = req.body?.payload ?? null;
-
+export async function processCallback({ serviceId, eventType, correlationId, payload, auth, registry }) {
     if (!serviceId) {
-        return res.status(400).json({
-            status: "err",
-            error:  "Missing required field: serviceId.",
-        });
+        return {
+            status: 400,
+            body:   { status: "err", error: "Missing required field: serviceId." },
+        };
     }
 
-    await externalServicesRegistry.initialize();
+    await registry.initialize();
 
     try {
-        externalServicesRegistry.authorizeCallbackCaller(serviceId, req.externalServiceAuth);
+        registry.authorizeCallbackCaller(serviceId, auth);
     } catch (error) {
-        return res.status(error.statusCode || 403).json({
-            status: "err",
-            error:  error.message,
-        });
+        return {
+            status: error.statusCode || 403,
+            body:   { status: "err", error: error.message },
+        };
     }
 
     try {
-        const dispatchResults = await externalServicesRegistry.dispatchServiceHook(
+        const { resultRecord, outcomes } = await registry.dispatchServiceHook(
             "callback-received",
             serviceId,
             {
@@ -38,33 +33,60 @@ router.post("/external-services/callbacks", callbackAuthMiddleware, async (req, 
                 eventType,
                 correlationId,
                 requestPayload: payload,
-                rawBody:        req.body,
-                auth:           req.externalServiceAuth,
+                auth,
             }
         );
 
-        return res.status(202).json({
-            status: "accepted",
-            result: {
-                serviceId,
-                eventType,
-                dispatched: dispatchResults.length,
+        const correlationStatus = resultRecord?.job_id ? "matched" : "unknown";
+        const isDuplicate       = resultRecord?.is_duplicate ?? false;
+
+        return {
+            status: 202,
+            body:   {
+                status: "accepted",
+                result: {
+                    serviceId,
+                    eventType,
+                    correlationId,
+                    correlationStatus,
+                    resultId:   resultRecord?.id ?? null,
+                    isDuplicate,
+                    dispatched: outcomes.length,
+                },
             },
-        });
+        };
     } catch (error) {
         if (error.statusCode) {
-            return res.status(error.statusCode).json({
-                status: "err",
-                error:  error.message,
-            });
+            return {
+                status: error.statusCode,
+                body:   { status: "err", error: error.message },
+            };
         }
 
         console.error("[external-services] Error dispatching callback-received hook.", error);
-        return res.status(500).json({
-            status: "err",
-            error:  "Internal server error.",
-        });
+        return {
+            status: 500,
+            body:   { status: "err", error: "Internal server error." },
+        };
     }
+}
+
+router.post("/external-services/callbacks", callbackAuthMiddleware, async (req, res) => {
+    const serviceId     = typeof req.body?.serviceId === "string" ? req.body.serviceId.trim() : "";
+    const eventType     = typeof req.body?.eventType === "string" ? req.body.eventType.trim() : "result";
+    const correlationId = req.body?.correlationId ?? null;
+    const payload       = req.body?.payload ?? null;
+
+    const { status, body } = await processCallback({
+        serviceId,
+        eventType,
+        correlationId,
+        payload,
+        auth:     req.externalServiceAuth,
+        registry: externalServicesRegistry,
+    });
+
+    return res.status(status).json(body);
 });
 
 router.get("/external-services", async (req, res) => {

--- a/ethicapp/backend/controllers/external-services.js
+++ b/ethicapp/backend/controllers/external-services.js
@@ -5,7 +5,7 @@ import { callbackAuthMiddleware } from "../middleware/external-services-callback
 
 const router = express.Router();
 
-export async function processCallback({ serviceId, eventType, correlationId, payload, auth, registry }) {
+export async function processCallback({ serviceId, eventType, correlationId, payload, rawBody, auth, registry }) {
     if (!serviceId) {
         return {
             status: 400,
@@ -33,6 +33,7 @@ export async function processCallback({ serviceId, eventType, correlationId, pay
                 eventType,
                 correlationId,
                 requestPayload: payload,
+                rawBody,
                 auth,
             }
         );
@@ -82,6 +83,7 @@ router.post("/external-services/callbacks", callbackAuthMiddleware, async (req, 
         eventType,
         correlationId,
         payload,
+        rawBody:  req.body,
         auth:     req.externalServiceAuth,
         registry: externalServicesRegistry,
     });

--- a/ethicapp/backend/services/__tests__/external-service-jobs.service.node-test.mjs
+++ b/ethicapp/backend/services/__tests__/external-service-jobs.service.node-test.mjs
@@ -283,6 +283,57 @@ test("createResult: null correlationId — skips job lookup, unknown-correlation
     assert.ok(db.calls[0].sql.includes("INSERT INTO external_service_results"));
 });
 
+test("createResult: duplicate — terminal job is not overwritten to callback-received", async () => {
+    const jobRow    = {
+        id:          JOB_UUID,
+        status:      JOB_STATUS.COMPLETED,
+        session_id:  null,
+        phase_id:    null,
+        question_id: null,
+        group_id:    null,
+        user_id:     null,
+    };
+    const resultRow = { id: RESULT_UUID, job_id: JOB_UUID, status: RESULT_STATUS.CALLBACK_RECEIVED };
+    // Only 2 calls expected: SELECT + INSERT; no UPDATE because job is terminal.
+    const db  = makeDbQueue([jobRow], [resultRow]);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const result = await svc.createResult({
+        correlationId: JOB_UUID,
+        serviceId:     "polyadic-devils-advocate",
+        rawPayload:    {},
+    });
+
+    assert.equal(db.calls.length, 2, "should not UPDATE when job is already terminal");
+    assert.equal(result.is_duplicate,     true);
+    assert.equal(result.job_prior_status, JOB_STATUS.COMPLETED);
+});
+
+test("createResult: non-terminal job sets is_duplicate to false", async () => {
+    const jobRow    = {
+        id:          JOB_UUID,
+        status:      JOB_STATUS.DISPATCHED,
+        session_id:  null,
+        phase_id:    null,
+        question_id: null,
+        group_id:    null,
+        user_id:     null,
+    };
+    const resultRow = { id: RESULT_UUID, job_id: JOB_UUID, status: RESULT_STATUS.CALLBACK_RECEIVED };
+    const db  = makeDbQueue([jobRow], [resultRow], []);
+    const svc = new ExternalServiceJobsService({ dbQuery: db });
+
+    const result = await svc.createResult({
+        correlationId: JOB_UUID,
+        serviceId:     "polyadic-devils-advocate",
+        rawPayload:    {},
+    });
+
+    assert.equal(db.calls.length, 3, "should UPDATE non-terminal job");
+    assert.equal(result.is_duplicate,     false);
+    assert.equal(result.job_prior_status, JOB_STATUS.DISPATCHED);
+});
+
 // ─── updateResult ─────────────────────────────────────────────────────────────
 
 test("updateResult: sets status, sanitizedPayload, and adapterResult", async () => {

--- a/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
+++ b/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
@@ -226,12 +226,61 @@ test("dispatchServiceHook: marks result FAILED when handler throws", async () =>
         { serviceId: "svc-a", handler: async () => { throw new Error("handler error"); } },
     ]);
 
-    const results = await registry.dispatchServiceHook("callback-received", "svc-a", {});
+    const { outcomes } = await registry.dispatchServiceHook("callback-received", "svc-a", {});
 
-    assert.equal(results[0].status, "rejected");
+    assert.equal(outcomes[0].status, "rejected");
     assert.equal(updateResultCalls.length, 1);
     assert.equal(updateResultCalls[0].id, RESULT_UUID);
     assert.equal(updateResultCalls[0].status, RESULT_STATUS.FAILED);
+});
+
+test("dispatchServiceHook: returns resultRecord alongside outcomes", async () => {
+    const { registry } = makeRegistry();
+
+    registry.hookSubscribers.set("callback-received", [
+        { serviceId: "svc-a", handler: async () => {} },
+    ]);
+
+    const response = await registry.dispatchServiceHook("callback-received", "svc-a", {});
+
+    assert.ok(Object.hasOwn(response, "resultRecord"), "should have resultRecord key");
+    assert.ok(Object.hasOwn(response, "outcomes"),     "should have outcomes key");
+    assert.ok(Array.isArray(response.outcomes));
+    assert.equal(response.resultRecord?.id, RESULT_UUID);
+});
+
+test("dispatchServiceHook: passes isDuplicate in handler context when job is terminal", async () => {
+    let capturedContext = null;
+    const { registry } = makeRegistry({
+        createResult: async () => ({
+            id:               RESULT_UUID,
+            job_id:           JOB_UUID,
+            job_prior_status: "completed",
+            is_duplicate:     true,
+        }),
+    });
+
+    registry.hookSubscribers.set("callback-received", [
+        { serviceId: "svc-a", handler: async (ctx) => { capturedContext = ctx; } },
+    ]);
+
+    await registry.dispatchServiceHook("callback-received", "svc-a", {});
+
+    assert.ok(capturedContext);
+    assert.equal(capturedContext.isDuplicate, true);
+});
+
+test("dispatchServiceHook: isDuplicate is false for non-terminal job", async () => {
+    let capturedContext = null;
+    const { registry } = makeRegistry();
+
+    registry.hookSubscribers.set("callback-received", [
+        { serviceId: "svc-a", handler: async (ctx) => { capturedContext = ctx; } },
+    ]);
+
+    await registry.dispatchServiceHook("callback-received", "svc-a", {});
+
+    assert.equal(capturedContext?.isDuplicate, false);
 });
 
 // ─── recordCallbackResult ─────────────────────────────────────────────────────

--- a/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
+++ b/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
@@ -323,6 +323,75 @@ test("recordCallbackResult: maps result.status 'failed' to RESULT_STATUS.FAILED"
     assert.equal(updateResultCalls[0].status, RESULT_STATUS.FAILED);
 });
 
+test("recordCallbackResult: also advances job to completed when both resultId and jobId are present", async () => {
+    const statusCalls = [];
+    const { registry } = makeRegistry({
+        updateJobStatus: async (id, status) => { statusCalls.push({ id, status }); },
+    });
+
+    await registry.recordCallbackResult({
+        hookName:  "callback-received",
+        serviceId: "svc-a",
+        result:    { score: 42 },
+        context:   { resultId: RESULT_UUID, jobId: JOB_UUID, serviceId: "svc-a" },
+    });
+
+    assert.equal(statusCalls.length, 1);
+    assert.equal(statusCalls[0].id, JOB_UUID);
+    assert.equal(statusCalls[0].status, JOB_STATUS.COMPLETED);
+});
+
+test("recordCallbackResult: advances job to failed when resultId and jobId present and result failed", async () => {
+    const statusCalls = [];
+    const { registry } = makeRegistry({
+        updateJobStatus: async (id, status) => { statusCalls.push({ id, status }); },
+    });
+
+    await registry.recordCallbackResult({
+        hookName:  "callback-received",
+        serviceId: "svc-a",
+        result:    { status: "failed" },
+        context:   { resultId: RESULT_UUID, jobId: JOB_UUID },
+    });
+
+    assert.equal(statusCalls[0].status, JOB_STATUS.FAILED);
+});
+
+test("dispatchServiceHook: second callback for same correlationId is duplicate after first completes", async () => {
+    let handlerCallCount = 0;
+    let callCount        = 0;
+
+    const { registry } = makeRegistry({
+        createResult: async () => {
+            callCount++;
+            if (callCount === 1) {
+                return { id: RESULT_UUID, job_id: JOB_UUID, is_duplicate: false };
+            }
+            // Second call: job is now terminal after adapter called callback(result)
+            return { id: `${RESULT_UUID}-2`, job_id: JOB_UUID, is_duplicate: true, job_prior_status: JOB_STATUS.COMPLETED };
+        },
+    });
+
+    registry.hookSubscribers.set("callback-received", [
+        {
+            serviceId: "svc-a",
+            handler:   async (ctx, { callback }) => {
+                handlerCallCount++;
+                await callback({ score: 10 });
+            },
+        },
+    ]);
+
+    // First callback — should dispatch handler
+    await registry.dispatchServiceHook("callback-received", "svc-a", { correlationId: JOB_UUID });
+
+    // Second callback with same correlationId — job now terminal, should be a duplicate
+    const { outcomes } = await registry.dispatchServiceHook("callback-received", "svc-a", { correlationId: JOB_UUID });
+
+    assert.equal(handlerCallCount, 1, "handler must not run for duplicate callback");
+    assert.deepEqual(outcomes, []);
+});
+
 test("recordCallbackResult: calls updateJobStatus when context has jobId only", async () => {
     const statusCalls = [];
     const { registry } = makeRegistry({

--- a/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
+++ b/ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs
@@ -249,8 +249,8 @@ test("dispatchServiceHook: returns resultRecord alongside outcomes", async () =>
     assert.equal(response.resultRecord?.id, RESULT_UUID);
 });
 
-test("dispatchServiceHook: passes isDuplicate in handler context when job is terminal", async () => {
-    let capturedContext = null;
+test("dispatchServiceHook: skips handlers and returns empty outcomes when is_duplicate", async () => {
+    let handlerCalled = false;
     const { registry } = makeRegistry({
         createResult: async () => ({
             id:               RESULT_UUID,
@@ -261,13 +261,16 @@ test("dispatchServiceHook: passes isDuplicate in handler context when job is ter
     });
 
     registry.hookSubscribers.set("callback-received", [
-        { serviceId: "svc-a", handler: async (ctx) => { capturedContext = ctx; } },
+        { serviceId: "svc-a", handler: async () => { handlerCalled = true; } },
     ]);
 
-    await registry.dispatchServiceHook("callback-received", "svc-a", {});
+    const { resultRecord, outcomes } = await registry.dispatchServiceHook(
+        "callback-received", "svc-a", {}
+    );
 
-    assert.ok(capturedContext);
-    assert.equal(capturedContext.isDuplicate, true);
+    assert.equal(handlerCalled, false, "handler must not run for duplicate callbacks");
+    assert.deepEqual(outcomes, []);
+    assert.equal(resultRecord?.id, RESULT_UUID);
 });
 
 test("dispatchServiceHook: isDuplicate is false for non-terminal job", async () => {

--- a/ethicapp/backend/services/external-service-jobs.service.js
+++ b/ethicapp/backend/services/external-service-jobs.service.js
@@ -20,6 +20,13 @@ export const RESULT_STATUS = Object.freeze({
     UNKNOWN_CORRELATION: "unknown-correlation",
 });
 
+const TERMINAL_JOB_STATUSES = new Set([
+    JOB_STATUS.COMPLETED,
+    JOB_STATUS.FAILED,
+    JOB_STATUS.SKIPPED,
+    JOB_STATUS.EXPIRED,
+]);
+
 let _pool = null;
 
 function getPool() {
@@ -109,11 +116,12 @@ export class ExternalServiceJobsService {
         userId        = null,
     }) {
         let jobId        = null;
+        let jobStatus    = null;
         let resultStatus = RESULT_STATUS.UNKNOWN_CORRELATION;
 
         if (correlationId) {
             const matchRows = await this._db(
-                `SELECT id, session_id, phase_id, question_id, group_id, user_id
+                `SELECT id, status, session_id, phase_id, question_id, group_id, user_id
                  FROM external_service_jobs
                  WHERE id::text = $1 AND service_id = $2`,
                 [correlationId, serviceId]
@@ -121,6 +129,7 @@ export class ExternalServiceJobsService {
             if (matchRows.length > 0) {
                 const job    = matchRows[0];
                 jobId        = job.id;
+                jobStatus    = job.status;
                 resultStatus = RESULT_STATUS.CALLBACK_RECEIVED;
                 // Propagate job context to result when caller did not provide it.
                 sessionId    = sessionId  ?? job.session_id;
@@ -148,7 +157,13 @@ export class ExternalServiceJobsService {
 
         const result = rows[0] || null;
 
-        if (result && jobId) {
+        if (result && jobStatus !== null) {
+            result.job_prior_status = jobStatus;
+            result.is_duplicate     = TERMINAL_JOB_STATUSES.has(jobStatus);
+        }
+
+        // Only advance a non-terminal job to callback-received.
+        if (result && jobId && !TERMINAL_JOB_STATUSES.has(jobStatus)) {
             await this._db(
                 `UPDATE external_service_jobs
                  SET status = $2, updated_at = now()

--- a/ethicapp/backend/services/external-services.service.js
+++ b/ethicapp/backend/services/external-services.service.js
@@ -64,9 +64,9 @@ export class ExternalServicesRegistry {
         }
 
         const normalizedService = {
-            id: service.id,
+            id:          service.id,
             description: service.description || "",
-            hooks: Array.isArray(service.hooks)
+            hooks:       Array.isArray(service.hooks)
                 ? service.hooks.filter(hookName => {
                     const isValid = isValidHookName(hookName);
                     if (!isValid) {
@@ -75,8 +75,8 @@ export class ExternalServicesRegistry {
                     return isValid;
                 })
                 : [],
-            enabled: service.enabled !== false,
-            adapter: service.adapter,
+            enabled:      service.enabled !== false,
+            adapter:      service.adapter,
             callbackAuth: service.callbackAuth && typeof service.callbackAuth === "object"
                 ? {
                     allowedClientIds: Array.isArray(service.callbackAuth.allowedClientIds)
@@ -105,11 +105,11 @@ export class ExternalServicesRegistry {
         }
 
         await register({
-            service: normalizedService,
+            service:   normalizedService,
             subscribe: (hookName, handler) => {
                 this.subscribe(normalizedService.id, hookName, handler);
             },
-            publishStudentResult: payload => this.publishStudentResult(normalizedService.id, payload),
+            publishStudentResult:    payload => this.publishStudentResult(normalizedService.id, payload),
             publishGroupChatMessage: payload => this.publishGroupChatMessage(normalizedService.id, payload),
             aiAdditionsClient,
         });
@@ -276,6 +276,10 @@ export class ExternalServicesRegistry {
             userId:        context.userId     ?? null,
         }).catch(() => null);
 
+        if (resultRecord?.is_duplicate) {
+            return { resultRecord, outcomes: [] };
+        }
+
         const subscribers = this.hookSubscribers.get(hookName) || [];
         const selectedSubscribers = subscribers.filter(
             subscriber => subscriber.serviceId === serviceId
@@ -314,12 +318,12 @@ export class ExternalServicesRegistry {
 
     async recordCallbackResult({ hookName, serviceId, result, context }) {
         const entry = {
-            id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+            id:         `${Date.now()}-${Math.random().toString(16).slice(2)}`,
             hookName,
             serviceId,
             receivedAt: new Date().toISOString(),
             result,
-            context: {
+            context:    {
                 sessionId:      context.sessionId,
                 phaseId:        context.phaseId,
                 startedPhaseId: context.startedPhaseId,
@@ -408,7 +412,7 @@ export class ExternalServicesRegistry {
         }
 
         const savedMessage = await saveChatMessage({
-            userId: null,
+            userId:          null,
             externalAgentId: agent.id,
             phaseId,
             questionId,
@@ -457,7 +461,7 @@ export class ExternalServicesRegistry {
                 SET display_name = EXCLUDED.display_name
                 RETURNING id, service_id, display_name
             `,
-            dbcon: dbconnString,
+            dbcon:     dbconnString,
             sqlParams: [
                 rpg2.param("plain", serviceId),
                 rpg2.param("plain", normalizedDisplayName),
@@ -470,26 +474,26 @@ export class ExternalServicesRegistry {
         }
 
         return {
-            id: Number(agent.id),
-            serviceId: agent.service_id,
+            id:          Number(agent.id),
+            serviceId:   agent.service_id,
             displayName: agent.display_name,
         };
     }
 
     normalizeServiceChatNotificationPayload({ message, agent, phaseId, questionId }) {
         return {
-            id: message.id,
-            uid: message.uid,
-            author_role: "external_service",
-            author_name: agent.displayName,
+            id:                  message.id,
+            uid:                 message.uid,
+            author_role:         "external_service",
+            author_name:         agent.displayName,
             external_service_id: agent.serviceId,
-            external_agent_id: agent.id,
-            groupId: message.tmid,
-            phaseId: message.stageid || phaseId,
-            questionId: message.did || questionId,
-            content: message.content,
-            stime: message.stime,
-            parent_id: message.parent_id,
+            external_agent_id:   agent.id,
+            groupId:             message.tmid,
+            phaseId:             message.stageid || phaseId,
+            questionId:          message.did || questionId,
+            content:             message.content,
+            stime:               message.stime,
+            parent_id:           message.parent_id,
         };
     }
 }

--- a/ethicapp/backend/services/external-services.service.js
+++ b/ethicapp/backend/services/external-services.service.js
@@ -350,6 +350,18 @@ export class ExternalServicesRegistry {
                     adapterResult: result,
                 })
                 .catch(err => console.error("[external-services] Failed to persist callback result.", err));
+
+            if (context.jobId) {
+                const jobStatus = result?.status === "failed"
+                    ? JOB_STATUS.FAILED
+                    : result?.status === "skipped"
+                        ? JOB_STATUS.SKIPPED
+                        : JOB_STATUS.COMPLETED;
+                const completedAt = jobStatus === JOB_STATUS.COMPLETED ? new Date().toISOString() : undefined;
+                await this._jobsService
+                    .updateJobStatus(context.jobId, jobStatus, { completedAt })
+                    .catch(err => console.error("[external-services] Failed to update job status after callback result.", err));
+            }
         } else if (context.jobId) {
             const jobStatus = result?.status === "failed"
                 ? JOB_STATUS.FAILED

--- a/ethicapp/backend/services/external-services.service.js
+++ b/ethicapp/backend/services/external-services.service.js
@@ -281,12 +281,13 @@ export class ExternalServicesRegistry {
             subscriber => subscriber.serviceId === serviceId
         );
 
-        return Promise.allSettled(selectedSubscribers.map(async ({ handler }) => {
+        const outcomes = await Promise.allSettled(selectedSubscribers.map(async ({ handler }) => {
             const serviceContext = {
                 ...context,
                 serviceId,
-                jobId:    resultRecord?.job_id ?? null,
-                resultId: resultRecord?.id     ?? null,
+                jobId:       resultRecord?.job_id      ?? null,
+                resultId:    resultRecord?.id          ?? null,
+                isDuplicate: resultRecord?.is_duplicate ?? false,
             };
 
             try {
@@ -307,6 +308,8 @@ export class ExternalServicesRegistry {
                 throw err;
             }
         }));
+
+        return { resultRecord, outcomes };
     }
 
     async recordCallbackResult({ hookName, serviceId, result, context }) {
@@ -344,9 +347,11 @@ export class ExternalServicesRegistry {
                 })
                 .catch(err => console.error("[external-services] Failed to persist callback result.", err));
         } else if (context.jobId) {
-            const jobStatus = result?.status === "failed"  ? JOB_STATUS.FAILED
-                : result?.status === "skipped" ? JOB_STATUS.SKIPPED
-                : JOB_STATUS.COMPLETED;
+            const jobStatus = result?.status === "failed"
+                ? JOB_STATUS.FAILED
+                : result?.status === "skipped"
+                    ? JOB_STATUS.SKIPPED
+                    : JOB_STATUS.COMPLETED;
             const completedAt = jobStatus === JOB_STATUS.COMPLETED ? new Date().toISOString() : undefined;
             await this._jobsService
                 .updateJobStatus(context.jobId, jobStatus, { completedAt })


### PR DESCRIPTION
## Summary

- **`ExternalServiceJobsService.createResult`**: adds `status` to the job correlation SELECT. If the matched job is already in a terminal state (`completed`, `failed`, `skipped`, `expired`), the job row is not overwritten back to `callback-received`. The created result row gets two transient computed fields — `is_duplicate: true` and `job_prior_status` — for callers to inspect.

- **`ExternalServicesRegistry.dispatchServiceHook`**: skips handler dispatch entirely when `resultRecord.is_duplicate` is true, returning `{ resultRecord, outcomes: [] }`. This prevents adapters from re-executing side effects (e.g. Polyadic re-publishing) on late or duplicate callbacks. Returns `{ resultRecord, outcomes }` instead of a bare `Promise.allSettled` array, surfacing correlation metadata to the controller.

- **`ExternalServicesRegistry.recordCallbackResult`**: when the adapter calls `callback(result)` in the `callback-received` flow and `context.jobId` is present alongside `context.resultId`, the associated job is also advanced to the equivalent terminal state (`completed`/`failed`/`skipped`). This closes the idempotency gap: a subsequent callback with the same `correlationId` finds the job terminal and is correctly flagged as duplicate.

- **`controllers/external-services.js`**: refactored the inline `POST /external-services/callbacks` handler into a named exported `processCallback` function for testability. The 202 response now includes `correlationStatus` (`"matched"` | `"unknown"`), `resultId`, and `isDuplicate`, giving callers a durable audit reference for every callback regardless of correlation outcome. All authentication and per-service authorization checks from #573 are preserved.

## Behavior by scenario

| Scenario | HTTP | `correlationStatus` | `isDuplicate` | Handlers dispatched |
|---|---|---|---|---|
| Valid correlationId matching a live job | 202 | `matched` | `false` | yes |
| Valid correlationId for already-completed job | 202 | `matched` | `true` | no |
| Missing correlationId | 202 | `unknown` | `false` | yes |
| Unknown correlationId | 202 | `unknown` | `false` | yes |
| Handler throws | 202 | matched/unknown | — | — |
| No subscribers | 202 | matched/unknown | — | — |

Unknown/missing correlation callbacks are always persisted in `external_service_results` as `unknown-correlation`.

## Test plan

- [ ] Run `node --test ethicapp/backend/services/__tests__/external-service-jobs.service.node-test.mjs ethicapp/backend/services/__tests__/external-services-dispatch.service.node-test.mjs ethicapp/backend/controllers/__tests__/external-services.node-test.mjs` — expect 65 pass, 0 fail.
- [ ] POST a callback with a known `correlationId` and verify the response includes `correlationStatus: "matched"` and a non-null `resultId`.
- [ ] POST a callback with no `correlationId` or an unrecognized one and verify `correlationStatus: "unknown"`.
- [ ] POST a callback for a job already in `completed` status and verify `isDuplicate: true` in the response, `dispatched: 0`, and that the job row is still `completed` in the DB.
- [ ] POST a second callback with the same `correlationId` after the adapter called `callback(result)` and verify it is also treated as duplicate (job was advanced to terminal by the first).
- [ ] Verify `external_service_results` has a row for every callback, including those with unknown correlation.

Closes #577
Part of epic #572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)