### PR TITLE
Show 24h message time in student and teacher group chats

### DIFF
--- a/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
+++ b/ethicapp-student/frontend/src/components/session-detail/phases/PhaseChatOverlay.jsx
@@ -87,7 +87,7 @@ function normalizeMessage(message) {
   const externalServiceId = message?.external_service_id ?? message?.externalServiceId ?? '';
   const content = typeof message?.content === 'string' ? message.content.trim() : '';
   const atsFeedback = parseAtsFeedbackPayload(content);
-  const createdAt = message?.date ?? message?.created_at ?? message?.createdAt ?? '';
+  const createdAt = message?.stime ?? message?.date ?? message?.created_at ?? message?.createdAt ?? '';
   const parentId = Number(message?.parent_id ?? message?.parentId);
 
   return {
@@ -101,6 +101,19 @@ function normalizeMessage(message) {
     createdAt: typeof createdAt === 'string' ? createdAt : '',
     parentId: Number.isInteger(parentId) ? parentId : null
   };
+}
+
+function formatMessageTime(value) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return '';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
 }
 
 function summarizeMessageForReply(message) {
@@ -311,10 +324,14 @@ export default function PhaseChatOverlay({ isOpen, onClose, onHeightChange, phas
             const replyTarget = Number.isInteger(message.parentId) ? messagesById[message.parentId] ?? null : null;
             const isOwnMessage = message.authorId === Number(userId);
             const isExternalAgent = message.authorRole === 'external_service';
+            const messageTime = formatMessageTime(message.createdAt);
 
             return (
               <div key={message.id} className={`mb-2 d-flex flex-column ${isOwnMessage ? 'align-items-end' : 'align-items-start'}`} style={{ marginLeft: `${depth * 12}px` }}>
-                <small className="text-muted d-block">{isOwnMessage ? t('sessionDetail.chatYouAuthor') : resolveDisplayName(message, participantsByUserId, isAnonymousPhase, t)}</small>
+                <small className="text-muted d-block">
+                  {isOwnMessage ? t('sessionDetail.chatYouAuthor') : resolveDisplayName(message, participantsByUserId, isAnonymousPhase, t)}
+                  {messageTime ? <span className="ms-1">{messageTime}</span> : null}
+                </small>
                 {replyTarget ? <div className={`small text-muted mb-1 px-2 ${isOwnMessage ? 'border-end pe-2 text-end' : 'border-start ps-2 text-start'}`}>-&gt; {summarizeMessageForReply(replyTarget)}</div> : null}
                 <div
                   className="rounded px-2 py-1 text-dark border shadow-sm"

--- a/ethicapp/frontend/assets/static/views/teacher/fragments/teacher-group-chat.template.html
+++ b/ethicapp/frontend/assets/static/views/teacher/fragments/teacher-group-chat.template.html
@@ -119,7 +119,7 @@
          ng-repeat="message in $ctrl.getMessages() track by message.id">
         <small class="text-muted teacher-group-chat-message-meta">
             {{ $ctrl.getChatAuthorName(message) }}
-            <span>{{ message.stime | date:'short' }}</span>
+            <span>{{ message.stime | date:'HH:mm' }}</span>
         </small>
         <div class="teacher-group-chat-reply-context"
              ng-if="$ctrl.getReplyTarget(message)">


### PR DESCRIPTION
## Summary

Group chat messages now show only the **message time in 24-hour format** (`HH:mm`), without the date, in both chat UIs.

- **Teacher (AngularJS)** — `teacher-group-chat.template.html`: the meta line's date filter changes from `date:'short'` (locale date + time, often 12h) to `date:'HH:mm'`. Template-only; no `dist` rebuild required.
- **Student (React)** — `PhaseChatOverlay.jsx`:
  - Adds a `formatMessageTime` helper that renders `HH:mm` (24h, `hour12: false`) and gracefully returns nothing for missing/invalid timestamps.
  - Renders the time next to the author name in the message meta line.
  - Fixes a latent gap: the student view previously normalized `createdAt` from `date`/`created_at`/`createdAt`, none of which the transcript returns — the backend timestamp column is `stime`. `normalizeMessage` now reads `stime` first, so the time is actually populated.

No backend or data changes.

## Test plan

- [x] Student frontend builds clean (`vite build`).
- [ ] Student chat: each message shows `HH:mm` (24h) next to the author; no date shown.
- [ ] Teacher chat: each message shows `HH:mm` (24h); no date shown.
- [ ] Messages with a missing/invalid timestamp render without a time and without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)