### PR TITLE
Resolve participant identity before forwarding to Polyadic Agents (#598)

### DIFF
--- a/deploy/deployment.manifest.example.yml
+++ b/deploy/deployment.manifest.example.yml
@@ -5,64 +5,64 @@ description: >
   with different image tags or digests.
 
 release:
-  id: "staging-uandes-external-services-architecture-2026-06-23"
+  id: "staging-uandes-external-services-architecture-2026-06-25"
   source_repository: "https://github.com/Ethicapp-Development/ethicapp-main"
-  source_ref: "v2026.06.23-esa"
-  source_revision: "63686356be55abf8409a2b871ea2f1bc2cd49775"
+  source_ref: "v2026.06.25-esa"
+  source_revision: "1ac48e48ba299008e3421726a0ce869c8cb55ecc"
   env_contract:
     path: "config/contracts/staging/uandes/external-services-architecture.yml"
-    source_ref: "v2026.06.23-esa"
-    source_revision: "63686356be55abf8409a2b871ea2f1bc2cd49775"
+    source_ref: "v2026.06.25-esa"
+    source_revision: "1ac48e48ba299008e3421726a0ce869c8cb55ecc"
 
 images:
   ethicapp:
     image: "ghcr.io/ethicapp-development/ethicapp"
-    tag: "v2026.06.23-esa"
+    tag: "v2026.06.25-esa"
     digest: ""
-    source_ref: "v2026.06.23-esa"
-    source_revision: "63686356be55abf8409a2b871ea2f1bc2cd49775"
+    source_ref: "v2026.06.25-esa"
+    source_revision: "1ac48e48ba299008e3421726a0ce869c8cb55ecc"
 
   nginx:
     image: "ghcr.io/ethicapp-development/ethicapp-nginx"
-    tag: "v2026.06.23-esa"
+    tag: "v2026.06.25-esa"
     digest: ""
-    source_ref: "v2026.06.23-esa"
-    source_revision: "63686356be55abf8409a2b871ea2f1bc2cd49775"
+    source_ref: "v2026.06.25-esa"
+    source_revision: "1ac48e48ba299008e3421726a0ce869c8cb55ecc"
 
   auth-backend:
     image: "ghcr.io/ethicapp-development/ethicapp-auth-backend"
-    tag: "v2026.06.23-esa"
+    tag: "v2026.06.25-esa"
     digest: ""
-    source_ref: "v2026.06.23-esa"
-    source_revision: "63686356be55abf8409a2b871ea2f1bc2cd49775"
+    source_ref: "v2026.06.25-esa"
+    source_revision: "1ac48e48ba299008e3421726a0ce869c8cb55ecc"
 
   ethicapp-student:
     image: "ghcr.io/ethicapp-development/ethicapp-student"
-    tag: "v2026.06.23-esa"
+    tag: "v2026.06.25-esa"
     digest: ""
-    source_ref: "v2026.06.23-esa"
-    source_revision: "63686356be55abf8409a2b871ea2f1bc2cd49775"
+    source_ref: "v2026.06.25-esa"
+    source_revision: "1ac48e48ba299008e3421726a0ce869c8cb55ecc"
 
   management-console:
     image: "ghcr.io/ethicapp-development/ethicapp-management-console"
-    tag: "v2026.06.23-esa"
+    tag: "v2026.06.25-esa"
     digest: ""
-    source_ref: "v2026.06.23-esa"
-    source_revision: "63686356be55abf8409a2b871ea2f1bc2cd49775"
+    source_ref: "v2026.06.25-esa"
+    source_revision: "1ac48e48ba299008e3421726a0ce869c8cb55ecc"
 
   external-mock-service:
     image: "ghcr.io/ethicapp-development/ethicapp-external-mock-service"
-    tag: "v2026.06.23-esa"
+    tag: "v2026.06.25-esa"
     digest: ""
-    source_ref: "v2026.06.23-esa"
-    source_revision: "63686356be55abf8409a2b871ea2f1bc2cd49775"
+    source_ref: "v2026.06.25-esa"
+    source_revision: "1ac48e48ba299008e3421726a0ce869c8cb55ecc"
 
   db-migrations:
     image: "ghcr.io/ethicapp-development/ethicapp-db-migrations"
-    tag: "v2026.06.23-esa"
+    tag: "v2026.06.25-esa"
     digest: ""
-    source_ref: "v2026.06.23-esa"
-    source_revision: "63686356be55abf8409a2b871ea2f1bc2cd49775"
+    source_ref: "v2026.06.25-esa"
+    source_revision: "1ac48e48ba299008e3421726a0ce869c8cb55ecc"
 
 external_images:
   postgresql:

--- a/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
+++ b/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
@@ -390,6 +390,27 @@ test("chat-message-received forwards firstname for identified phase participants
     assert.equal(harness.callbacks.at(-1).status, "completed");
 });
 
+test("chat-message-received forwards with user-<id> fallback when identity resolution fails", async () => {
+    const harness = createHarness({
+        dependencies: {
+            getTeamIdsForPhase:    async () => [],
+            getParticipantIdentity: async () => {
+                throw new Error("db unavailable");
+            },
+        },
+    });
+    await harness.initialize();
+
+    await harness.dispatch("chat-message-received", {
+        sessionId: 11, phaseId: 22, groupId: 301, userId: 9003,
+        correlationId: "corr-fail-001", content: "Still forwarded",
+    });
+
+    const messageRequest = harness.requests.find(r => r.pathname.includes("/messages"));
+    assert.equal(messageRequest.options.body.username, "user-9003");
+    assert.equal(harness.callbacks.at(-1).status, "completed");
+});
+
 test("phase room tracking is scoped by session and phase", async () => {
     const harness = createHarness({
         dependencies: {

--- a/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
+++ b/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
@@ -6,6 +6,7 @@ import {
     getRoomName,
     parseRoomName,
     register,
+    resolvePolyadicUsername,
 } from "../polyadic-bridge.adapter.js";
 
 function createHarness({ dependencies = {} } = {}) {
@@ -35,6 +36,7 @@ function createHarness({ dependencies = {} } = {}) {
         }),
         getCaseIdBySessionId:   async () => 51,
         getCaseDocumentRawText: async () => "Case text for discussion.",
+        getParticipantIdentity: async () => null,
         ...dependencies,
     };
 
@@ -297,6 +299,95 @@ test("activity-finished only closes rooms belonging to the finished session", as
 
     assert.ok(deletes.every(pathname => pathname.includes("-s11-")), "should not close other sessions' rooms");
     assert.equal(harness.callbacks.at(-1).payload.roomsClosed, 2);
+});
+
+test("resolvePolyadicUsername uses anon_mask for anonymous phases", () => {
+    assert.equal(
+        resolvePolyadicUsername({ phase_anonymous: true, anon_mask: "B", firstname: "Juan", lastname: "García", name: "jgarcia" }, 9001),
+        "B"
+    );
+});
+
+test("resolvePolyadicUsername uses firstname for identified phases", () => {
+    assert.equal(
+        resolvePolyadicUsername({ phase_anonymous: false, anon_mask: "C", firstname: "Ana", lastname: "López", name: "alopez" }, 9002),
+        "Ana"
+    );
+});
+
+test("resolvePolyadicUsername falls back to lastname when firstname is absent", () => {
+    assert.equal(
+        resolvePolyadicUsername({ phase_anonymous: false, anon_mask: null, firstname: "", lastname: "López", name: "alopez" }, 9002),
+        "López"
+    );
+});
+
+test("resolvePolyadicUsername falls back to users.name when firstname and lastname are absent", () => {
+    assert.equal(
+        resolvePolyadicUsername({ phase_anonymous: false, anon_mask: null, firstname: "", lastname: "", name: "alopez" }, 9002),
+        "alopez"
+    );
+});
+
+test("resolvePolyadicUsername falls back to user-<id> when identity is null", () => {
+    assert.equal(resolvePolyadicUsername(null, 9001), "user-9001");
+});
+
+test("resolvePolyadicUsername falls back to user-<id> when anonymous but anon_mask is absent", () => {
+    assert.equal(
+        resolvePolyadicUsername({ phase_anonymous: true, anon_mask: "", firstname: "Juan", lastname: "García", name: "jgarcia" }, 9001),
+        "user-9001"
+    );
+});
+
+test("chat-message-received forwards anon_mask for anonymous phase participants", async () => {
+    const harness = createHarness({
+        dependencies: {
+            getTeamIdsForPhase:    async () => [],
+            getParticipantIdentity: async () => ({
+                phase_anonymous: true,
+                anon_mask:       "A",
+                firstname:       "Juan",
+                lastname:        "García",
+                name:            "jgarcia",
+            }),
+        },
+    });
+    await harness.initialize();
+
+    await harness.dispatch("chat-message-received", {
+        sessionId: 11, phaseId: 22, groupId: 301, userId: 9001,
+        correlationId: "corr-anon-001", content: "My opinion",
+    });
+
+    const messageRequest = harness.requests.find(r => r.pathname.includes("/messages"));
+    assert.equal(messageRequest.options.body.username, "A");
+    assert.equal(harness.callbacks.at(-1).status, "completed");
+});
+
+test("chat-message-received forwards firstname for identified phase participants", async () => {
+    const harness = createHarness({
+        dependencies: {
+            getTeamIdsForPhase:    async () => [],
+            getParticipantIdentity: async () => ({
+                phase_anonymous: false,
+                anon_mask:       "B",
+                firstname:       "Ana",
+                lastname:        "López",
+                name:            "alopez",
+            }),
+        },
+    });
+    await harness.initialize();
+
+    await harness.dispatch("chat-message-received", {
+        sessionId: 11, phaseId: 22, groupId: 301, userId: 9002,
+        correlationId: "corr-ident-001", content: "I think we should act",
+    });
+
+    const messageRequest = harness.requests.find(r => r.pathname.includes("/messages"));
+    assert.equal(messageRequest.options.body.username, "Ana");
+    assert.equal(harness.callbacks.at(-1).status, "completed");
 });
 
 test("phase room tracking is scoped by session and phase", async () => {

--- a/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
+++ b/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
@@ -99,7 +99,7 @@ async function getFirstQuestionIdForPhase(phaseId) {
     return rows.length > 0 ? Number(rows[0].question_id) : null;
 }
 
-async function getParticipantIdentity(groupId, userId, phaseId) {
+async function getParticipantIdentity(groupId, userId) {
     const rows = await rpg2.execSQL({
         sql: `
             SELECT tu.anon_mask,
@@ -109,7 +109,8 @@ async function getParticipantIdentity(groupId, userId, phaseId) {
                    st.anon AS phase_anonymous
             FROM teamusers AS tu
             INNER JOIN users AS u ON u.id = tu.uid
-            INNER JOIN stages AS st ON st.id = $3
+            INNER JOIN teams AS t ON t.id = tu.tmid
+            INNER JOIN stages AS st ON st.id = t.stageid
             WHERE tu.tmid = $1
               AND tu.uid = $2
             LIMIT 1
@@ -118,7 +119,6 @@ async function getParticipantIdentity(groupId, userId, phaseId) {
         sqlParams: [
             rpg2.param("plain", groupId),
             rpg2.param("plain", userId),
-            rpg2.param("plain", phaseId),
         ],
     });
 
@@ -220,17 +220,10 @@ export function resolvePolyadicUsername(identity, userId) {
         return normalizeText(identity.anon_mask) || `user-${userId}`;
     }
 
-    const firstname = normalizeText(identity.firstname);
-    if (firstname) {
-        return firstname;
-    }
-
-    const fullName = `${firstname} ${normalizeText(identity.lastname)}`.trim();
-    if (fullName) {
-        return fullName;
-    }
-
-    return normalizeText(identity.name) || `user-${userId}`;
+    return normalizeText(identity.firstname)
+        || normalizeText(identity.lastname)
+        || normalizeText(identity.name)
+        || `user-${userId}`;
 }
 
 function createDependencies(overrides = {}) {
@@ -415,9 +408,15 @@ export async function register({
             rememberRoomContext(roomName, sessionId, phaseId, groupId, questionId);
         }
 
+        let polyadicUsername = `user-${userId}`;
         try {
-            const identity = await dependencies.getParticipantIdentity(groupId, userId, phaseId);
-            const polyadicUsername = resolvePolyadicUsername(identity, userId);
+            const identity = await dependencies.getParticipantIdentity(groupId, userId);
+            polyadicUsername = resolvePolyadicUsername(identity, userId);
+        } catch (error) {
+            console.warn(`[polyadic-bridge] Failed to resolve participant identity for user ${userId} in ${roomName}; using fallback username.`, error);
+        }
+
+        try {
             await forwardChatMessage(roomName, polyadicUsername, content, correlationId);
             await callback({
                 serviceId: service.id,

--- a/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
+++ b/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
@@ -99,6 +99,32 @@ async function getFirstQuestionIdForPhase(phaseId) {
     return rows.length > 0 ? Number(rows[0].question_id) : null;
 }
 
+async function getParticipantIdentity(groupId, userId, phaseId) {
+    const rows = await rpg2.execSQL({
+        sql: `
+            SELECT tu.anon_mask,
+                   u.firstname,
+                   u.lastname,
+                   u.name,
+                   st.anon AS phase_anonymous
+            FROM teamusers AS tu
+            INNER JOIN users AS u ON u.id = tu.uid
+            INNER JOIN stages AS st ON st.id = $3
+            WHERE tu.tmid = $1
+              AND tu.uid = $2
+            LIMIT 1
+        `,
+        dbcon:     config.dbconnString,
+        sqlParams: [
+            rpg2.param("plain", groupId),
+            rpg2.param("plain", userId),
+            rpg2.param("plain", phaseId),
+        ],
+    });
+
+    return rows.length > 0 ? rows[0] : null;
+}
+
 async function getFirstQuestionForPhase(phaseId) {
     const rows = await rpg2.execSQL({
         sql: `
@@ -185,6 +211,28 @@ async function resolveCaseText(sessionId, dependencies) {
     }
 }
 
+export function resolvePolyadicUsername(identity, userId) {
+    if (!identity) {
+        return `user-${userId}`;
+    }
+
+    if (identity.phase_anonymous) {
+        return normalizeText(identity.anon_mask) || `user-${userId}`;
+    }
+
+    const firstname = normalizeText(identity.firstname);
+    if (firstname) {
+        return firstname;
+    }
+
+    const fullName = `${firstname} ${normalizeText(identity.lastname)}`.trim();
+    if (fullName) {
+        return fullName;
+    }
+
+    return normalizeText(identity.name) || `user-${userId}`;
+}
+
 function createDependencies(overrides = {}) {
     return {
         getTeamIdsForPhase,
@@ -192,6 +240,7 @@ function createDependencies(overrides = {}) {
         getFirstQuestionForPhase,
         getCaseIdBySessionId:   getDefaultCaseIdBySessionId,
         getCaseDocumentRawText: getDefaultCaseDocumentRawText,
+        getParticipantIdentity,
         ...overrides,
     };
 }
@@ -367,7 +416,9 @@ export async function register({
         }
 
         try {
-            await forwardChatMessage(roomName, `user-${userId}`, content, correlationId);
+            const identity = await dependencies.getParticipantIdentity(groupId, userId, phaseId);
+            const polyadicUsername = resolvePolyadicUsername(identity, userId);
+            await forwardChatMessage(roomName, polyadicUsername, content, correlationId);
             await callback({
                 serviceId: service.id,
                 hook:      "chat-message-received",


### PR DESCRIPTION
## Summary

- Adds `getParticipantIdentity(groupId, userId)` DB function in the Polyadic bridge adapter that retrieves `anon_mask`, `firstname`, `lastname`, `name`, and `phase_anonymous` in a single query, joining `stages` via the team's `stageid`.
- Adds exported pure function `resolvePolyadicUsername(identity, userId)`: anonymous phases use `anon_mask`; identified phases prefer `firstname`, fall back to `lastname`, `users.name`, then `user-<id>`.
- Wires both into the `chat-message-received` handler, replacing the hardcoded `user-${userId}`. Identity resolution is fail-soft: a DB error falls back to `user-<id>` instead of dropping the message forward.

## Test plan

- [x] Run `node --test backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs` — all 20 tests pass (6 new for resolver logic, 3 new integration cases: anonymous forwarding, identified forwarding, and identity-failure fallback).
- [x] Verify no real participant names leak when `stages.anon` is true (covered by the anonymous test case).
- [x] Confirm existing tests remain green (fallback `user-<id>` when identity is null, correlation ID behavior, session lifecycle).

Closes #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)