### PR TITLE
Activity lifecycle hooks: activity-started / activity-finished (#589)

### DIFF
--- a/EXTERNAL.md
+++ b/EXTERNAL.md
@@ -43,8 +43,9 @@ Each manifest entry declares:
 - `enabled`: whether the adapter should be loaded.
 
 Hook names are standardized as kebab-case identifiers. New adapters should use
-names such as `phase-started`, `phase-ended`, `session-ended`,
-`chat-message-received`, `student-response-submitted`, and `callback-received`.
+names such as `phase-started`, `phase-ended`, `activity-started`,
+`activity-finished`, `chat-message-received`, `student-response-submitted`, and
+`callback-received`.
 
 Adapters are ESM modules that export `register(...)`. During startup,
 `externalServicesRegistry.initialize()` loads the manifest, imports each enabled
@@ -198,14 +199,36 @@ Current event hooks:
   group chat.
 - `callback-received`: dispatched when an external service calls the callback
   endpoint. Replaces the earlier `external-service-result` hook.
-- `session-ended`: dispatched when a session finishes and service-local context
-  should be cleaned up.
+- `activity-started`: dispatched once when the teacher transitions a session into
+  `in_progress` (its first phase), so adapters can run any preparation/warm-up.
+  It does not fire on ordinary phase-to-phase advances. Resolved against the
+  services enabled for the phase being entered.
+- `activity-finished`: dispatched when the teacher finishes an activity, so
+  adapters can run any required cleanup (close rooms, release provider sessions,
+  flush state). Resolved against the **union of services enabled across all
+  phases** of the activity design, so any service that may have opened
+  provider-side state is notified to clean up regardless of which phase the
+  activity finishes on (including early/incomplete finishes). Replaces the earlier
+  single-service `session-ended` hook.
 
-The phase transition hooks are dispatched from:
+> **Enabled-service resolution differs by lifecycle hook.** `activity-started` is
+> phase-scoped (resolved from the phase being entered, since preparation is
+> relevant to that phase). `activity-finished` resolves against the union of
+> enabled services across all phases of the design, guaranteeing that no
+> provider-side state leaks past the end of the activity.
+
+The phase transition and `activity-started` hooks are dispatched from:
 
 ```text
 ethicapp/backend/controllers/activities/activities-teacher.js
 POST /activities/:session_id/phase_transition
+```
+
+The `activity-finished` hook is dispatched from:
+
+```text
+ethicapp/backend/controllers/activities/activities-teacher.js
+POST /activities/:session_id/finish
 ```
 
 The student response hook is dispatched from:
@@ -342,6 +365,30 @@ export async function register({ subscribe, publishGroupChatMessage }) {
       groupId: context.groupId,
       parentId: context.savedMessage?.id,
       content: "Mock chat agent reply."
+    });
+  });
+}
+```
+
+Adapters can subscribe to the activity-lifecycle hooks to prepare or clean up
+provider-side state. These are broadcast (fire-and-forget) to the services
+enabled for the relevant phase:
+
+```js
+export async function register({ service, subscribe, callback }) {
+  subscribe("activity-started", async (context) => {
+    // context.sessionId, context.phaseId (the first phase entered)
+    // Warm up / allocate any provider resources for the activity here.
+  });
+
+  subscribe("activity-finished", async (context, { callback }) => {
+    // context.sessionId, context.phaseId (the last active phase)
+    // Release provider sessions / flush state here.
+    await callback({
+      serviceId: service.id,
+      hook:      "activity-finished",
+      status:    "completed",
+      payload:   { sessionId: context.sessionId },
     });
   });
 }

--- a/ethicapp/backend/controllers/activities/activities-teacher.js
+++ b/ethicapp/backend/controllers/activities/activities-teacher.js
@@ -9,7 +9,8 @@ import { requireRole } from "../../helpers/auth-helper.js";
 import { studentNotifications } from "../../config/socket.config.js";
 import redisClient from "../../db/redis.js";
 import { getDesignTypeBySessionId } from "./activities-common.js";
-import { getPhaseDesignByPhaseId } from "../../helpers/designs-helper.js";
+import { getPhaseDesignByPhaseId, getEnabledExternalServiceIdsBySessionId } from "../../helpers/designs-helper.js";
+import { shouldDispatchActivityStarted } from "../../helpers/activity-lifecycle-helper.js";
 import externalServicesRegistry from "../../services/external-services.service.js";
 
 const router = express.Router();
@@ -362,7 +363,7 @@ router.post("/activities/:session_id/phase_transition", async (req, res) => {
 
         const sessionState = await rpg2.singleSQL({
             sql: `
-                SELECT current_stage
+                SELECT current_stage, status
                 FROM sessions
                 WHERE id = $1
             `,
@@ -375,6 +376,7 @@ router.post("/activities/:session_id/phase_transition", async (req, res) => {
         }
 
         const previousPhaseId = Number(sessionState.current_stage) || null;
+        const previousStatus  = Number(sessionState.status) || null;
 
         result = await rpg2.execSQL({
             sql: `
@@ -398,6 +400,17 @@ router.post("/activities/:session_id/phase_transition", async (req, res) => {
             startedPhaseId: phaseId,
             endedPhaseId:   previousPhaseId,
         });
+
+        // Fire activity-started only on the transition into in_progress (the
+        // activity's first phase), not on ordinary phase-to-phase advances.
+        if (shouldDispatchActivityStarted(previousStatus)) {
+            dispatchActivityStartedHook({
+                sessionId,
+                phaseId:        phaseId,
+                startedPhaseId: phaseId,
+                endedPhaseId:   previousPhaseId,
+            });
+        }
 
         res.status(200).json({ status: "ok", message: "Session transitioned to the new phase." });
     } catch (err) {
@@ -425,6 +438,34 @@ async function dispatchPhaseTransitionHooks({ sessionId, startedPhaseId, endedPh
         });
     } catch (error) {
         console.error("[external-services] Error dispatching phase transition hooks.", error);
+    }
+}
+
+// Broadcasts activity-started to the services enabled for the phase being
+// entered (phase-scoped, since preparation is relevant to that phase), isolating
+// any adapter failure so it never breaks the teacher request.
+async function dispatchActivityStartedHook(context) {
+    try {
+        await dispatchPhaseHook("activity-started", context);
+    } catch (error) {
+        console.error("[external-services] Error dispatching activity-started hook.", error);
+    }
+}
+
+// Broadcasts activity-finished to the union of services enabled across ALL phases
+// of the activity design, so any service that could have opened provider-side
+// state (e.g. chat rooms) is notified to clean up — regardless of which phase the
+// activity finished on. This is the safety net guaranteeing nothing leaks past
+// the end of the activity. Adapter failures are isolated from the teacher request.
+async function dispatchActivityFinishedHook(sessionId, context) {
+    try {
+        const enabledServiceIds = await getEnabledExternalServiceIdsBySessionId(sessionId);
+        if (enabledServiceIds.length === 0) {
+            return;
+        }
+        await externalServicesRegistry.dispatchHook("activity-finished", context, { enabledServiceIds });
+    } catch (error) {
+        console.error("[external-services] Error dispatching activity-finished hook.", error);
     }
 }
 
@@ -508,13 +549,16 @@ router.post("/activities/:session_id/finish", async (req, res) => {
 
         studentNotifications.endSession(sessionId);
 
-        try {
-            await externalServicesRegistry.dispatchServiceHook("session-ended", "polyadic-devils-advocate", {
-                sessionId: Number(sessionId),
-            });
-        } catch (hookErr) {
-            console.error("[external-services] Error dispatching session-ended hook.", hookErr);
-        }
+        // Broadcast activity-finished to every service enabled anywhere in the
+        // activity design (union across phases) so adapters can run required
+        // cleanup regardless of which phase the activity finished on. Fired even
+        // when there is no current phase, so nothing leaks past the activity end.
+        await dispatchActivityFinishedHook(Number(sessionId), {
+            sessionId:      Number(sessionId),
+            phaseId:        previousPhaseId,
+            startedPhaseId: null,
+            endedPhaseId:   previousPhaseId,
+        });
 
         res.status(200).json({ status: "ok", message: "Activity session finished successfully." });
     } catch (err) {

--- a/ethicapp/backend/external-services/README.md
+++ b/ethicapp/backend/external-services/README.md
@@ -55,8 +55,8 @@ callback results in memory for operational visibility and injects the current
 `serviceId` into hook contexts.
 
 Hook names are part of the adapter interface and must use kebab-case, for
-example `phase-started`, `phase-ended`, `student-response-submitted`, and
-`callback-received`.
+example `phase-started`, `phase-ended`, `activity-started`, `activity-finished`,
+`student-response-submitted`, and `callback-received`.
 
 ## Available Hook Publishers
 
@@ -70,8 +70,8 @@ The registry provides two helper publishers to adapters:
   `agentDisplayName` are optional but should be provided when available.
 
 Hook names are part of the adapter interface and must use kebab-case, for
-example `phase-started`, `phase-ended`, `student-response-submitted`, and
-`callback-received`.
+example `phase-started`, `phase-ended`, `activity-started`, `activity-finished`,
+`student-response-submitted`, and `callback-received`.
 
 Adapters can also call the `callback(result)` function passed to a subscribed
 hook handler. This is for recording adapter outcomes, not for communicating with

--- a/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
+++ b/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
@@ -252,6 +252,44 @@ test("phase-ended closes rooms created for that phase", async () => {
     assert.equal(harness.callbacks.at(-1).payload.roomsClosed, 2);
 });
 
+test("activity-finished closes every room for the session across all phases", async () => {
+    const harness = createHarness();
+    await harness.initialize();
+
+    await harness.dispatch("phase-started", { sessionId: 11, phaseId: 22 });
+    await harness.dispatch("phase-started", { sessionId: 11, phaseId: 33 });
+    await harness.dispatch("activity-finished", { sessionId: 11, phaseId: 33 });
+
+    const deletes = harness.requests
+        .filter(request => request.options.method === "DELETE")
+        .map(request => request.pathname);
+
+    assert.deepEqual(deletes, [
+        "/rooms/ethicapp-s11-p22-g301/sessions/active",
+        "/rooms/ethicapp-s11-p22-g302/sessions/active",
+        "/rooms/ethicapp-s11-p33-g301/sessions/active",
+        "/rooms/ethicapp-s11-p33-g302/sessions/active",
+    ]);
+    assert.equal(harness.callbacks.at(-1).hook, "activity-finished");
+    assert.equal(harness.callbacks.at(-1).payload.roomsClosed, 4);
+});
+
+test("activity-finished only closes rooms belonging to the finished session", async () => {
+    const harness = createHarness();
+    await harness.initialize();
+
+    await harness.dispatch("phase-started", { sessionId: 11, phaseId: 22 });
+    await harness.dispatch("phase-started", { sessionId: 12, phaseId: 22 });
+    await harness.dispatch("activity-finished", { sessionId: 11, phaseId: 22 });
+
+    const deletes = harness.requests
+        .filter(request => request.options.method === "DELETE")
+        .map(request => request.pathname);
+
+    assert.ok(deletes.every(pathname => pathname.includes("-s11-")), "should not close other sessions' rooms");
+    assert.equal(harness.callbacks.at(-1).payload.roomsClosed, 2);
+});
+
 test("phase room tracking is scoped by session and phase", async () => {
     const harness = createHarness({
         dependencies: {

--- a/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
+++ b/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
@@ -480,7 +480,7 @@ export async function register({
         });
     });
 
-    subscribe("session-ended", async (context, { callback }) => {
+    subscribe("activity-finished", async (context, { callback }) => {
         const sessionId = Number(context.sessionId);
         let roomsClosed = 0;
 
@@ -510,7 +510,7 @@ export async function register({
 
         await callback({
             serviceId: service.id,
-            hook:      "session-ended",
+            hook:      "activity-finished",
             status:    "completed",
             payload:   { sessionId, roomsClosed },
         });

--- a/ethicapp/backend/external-services/manifest.json
+++ b/ethicapp/backend/external-services/manifest.json
@@ -31,7 +31,7 @@
         "phase-started",
         "phase-ended",
         "callback-received",
-        "session-ended"
+        "activity-finished"
       ],
       "enabled": true,
       "callbackAuth": {

--- a/ethicapp/backend/helpers/__tests__/activity-lifecycle-helper.node-test.mjs
+++ b/ethicapp/backend/helpers/__tests__/activity-lifecycle-helper.node-test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldDispatchActivityStarted, unionEnabledServiceIds } from "../activity-lifecycle-helper.js";
+import * as StatusCodes from "../../../common/modules/session-status.js";
+
+const INITIATED   = StatusCodes.getStatusCode("initiated");
+const IN_PROGRESS = StatusCodes.getStatusCode("in_progress");
+const FINISHED    = StatusCodes.getStatusCode("finished");
+
+test("shouldDispatchActivityStarted: fires when entering in_progress from initiated", () => {
+    assert.equal(shouldDispatchActivityStarted(INITIATED), true);
+});
+
+test("shouldDispatchActivityStarted: fires when previous status is null/unknown", () => {
+    assert.equal(shouldDispatchActivityStarted(null), true);
+});
+
+test("shouldDispatchActivityStarted: does not fire on ordinary phase advance (already in_progress)", () => {
+    assert.equal(shouldDispatchActivityStarted(IN_PROGRESS), false);
+});
+
+test("shouldDispatchActivityStarted: fires when re-opening a finished activity into in_progress", () => {
+    assert.equal(shouldDispatchActivityStarted(FINISHED), true);
+});
+
+test("unionEnabledServiceIds: unions ids across phases and de-duplicates", () => {
+    const phases = [
+        { externalServices: { enabledServiceIds: ["polyadic-devils-advocate"] } },
+        { externalServices: { enabledServiceIds: ["argumentation-tutor-system", "polyadic-devils-advocate"] } },
+        { externalServices: { enabledServiceIds: ["mock-ai-response-review"] } },
+    ];
+    assert.deepEqual(unionEnabledServiceIds(phases), [
+        "polyadic-devils-advocate",
+        "argumentation-tutor-system",
+        "mock-ai-response-review",
+    ]);
+});
+
+test("unionEnabledServiceIds: includes services only enabled in intermediate phases", () => {
+    const phases = [
+        { externalServices: { enabledServiceIds: [] } },
+        { externalServices: { enabledServiceIds: ["polyadic-devils-advocate"] } },
+        { /* final reflection phase, no external services */ },
+    ];
+    assert.deepEqual(unionEnabledServiceIds(phases), ["polyadic-devils-advocate"]);
+});
+
+test("unionEnabledServiceIds: trims and drops empty ids", () => {
+    const phases = [
+        { externalServices: { enabledServiceIds: ["  polyadic-devils-advocate  ", "", "   "] } },
+    ];
+    assert.deepEqual(unionEnabledServiceIds(phases), ["polyadic-devils-advocate"]);
+});
+
+test("unionEnabledServiceIds: returns empty array for missing/invalid phases", () => {
+    assert.deepEqual(unionEnabledServiceIds(undefined), []);
+    assert.deepEqual(unionEnabledServiceIds(null), []);
+    assert.deepEqual(unionEnabledServiceIds([]), []);
+    assert.deepEqual(unionEnabledServiceIds([{}, { externalServices: {} }]), []);
+});

--- a/ethicapp/backend/helpers/activity-lifecycle-helper.js
+++ b/ethicapp/backend/helpers/activity-lifecycle-helper.js
@@ -1,0 +1,56 @@
+import * as StatusCodes from "../../common/modules/session-status.js";
+
+/**
+ * Decides whether the `activity-started` lifecycle hook should fire for a phase
+ * transition.
+ *
+ * The `/phase_transition` route always moves the session into `in_progress`, so
+ * the hook must fire only when the session is *entering* that state (its first
+ * phase) — i.e. when its previous status was not already `in_progress`. This
+ * keeps `activity-started` from firing on ordinary phase-to-phase advances.
+ *
+ * A null/unknown previous status (e.g. a freshly initiated session) counts as
+ * "not in progress", so the hook fires.
+ *
+ * @param {number|null} previousStatus - The session status before the transition.
+ * @returns {boolean} True when `activity-started` should be dispatched.
+ */
+export function shouldDispatchActivityStarted(previousStatus) {
+    const inProgress = StatusCodes.getStatusCode("in_progress");
+    return previousStatus !== inProgress;
+}
+
+/**
+ * Collects the union of enabled external-service ids across every phase of an
+ * activity design.
+ *
+ * This is the resolution used for the `activity-finished` cleanup hook: a service
+ * enabled in *any* phase must be notified when the activity ends, regardless of
+ * which phase it finishes on, so no provider-side state (e.g. open chat rooms)
+ * can leak past the end of the activity.
+ *
+ * @param {Array<Object>} phases - The design's `phases` array.
+ * @returns {string[]} De-duplicated, trimmed list of enabled service ids.
+ */
+export function unionEnabledServiceIds(phases) {
+    const ids = new Set();
+
+    if (!Array.isArray(phases)) {
+        return [];
+    }
+
+    for (const phase of phases) {
+        const enabled = phase?.externalServices?.enabledServiceIds;
+        if (!Array.isArray(enabled)) {
+            continue;
+        }
+        for (const id of enabled) {
+            const trimmed = String(id).trim();
+            if (trimmed) {
+                ids.add(trimmed);
+            }
+        }
+    }
+
+    return Array.from(ids);
+}

--- a/ethicapp/backend/helpers/designs-helper.js
+++ b/ethicapp/backend/helpers/designs-helper.js
@@ -1,5 +1,6 @@
 import * as config from "../config/database.config.js";
 import * as rpg2 from "../db/rest-pg-2.js";
+import { unionEnabledServiceIds } from "./activity-lifecycle-helper.js";
 
 /**
  * Fetches a design from the "designs" table by its ID.
@@ -169,5 +170,45 @@ export async function getPhaseDesignByPhaseId(phaseId) {
         console.error("Error in getPhaseDesignByPhaseId:", error);
         throw new Error("Unable to fetch phase design.");
     }
+}
+
+/**
+ * Fetches the union of enabled external-service ids across all phases of the
+ * activity design bound to a session. Used to resolve the broadcast audience for
+ * the `activity-finished` cleanup hook, so any service enabled in any phase is
+ * notified when the activity ends — regardless of which phase it finishes on.
+ *
+ * Design shape per canonical-schemas/ethicapp-v1.schema.json:
+ * `design.phases[].externalServices.enabledServiceIds`.
+ *
+ * @param {number} sessionId - The session whose activity design is inspected.
+ * @returns {Promise<string[]>} De-duplicated enabled service ids (empty if none).
+ */
+export async function getEnabledExternalServiceIdsBySessionId(sessionId) {
+    const activityResult = await rpg2.singleSQL({
+        dbcon: config.dbconnString,
+        sql: `
+            SELECT design
+            FROM activity
+            WHERE session = $1
+        `,
+        sqlParams: [rpg2.param('plain', sessionId)],
+    });
+
+    if (!activityResult) {
+        return [];
+    }
+
+    const designResult = await rpg2.singleSQL({
+        dbcon: config.dbconnString,
+        sql: `
+            SELECT design
+            FROM designs
+            WHERE id = $1
+        `,
+        sqlParams: [rpg2.param('plain', activityResult.design)],
+    });
+
+    return unionEnabledServiceIds(designResult?.design?.phases);
 }
 


### PR DESCRIPTION
## Summary

Implements #589: two broadcast activity-lifecycle hooks so external-service adapters can react to the boundaries of an activity, and migrates the previous single-service `session-ended` hook to the new model.

- **`activity-started`** — fired on `POST /activities/:id/phase_transition` only when the session enters `in_progress` (its first phase), **not** on ordinary phase-to-phase advances. Lets adapters run preparation/warm-up.
- **`activity-finished`** — fired on `POST /activities/:id/finish`. Lets adapters run cleanup (close rooms, release provider sessions, flush state). Replaces the hardcoded `session-ended` dispatch.

Both dispatch via the broadcast `registry.dispatchHook` and isolate adapter failures from the teacher request.

## Design decisions (agreed during implementation)

| Topic | Decision |
|---|---|
| Old `session-ended` | Removed entirely (no deprecation); polyadic adapter + manifest migrated to `activity-finished`. |
| Dispatch mechanism | Broadcast `dispatchHook`, consistent with `phase-started`/`phase-ended`. |
| `activity-started` trigger | Fires when the prior status was not `in_progress` (`initiated`→`in_progress`), via the pure helper `shouldDispatchActivityStarted`. |
| `activity-started` resolution | Phase-scoped — services enabled in the phase being entered (preparation is phase-relevant). |
| `activity-finished` resolution | **Union of services enabled across all phases** of the activity design. Guarantees no provider-side state (e.g. open chat rooms) leaks past the end of the activity, regardless of which phase it finishes on — including early/incomplete finishes. |

The union resolution closes a real gap: with phase-scoped resolution, finishing on a phase where a room-opening service wasn't enabled (after an earlier `phase-ended` close failed) could leave rooms open. The union audience always reaches every service that could have opened state. Union extraction follows the canonical design schema (`design.phases[].externalServices.enabledServiceIds`, see `canonical-schemas/ethicapp-v1.schema.json`).

## Changes

| File | What changed |
|---|---|
| `controllers/activities/activities-teacher.js` | `dispatchActivityStartedHook` (phase-scoped) + `dispatchActivityFinishedHook` (union); read prior `status` in phase_transition; removed hardcoded `session-ended`. |
| `helpers/activity-lifecycle-helper.js` (new) | Pure `shouldDispatchActivityStarted(previousStatus)` and `unionEnabledServiceIds(phases)`. |
| `helpers/designs-helper.js` | `getEnabledExternalServiceIdsBySessionId(sessionId)`. |
| `external-services/adapters/polyadic-bridge.adapter.js` + `manifest.json` | `session-ended` → `activity-finished`. |
| `EXTERNAL.md`, `external-services/README.md` | Document both hooks, dispatch sources, per-hook resolution, adapter example. |
| Test files | Pure trigger/union helpers; adapter `activity-finished` cleanup (closes every room for the session across phases; session-scoped). |

## Test plan

- [x] `node --test` backend suite green locally (Node 24): 154 tests, 0 failures.
- [x] `activity-started` fires on `initiated`→`in_progress`, skips on ordinary phase advances (unit).
- [x] `unionEnabledServiceIds` unions across phases, includes intermediate-only services, trims, handles invalid input (unit).
- [x] polyadic `activity-finished` closes every room for the session across phases and is session-scoped (adapter test).

## Known limitations (out of scope — polyadic side, not EthicApp)

- Room tracking (`phaseRooms`/`roomContext`) is in-process; a backend restart loses it, so EthicApp can't close pre-restart rooms — a polyadic-agents TTL/expiry would cover this.
- No retry on a failed `DELETE` close call.

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
