### PR TITLE
Fix group chat message counts on dashboard refresh

### DIFF
--- a/ethicapp/frontend/assets/js/helpers/__tests__/dashboard-data-joiners.node-test.mjs
+++ b/ethicapp/frontend/assets/js/helpers/__tests__/dashboard-data-joiners.node-test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { DashboardDataJoiners } from "../dashboard-data-joiners.js";
+
+const phaseDescriptor = {
+    number:    1,
+    questions: [{ id: 11, number: 1 }],
+};
+
+describe("dashboard data joiners", () => {
+    it("replaces ranking chat totals when refreshing existing phase data", () => {
+        const users = [{ id: 1, name: "Ada", role: "A" }];
+        const chats = [{ userId: 1, messageCount: 3 }];
+
+        const initialState = DashboardDataJoiners.ranking.joinPhaseData(
+            phaseDescriptor, [], users, chats
+        );
+        const refreshedState = DashboardDataJoiners.ranking.joinPhaseData(
+            phaseDescriptor, [], users, chats, initialState
+        );
+
+        assert.equal(refreshedState[0].chatCount, 3);
+
+        const updatedState = DashboardDataJoiners.ranking.joinPhaseData(
+            phaseDescriptor, [], users, [{ userId: 1, messageCount: 4 }], refreshedState
+        );
+
+        assert.equal(updatedState[0].chatCount, 4);
+    });
+
+    it("replaces external group chat totals when refreshing group statistics", () => {
+        const phaseState = [{
+            userId:      1,
+            userName:    "Ada",
+            groupId:     7,
+            groupNumber: 1,
+        }];
+        const chats = [{
+            userId:       2,
+            teamId:       7,
+            questionId:   11,
+            messageCount: 5,
+        }];
+
+        DashboardDataJoiners.semantic_differential.addExternalGroupChatInfo(
+            phaseState, chats, phaseDescriptor.questions
+        );
+        const firstRefresh = DashboardDataJoiners.semantic_differential.updateGroupStatistics(
+            phaseState, () => "Group"
+        );
+
+        DashboardDataJoiners.semantic_differential.addExternalGroupChatInfo(
+            firstRefresh, chats, phaseDescriptor.questions
+        );
+        const secondRefresh = DashboardDataJoiners.semantic_differential.updateGroupStatistics(
+            firstRefresh, () => "Group"
+        );
+        const groupSummary = secondRefresh.find(user => user.groupStatistics);
+
+        assert.equal(groupSummary.chatR1, 5);
+        assert.equal(groupSummary.totalChatCount, 5);
+    });
+});

--- a/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
+++ b/ethicapp/frontend/assets/js/helpers/dashboard-data-joiners.js
@@ -163,6 +163,16 @@ let rankingPhaseDataJoiner = (phaseDescriptor, responses, users,
         }
     });
 
+    // Sum the current cumulative chat counts before merging with persisted data.
+    // The API returns totals rather than deltas, so these values must replace
+    // any counts from a previous dashboard refresh.
+    relevantChats.forEach(chat => {
+        const user = usersMap[chat.uid || chat.userId];
+        if (user) {
+            user.chatCount += Number(chat.messageCount || 0);
+        }
+    });
+
     // If no existingData is provided, build the structure from scratch
     if (!existingData) {
         // Assign responses and chat statistics for each user
@@ -172,14 +182,6 @@ let rankingPhaseDataJoiner = (phaseDescriptor, responses, users,
                 // Assign the ranked item description and actor ID to the respective order
                 user[`r${response.orden}`] = response.description || null;
                 user[`idR${response.orden}`] = response.actorid || null;
-            }
-        });
-
-        // Sum up chat counts for each user
-        relevantChats.forEach(chat => {
-            const user = usersMap[chat.uid || chat.userId];
-            if (user) {
-                user.chatCount += chat.messageCount || 0;
             }
         });
 
@@ -207,6 +209,8 @@ let rankingPhaseDataJoiner = (phaseDescriptor, responses, users,
             existingDataMap[user.uid] = user; // Add new users
         } else {
             const existingUser = existingDataMap[user.uid];
+            existingUser.chatCount = user.chatCount;
+
             // Update ranked items and actor IDs
             responses
                 .filter(response => response.uid === user.uid)
@@ -215,12 +219,6 @@ let rankingPhaseDataJoiner = (phaseDescriptor, responses, users,
                     existingUser[`idR${response.orden}`] = response.actorid || null;
                 });
 
-            // Update chat counts
-            relevantChats
-                .filter(chat => (chat.uid || chat.userId) === user.uid)
-                .forEach(chat => {
-                    existingUser.chatCount += chat.messageCount || 0;
-                });
         }
     });
 
@@ -309,6 +307,14 @@ function addExternalGroupChatInfo(phaseState, chatMessageCount, questions) {
         acc[Number(question.id)] = question;
         return acc;
     }, {});
+
+    phaseState
+        .filter(user => !user.groupStatistics)
+        .forEach(user => {
+            (questions || []).forEach(question => {
+                user[`__groupChatR${question.number}`] = 0;
+            });
+        });
 
     (chatMessageCount || []).forEach(chat => {
         if (usersById.has(Number(chat.userId))) {


### PR DESCRIPTION
## Context

Fixes #609: group-phase chat message counts were inflated on every dashboard refresh because the cumulative count was added to the prior phase state.

## Changes

- Recalculate and replace the per-user chat total for ranking phases.
- Reset and rebuild per-question external group-chat accumulators for group phases.
- Add regression tests covering consecutive ranking and group-statistics refreshes.

## Impact and root cause

`getChatMessageCount` returns cumulative counts. Because the phase state is reused on each refresh, counts must overwrite the prior values instead of being added to them.

## Verification

- `node --test ethicapp/frontend/assets/js/helpers/__tests__/dashboard-data-joiners.node-test.mjs ethicapp/frontend/assets/js/helpers/__tests__/phase-validation-helpers.node-test.mjs`
- `npm run lint-js`

## Limitations

`ethicapp/frontend` does not define a `build` script. Asset compilation is performed through the repository asset-build workflow and CI.