### PR TITLE
Send localized agent nickname and conversation language when creating Polyadic rooms

### DIFF
--- a/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
+++ b/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
@@ -7,6 +7,7 @@ import {
     parseRoomName,
     register,
     resolveAgentNickname,
+    resolveConversationLanguage,
     resolvePolyadicUsername,
 } from "../polyadic-bridge.adapter.js";
 
@@ -426,7 +427,20 @@ test("resolveAgentNickname falls back by language prefix and defaults to @agente
     assert.equal(resolveAgentNickname(null), "@agente");
 });
 
-test("phase-started creates rooms with the localized agent nickname (en_US)", async () => {
+test("resolveConversationLanguage returns the LLM-facing language name per language code", () => {
+    assert.equal(resolveConversationLanguage("en_US"), "English");
+    assert.equal(resolveConversationLanguage("es_CL"), "español");
+});
+
+test("resolveConversationLanguage falls back by language prefix and defaults to español", () => {
+    assert.equal(resolveConversationLanguage("en_GB"), "English");
+    assert.equal(resolveConversationLanguage("es_ES"), "español");
+    assert.equal(resolveConversationLanguage("pt_BR"), "español");
+    assert.equal(resolveConversationLanguage(""), "español");
+    assert.equal(resolveConversationLanguage(null), "español");
+});
+
+test("phase-started creates rooms with the localized agent nickname and idioma (en_US)", async () => {
     const harness = createHarness({
         dependencies: {
             getTeamIdsForPhase:     async () => [301],
@@ -439,9 +453,10 @@ test("phase-started creates rooms with the localized agent nickname (en_US)", as
 
     const sessionRequest = harness.requests.find(r => r.pathname.endsWith("/sessions"));
     assert.equal(sessionRequest.options.body.agent_nickname, "@agent");
+    assert.equal(sessionRequest.options.body.idioma, "English");
 });
 
-test("chat-message-received creates a missing room with the localized agent nickname (es_CL)", async () => {
+test("chat-message-received creates a missing room with the localized agent nickname and idioma (es_CL)", async () => {
     const harness = createHarness({
         dependencies: {
             getTeamIdsForPhase:     async () => [],
@@ -457,9 +472,10 @@ test("chat-message-received creates a missing room with the localized agent nick
 
     const sessionRequest = harness.requests.find(r => r.pathname.endsWith("/sessions"));
     assert.equal(sessionRequest.options.body.agent_nickname, "@agente");
+    assert.equal(sessionRequest.options.body.idioma, "español");
 });
 
-test("phase-started falls back to default agent nickname when language resolution fails", async () => {
+test("phase-started falls back to default nickname and idioma when language resolution fails", async () => {
     const harness = createHarness({
         dependencies: {
             getTeamIdsForPhase:     async () => [301],
@@ -474,6 +490,7 @@ test("phase-started falls back to default agent nickname when language resolutio
 
     const sessionRequest = harness.requests.find(r => r.pathname.endsWith("/sessions"));
     assert.equal(sessionRequest.options.body.agent_nickname, "@agente");
+    assert.equal(sessionRequest.options.body.idioma, "español");
 });
 
 test("phase room tracking is scoped by session and phase", async () => {

--- a/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
+++ b/ethicapp/backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs
@@ -6,6 +6,7 @@ import {
     getRoomName,
     parseRoomName,
     register,
+    resolveAgentNickname,
     resolvePolyadicUsername,
 } from "../polyadic-bridge.adapter.js";
 
@@ -37,6 +38,7 @@ function createHarness({ dependencies = {} } = {}) {
         getCaseIdBySessionId:   async () => 51,
         getCaseDocumentRawText: async () => "Case text for discussion.",
         getParticipantIdentity: async () => null,
+        getSessionLanguageCode: async () => "es_CL",
         ...dependencies,
     };
 
@@ -409,6 +411,69 @@ test("chat-message-received forwards with user-<id> fallback when identity resol
     const messageRequest = harness.requests.find(r => r.pathname.includes("/messages"));
     assert.equal(messageRequest.options.body.username, "user-9003");
     assert.equal(harness.callbacks.at(-1).status, "completed");
+});
+
+test("resolveAgentNickname returns localized nickname per language code", () => {
+    assert.equal(resolveAgentNickname("en_US"), "@agent");
+    assert.equal(resolveAgentNickname("es_CL"), "@agente");
+});
+
+test("resolveAgentNickname falls back by language prefix and defaults to @agente", () => {
+    assert.equal(resolveAgentNickname("en_GB"), "@agent");
+    assert.equal(resolveAgentNickname("es_ES"), "@agente");
+    assert.equal(resolveAgentNickname("pt_BR"), "@agente");
+    assert.equal(resolveAgentNickname(""), "@agente");
+    assert.equal(resolveAgentNickname(null), "@agente");
+});
+
+test("phase-started creates rooms with the localized agent nickname (en_US)", async () => {
+    const harness = createHarness({
+        dependencies: {
+            getTeamIdsForPhase:     async () => [301],
+            getSessionLanguageCode: async () => "en_US",
+        },
+    });
+    await harness.initialize();
+
+    await harness.dispatch("phase-started", { sessionId: 11, phaseId: 22 });
+
+    const sessionRequest = harness.requests.find(r => r.pathname.endsWith("/sessions"));
+    assert.equal(sessionRequest.options.body.agent_nickname, "@agent");
+});
+
+test("chat-message-received creates a missing room with the localized agent nickname (es_CL)", async () => {
+    const harness = createHarness({
+        dependencies: {
+            getTeamIdsForPhase:     async () => [],
+            getSessionLanguageCode: async () => "es_CL",
+        },
+    });
+    await harness.initialize();
+
+    await harness.dispatch("chat-message-received", {
+        sessionId: 11, phaseId: 22, groupId: 301, userId: 9001,
+        correlationId: "corr-lang-001", content: "Hola",
+    });
+
+    const sessionRequest = harness.requests.find(r => r.pathname.endsWith("/sessions"));
+    assert.equal(sessionRequest.options.body.agent_nickname, "@agente");
+});
+
+test("phase-started falls back to default agent nickname when language resolution fails", async () => {
+    const harness = createHarness({
+        dependencies: {
+            getTeamIdsForPhase:     async () => [301],
+            getSessionLanguageCode: async () => {
+                throw new Error("db unavailable");
+            },
+        },
+    });
+    await harness.initialize();
+
+    await harness.dispatch("phase-started", { sessionId: 11, phaseId: 22 });
+
+    const sessionRequest = harness.requests.find(r => r.pathname.endsWith("/sessions"));
+    assert.equal(sessionRequest.options.body.agent_nickname, "@agente");
 });
 
 test("phase room tracking is scoped by session and phase", async () => {

--- a/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
+++ b/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
@@ -211,6 +211,37 @@ async function resolveCaseText(sessionId, dependencies) {
     }
 }
 
+async function getSessionLanguageCode(sessionId) {
+    const row = await rpg2.singleSQL({
+        sql: `
+            SELECT d.language_code
+            FROM activity AS a
+            INNER JOIN designs AS d ON d.id = a.design
+            WHERE a.session = $1
+            LIMIT 1
+        `,
+        dbcon:     config.dbconnString,
+        sqlParams: [rpg2.param("plain", sessionId)],
+    });
+
+    return row?.language_code ? normalizeText(row.language_code) : null;
+}
+
+const AGENT_NICKNAMES = {
+    en_US: "@agent",
+    es_CL: "@agente",
+};
+const DEFAULT_AGENT_NICKNAME = AGENT_NICKNAMES.es_CL;
+
+export function resolveAgentNickname(languageCode) {
+    const normalized = normalizeText(languageCode);
+    if (AGENT_NICKNAMES[normalized]) {
+        return AGENT_NICKNAMES[normalized];
+    }
+
+    return normalized.toLowerCase().startsWith("en") ? AGENT_NICKNAMES.en_US : DEFAULT_AGENT_NICKNAME;
+}
+
 export function resolvePolyadicUsername(identity, userId) {
     if (!identity) {
         return `user-${userId}`;
@@ -234,6 +265,7 @@ function createDependencies(overrides = {}) {
         getCaseIdBySessionId:   getDefaultCaseIdBySessionId,
         getCaseDocumentRawText: getDefaultCaseDocumentRawText,
         getParticipantIdentity,
+        getSessionLanguageCode,
         ...overrides,
     };
 }
@@ -247,12 +279,13 @@ async function requestPolyadicJson(pathname, { method = "GET", body = null } = {
     });
 }
 
-async function ensurePolyadicSession(roomName, topic) {
+async function ensurePolyadicSession(roomName, topic, agentNickname) {
     await requestPolyadicJson(`/rooms/${encodeURIComponent(roomName)}/sessions`, {
         method: "POST",
         body:   {
             prompt_inicial: topic || "EthicApp discussion",
             pipeline_type:  getPipelineType(),
+            agent_nickname: agentNickname || DEFAULT_AGENT_NICKNAME,
         },
     });
 
@@ -308,24 +341,36 @@ export async function register({
         return context;
     }
 
+    async function resolveAgentNicknameForSession(sessionId) {
+        try {
+            const languageCode = await dependencies.getSessionLanguageCode(sessionId);
+            return resolveAgentNickname(languageCode);
+        } catch (error) {
+            console.warn(`[polyadic-bridge] Unable to resolve conversation language for session ${sessionId}; using default agent nickname.`, error);
+            return DEFAULT_AGENT_NICKNAME;
+        }
+    }
+
     async function buildTopicForPhase(sessionId, phaseId) {
         const caseText = await resolveCaseText(sessionId, dependencies);
         const question = await dependencies.getFirstQuestionForPhase(phaseId);
         const questionText = formatQuestionText(question);
         const fallbackTopic = `EthicApp session ${sessionId} phase ${phaseId}`;
+        const agentNickname = await resolveAgentNicknameForSession(sessionId);
 
         return {
             questionId: question?.id ?? null,
             topic:      composeTopic(caseText || fallbackTopic, questionText),
+            agentNickname,
         };
     }
 
-    async function createRoom({ sessionId, phaseId, groupId, questionId, topic }) {
+    async function createRoom({ sessionId, phaseId, groupId, questionId, topic, agentNickname }) {
         const roomName = getRoomName(sessionId, phaseId, groupId);
         rememberRoomContext(roomName, sessionId, phaseId, groupId, questionId);
 
         try {
-            await ensurePolyadicSession(roomName, topic);
+            await ensurePolyadicSession(roomName, topic, agentNickname);
             return roomName;
         } catch (error) {
             roomContext.delete(roomName);
@@ -337,11 +382,11 @@ export async function register({
     subscribe("phase-started", async (context, { callback }) => {
         const { sessionId, phaseId } = context;
         const teamIds = await dependencies.getTeamIdsForPhase(sessionId, phaseId);
-        const { questionId, topic } = await buildTopicForPhase(sessionId, phaseId);
+        const { questionId, topic, agentNickname } = await buildTopicForPhase(sessionId, phaseId);
         const createdRooms = new Set();
 
         for (const groupId of teamIds) {
-            const roomName = await createRoom({ sessionId, phaseId, groupId, questionId, topic });
+            const roomName = await createRoom({ sessionId, phaseId, groupId, questionId, topic, agentNickname });
             if (roomName) {
                 createdRooms.add(roomName);
             }
@@ -389,8 +434,9 @@ export async function register({
                 sessionId,
                 phaseId,
                 groupId,
-                questionId: questionId ?? topicData.questionId,
-                topic:      topicData.topic,
+                questionId:    questionId ?? topicData.questionId,
+                topic:         topicData.topic,
+                agentNickname: topicData.agentNickname,
             });
 
             if (!createdRoom) {

--- a/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
+++ b/ethicapp/backend/external-services/adapters/polyadic-bridge.adapter.js
@@ -233,13 +233,32 @@ const AGENT_NICKNAMES = {
 };
 const DEFAULT_AGENT_NICKNAME = AGENT_NICKNAMES.es_CL;
 
+const CONVERSATION_LANGUAGES = {
+    en_US: "English",
+    es_CL: "español",
+};
+const DEFAULT_CONVERSATION_LANGUAGE = CONVERSATION_LANGUAGES.es_CL;
+
+function isEnglishLanguageCode(languageCode) {
+    return normalizeText(languageCode).toLowerCase().startsWith("en");
+}
+
 export function resolveAgentNickname(languageCode) {
     const normalized = normalizeText(languageCode);
     if (AGENT_NICKNAMES[normalized]) {
         return AGENT_NICKNAMES[normalized];
     }
 
-    return normalized.toLowerCase().startsWith("en") ? AGENT_NICKNAMES.en_US : DEFAULT_AGENT_NICKNAME;
+    return isEnglishLanguageCode(normalized) ? AGENT_NICKNAMES.en_US : DEFAULT_AGENT_NICKNAME;
+}
+
+export function resolveConversationLanguage(languageCode) {
+    const normalized = normalizeText(languageCode);
+    if (CONVERSATION_LANGUAGES[normalized]) {
+        return CONVERSATION_LANGUAGES[normalized];
+    }
+
+    return isEnglishLanguageCode(normalized) ? CONVERSATION_LANGUAGES.en_US : DEFAULT_CONVERSATION_LANGUAGE;
 }
 
 export function resolvePolyadicUsername(identity, userId) {
@@ -279,13 +298,14 @@ async function requestPolyadicJson(pathname, { method = "GET", body = null } = {
     });
 }
 
-async function ensurePolyadicSession(roomName, topic, agentNickname) {
+async function ensurePolyadicSession(roomName, topic, agentNickname, idioma) {
     await requestPolyadicJson(`/rooms/${encodeURIComponent(roomName)}/sessions`, {
         method: "POST",
         body:   {
             prompt_inicial: topic || "EthicApp discussion",
             pipeline_type:  getPipelineType(),
             agent_nickname: agentNickname || DEFAULT_AGENT_NICKNAME,
+            idioma:         idioma || DEFAULT_CONVERSATION_LANGUAGE,
         },
     });
 
@@ -341,13 +361,19 @@ export async function register({
         return context;
     }
 
-    async function resolveAgentNicknameForSession(sessionId) {
+    async function resolveSessionLanguageContext(sessionId) {
         try {
             const languageCode = await dependencies.getSessionLanguageCode(sessionId);
-            return resolveAgentNickname(languageCode);
+            return {
+                agentNickname: resolveAgentNickname(languageCode),
+                idioma:        resolveConversationLanguage(languageCode),
+            };
         } catch (error) {
-            console.warn(`[polyadic-bridge] Unable to resolve conversation language for session ${sessionId}; using default agent nickname.`, error);
-            return DEFAULT_AGENT_NICKNAME;
+            console.warn(`[polyadic-bridge] Unable to resolve conversation language for session ${sessionId}; using defaults.`, error);
+            return {
+                agentNickname: DEFAULT_AGENT_NICKNAME,
+                idioma:        DEFAULT_CONVERSATION_LANGUAGE,
+            };
         }
     }
 
@@ -356,21 +382,22 @@ export async function register({
         const question = await dependencies.getFirstQuestionForPhase(phaseId);
         const questionText = formatQuestionText(question);
         const fallbackTopic = `EthicApp session ${sessionId} phase ${phaseId}`;
-        const agentNickname = await resolveAgentNicknameForSession(sessionId);
+        const { agentNickname, idioma } = await resolveSessionLanguageContext(sessionId);
 
         return {
             questionId: question?.id ?? null,
             topic:      composeTopic(caseText || fallbackTopic, questionText),
             agentNickname,
+            idioma,
         };
     }
 
-    async function createRoom({ sessionId, phaseId, groupId, questionId, topic, agentNickname }) {
+    async function createRoom({ sessionId, phaseId, groupId, questionId, topic, agentNickname, idioma }) {
         const roomName = getRoomName(sessionId, phaseId, groupId);
         rememberRoomContext(roomName, sessionId, phaseId, groupId, questionId);
 
         try {
-            await ensurePolyadicSession(roomName, topic, agentNickname);
+            await ensurePolyadicSession(roomName, topic, agentNickname, idioma);
             return roomName;
         } catch (error) {
             roomContext.delete(roomName);
@@ -382,11 +409,11 @@ export async function register({
     subscribe("phase-started", async (context, { callback }) => {
         const { sessionId, phaseId } = context;
         const teamIds = await dependencies.getTeamIdsForPhase(sessionId, phaseId);
-        const { questionId, topic, agentNickname } = await buildTopicForPhase(sessionId, phaseId);
+        const { questionId, topic, agentNickname, idioma } = await buildTopicForPhase(sessionId, phaseId);
         const createdRooms = new Set();
 
         for (const groupId of teamIds) {
-            const roomName = await createRoom({ sessionId, phaseId, groupId, questionId, topic, agentNickname });
+            const roomName = await createRoom({ sessionId, phaseId, groupId, questionId, topic, agentNickname, idioma });
             if (roomName) {
                 createdRooms.add(roomName);
             }
@@ -437,6 +464,7 @@ export async function register({
                 questionId:    questionId ?? topicData.questionId,
                 topic:         topicData.topic,
                 agentNickname: topicData.agentNickname,
+                idioma:        topicData.idioma,
             });
 
             if (!createdRoom) {


### PR DESCRIPTION
## Summary

When the Polyadic bridge creates a room/session, it now sends both a localized agent nickname and the conversation language, so the agent is addressed naturally and converses in the activity's language.

- Resolves the conversation language from `designs.language_code` for the session (same `activity → designs` join already used by `getCaseIdBySessionId`), in a single lookup shared by both resolvers.
- `resolveAgentNickname` → `@agent` for `en_US`, `@agente` for `es_CL` (language-prefix fallback, default `@agente`). Sent as `agent_nickname`.
- `resolveConversationLanguage` → `English` for `en_US`, `español` for `es_CL` (language-prefix fallback, default `español`). Sent as `idioma`, which Polyadic injects into the agent prompt as the output language.
- Both `agent_nickname` and `idioma` are fields the Polyadic Agents API **already accepts** (`polyadic-agents/backend/app/main.py`), so no change is needed on the Polyadic side.
- Language resolution is fail-soft: a DB error falls back to the default nickname and language instead of blocking room creation.

No backend schema or Polyadic-service changes required.

## Test plan

- [ ] `node --test backend/external-services/adapters/__tests__/polyadic-bridge.adapter.node-test.mjs` — all 27 tests pass (4 new resolver unit tests, 3 integration cases asserting both `agent_nickname` and `idioma`: en_US, es_CL, and language-resolution failure fallback).
- [ ] Confirm `phase-started` and `chat-message-received` (missing-room path) both send `agent_nickname` and `idioma` in the session-creation body.
- [ ] Confirm existing session/message/lifecycle behavior is otherwise unchanged.

## Notes

- Defaults (`@agente` / `español`) are aligned with the content default language (`es_CL`). Easy to flip if `en_US` is preferred as the global default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)