### PR TITLE
Highlight external agent chat messages with pastel-yellow background (#603)

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
@@ -310,6 +310,7 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
             const depth = getMessageDepth(message);
             const replyTarget = Number.isInteger(message.parentId) ? messagesById[message.parentId] ?? null : null;
             const isOwnMessage = message.authorId === Number(userId);
+            const isExternalAgent = message.authorRole === 'external_service';
 
             return (
               <div key={message.id} className={`mb-2 d-flex flex-column ${isOwnMessage ? 'align-items-end' : 'align-items-start'}`} style={{ marginLeft: `${depth * 12}px` }}>
@@ -317,7 +318,7 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
                 {replyTarget ? <div className={`small text-muted mb-1 px-2 ${isOwnMessage ? 'border-end pe-2 text-end' : 'border-start ps-2 text-start'}`}>-&gt; {summarizeMessageForReply(replyTarget)}</div> : null}
                 <div
                   className="rounded px-2 py-1 text-dark border shadow-sm"
-                  style={{ maxWidth: '85%', backgroundColor: isOwnMessage ? '#deffcf' : '#ffffff' }}
+                  style={{ maxWidth: '85%', backgroundColor: isOwnMessage ? '#deffcf' : isExternalAgent ? '#fdf6c3' : '#ffffff' }}
                 >
                   {message.atsFeedback ? <AtsFeedbackBubble feedback={message.atsFeedback} t={t} /> : message.content}
                 </div>

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/teacher-group-chat.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/teacher-group-chat.template.html
@@ -49,6 +49,10 @@
         background-color: #deffcf;
     }
 
+    .teacher-group-chat-bubble-agent {
+        background-color: #fdf6c3;
+    }
+
     .teacher-group-chat-reply-context {
         max-width: 85%;
         margin-bottom: .25em;
@@ -125,7 +129,8 @@
         <div class="teacher-group-chat-bubble"
              ng-class="{
                 'teacher-group-chat-bubble-own': $ctrl.isOwnMessage(message),
-                'teacher-group-chat-bubble-peer': !$ctrl.isOwnMessage(message)
+                'teacher-group-chat-bubble-agent': message.authorRole === 'external_service',
+                'teacher-group-chat-bubble-peer': !$ctrl.isOwnMessage(message) && message.authorRole !== 'external_service'
              }">
             {{ message.content }}
         </div>


### PR DESCRIPTION
## Summary

Renders external service agent chat messages (`authorRole === 'external_service'`) with a pastel-yellow background (`#fdf6c3`), distinct from the user's own messages (green `#deffcf`) and other human participants' messages (white), in **both** chat UIs.

- **Student (React)** — `PhaseChatOverlay.jsx`: adds an `isExternalAgent` flag and a third case to the bubble's inline `backgroundColor`.
- **Teacher (AngularJS)** — `teacher-group-chat.template.html`: adds a `.teacher-group-chat-bubble-agent` CSS rule and a three-way `ng-class` (own / agent / peer). Template is loaded at runtime via `templateUrl`, so **no `dist/teacher-admin.js` rebuild is required**.

`authorRole` already flows through both UIs' message normalization and the backend already tags agent messages (`group-messages.js`), so no backend, data-model, or normalization changes are needed.

## Test plan

- [x] Student chat: an external agent message (e.g. Polyadic ConversationGuide reply) shows a pastel-yellow bubble; own messages stay green, peers stay white.
- [x] Teacher chat: same agent message shows the identical pastel-yellow bubble; own/peer styling unchanged.
- [x] Confirm the yellow tone (`#fdf6c3`) matches across both UIs.

## Out of scope

Explicitly labeling external-agent authors in the teacher UI (parity with the student "External agent" label) is intentionally not included — it would touch a bundled file and require a `dist/teacher-admin.js` rebuild. Tracked as a possible follow-up.

Closes #603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)