### PR TITLE
Fix duplicated rows in CSV report exports

### DIFF
--- a/ethicapp/backend/controllers/activities/__tests__/reports.node-test.mjs
+++ b/ethicapp/backend/controllers/activities/__tests__/reports.node-test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    buildSemanticDifferentialChatTranscriptSql,
+    buildSemanticDifferentialResponsesReportSql,
+} from "../report-query-builders.js";
+
+test("responses report resolves at most one team for each source row", () => {
+    const sql = buildSemanticDifferentialResponsesReportSql();
+
+    assert.doesNotMatch(sql, /LEFT JOIN teams AS t/);
+    assert.match(sql, /SELECT tu\.tmid[\s\S]*tu\.uid = ds\.uid/);
+    assert.match(sql, /t\.sesid = st\.sesid[\s\S]*t\.stageid = st\.id/);
+    assert.match(sql, /ORDER BY tu\.tmid[\s\S]*LIMIT 1[\s\S]*\) AS team_id/);
+});
+
+test("chat transcript preserves its recorded team and avoids phase-wide team joins", () => {
+    const sql = buildSemanticDifferentialChatTranscriptSql();
+
+    assert.doesNotMatch(sql, /LEFT JOIN teams AS t/);
+    assert.match(sql, /COALESCE\(dc\.tmid, \([\s\S]*tu\.uid = dc\.uid/);
+    assert.match(sql, /t\.sesid = st\.sesid[\s\S]*t\.stageid = st\.id/);
+    assert.match(sql, /ORDER BY tu\.tmid[\s\S]*LIMIT 1[\s\S]*\)\) AS team_id/);
+});

--- a/ethicapp/backend/controllers/activities/report-query-builders.js
+++ b/ethicapp/backend/controllers/activities/report-query-builders.js
@@ -1,0 +1,78 @@
+export function buildSemanticDifferentialResponsesReportSql() {
+    return `
+        SELECT
+            ds.id,
+            ds.uid AS user_id,
+            (
+                SELECT tu.tmid
+                FROM teamusers AS tu
+                INNER JOIN teams AS t
+                    ON t.id = tu.tmid
+                WHERE tu.uid = ds.uid
+                  AND t.sesid = st.sesid
+                  AND t.stageid = st.id
+                ORDER BY tu.tmid
+                LIMIT 1
+            ) AS team_id,
+            u.name,
+            u.rut,
+            u.sex AS gender,
+            d.orden AS question_number,
+            d.title AS question_text,
+            d.tleft AS left_pole,
+            d.tright AS right_pole,
+            d.num AS max_scale_range,
+            ds.sel AS selected_value,
+            ds.comment,
+            st.number AS phase_number,
+            ds.stime AS time
+        FROM differential_selection AS ds
+        INNER JOIN differential AS d
+            ON ds.did = d.id
+        INNER JOIN stages AS st
+            ON d.stageid = st.id
+        INNER JOIN users AS u
+            ON ds.uid = u.id
+        WHERE st.sesid = $1
+        ORDER BY st.number, d.orden, u.name, ds.id
+    `;
+}
+
+export function buildSemanticDifferentialChatTranscriptSql() {
+    return `
+        SELECT
+            dc.id,
+            dc.uid AS user_id,
+            COALESCE(dc.tmid, (
+                SELECT tu.tmid
+                FROM teamusers AS tu
+                INNER JOIN teams AS t
+                    ON t.id = tu.tmid
+                WHERE tu.uid = dc.uid
+                  AND t.sesid = st.sesid
+                  AND t.stageid = st.id
+                ORDER BY tu.tmid
+                LIMIT 1
+            )) AS team_id,
+            u.name,
+            u.rut,
+            u.sex AS gender,
+            d.orden AS question_number,
+            d.title AS question_text,
+            d.tleft AS left_pole,
+            d.tright AS right_pole,
+            dc.content AS message,
+            st.number AS phase_number,
+            dc.stime AS time,
+            dc.parent_id AS reply_to
+        FROM differential_chat AS dc
+        INNER JOIN differential AS d
+            ON dc.did = d.id
+        INNER JOIN stages AS st
+            ON d.stageid = st.id
+        INNER JOIN users AS u
+            ON dc.uid = u.id
+        WHERE st.sesid = $1
+        ORDER BY st.number, d.orden, team_id, dc.stime, dc.id
+    `;
+}

--- a/ethicapp/backend/controllers/activities/reports.js
+++ b/ethicapp/backend/controllers/activities/reports.js
@@ -11,6 +11,10 @@ import {
     markActivityReportExportFailed,
 } from "../../helpers/activity-report-audit-helper.js";
 import { getDesignTypeBySessionId } from "./activities-common.js";
+import {
+    buildSemanticDifferentialChatTranscriptSql,
+    buildSemanticDifferentialResponsesReportSql,
+} from "./report-query-builders.js";
 
 const router = express.Router();
 const REPORT_NOT_IMPLEMENTED = "REPORT_NOT_IMPLEMENTED";
@@ -163,39 +167,7 @@ function hashContent(content) {
 async function buildSemanticDifferentialResponsesReport(context) {
     const rows = await rpg2.execSQL({
         dbcon: config.dbconnString,
-        sql: `
-            SELECT
-                ds.id,
-                ds.uid AS user_id,
-                tu.tmid AS team_id,
-                u.name,
-                u.rut,
-                u.sex AS gender,
-                d.orden AS question_number,
-                d.title AS question_text,
-                d.tleft AS left_pole,
-                d.tright AS right_pole,
-                d.num AS max_scale_range,
-                ds.sel AS selected_value,
-                ds.comment,
-                st.number AS phase_number,
-                ds.stime AS time
-            FROM differential_selection AS ds
-            INNER JOIN differential AS d
-                ON ds.did = d.id
-            INNER JOIN stages AS st
-                ON d.stageid = st.id
-            INNER JOIN users AS u
-                ON ds.uid = u.id
-            LEFT JOIN teams AS t
-                ON t.sesid = st.sesid
-               AND t.stageid = st.id
-            LEFT JOIN teamusers AS tu
-                ON tu.tmid = t.id
-               AND tu.uid = ds.uid
-            WHERE st.sesid = $1
-            ORDER BY st.number, d.orden, u.name, ds.id
-        `,
+        sql: buildSemanticDifferentialResponsesReportSql(),
         sqlParams: [rpg2.param("plain", context.sessionId)],
     });
 
@@ -214,38 +186,7 @@ async function buildSemanticDifferentialResponsesReport(context) {
 async function buildSemanticDifferentialChatTranscript(context) {
     const rows = await rpg2.execSQL({
         dbcon: config.dbconnString,
-        sql: `
-            SELECT
-                dc.id,
-                dc.uid AS user_id,
-                COALESCE(dc.tmid, tu.tmid) AS team_id,
-                u.name,
-                u.rut,
-                u.sex AS gender,
-                d.orden AS question_number,
-                d.title AS question_text,
-                d.tleft AS left_pole,
-                d.tright AS right_pole,
-                dc.content AS message,
-                st.number AS phase_number,
-                dc.stime AS time,
-                dc.parent_id AS reply_to
-            FROM differential_chat AS dc
-            INNER JOIN differential AS d
-                ON dc.did = d.id
-            INNER JOIN stages AS st
-                ON d.stageid = st.id
-            INNER JOIN users AS u
-                ON dc.uid = u.id
-            LEFT JOIN teams AS t
-                ON t.sesid = st.sesid
-               AND t.stageid = st.id
-            LEFT JOIN teamusers AS tu
-                ON tu.tmid = t.id
-               AND tu.uid = dc.uid
-            WHERE st.sesid = $1
-            ORDER BY st.number, d.orden, team_id, dc.stime, dc.id
-        `,
+        sql: buildSemanticDifferentialChatTranscriptSql(),
         sqlParams: [rpg2.param("plain", context.sessionId)],
     });
 


### PR DESCRIPTION
## Context

Fixes #610. Semantic differential CSV exports duplicated each source row once for every team in the phase.

## Root cause

Both report queries joined `teams` by session and phase before applying the user membership predicate. The `LEFT JOIN` preserved non-member team rows, creating a phase-wide fan-out.

## Changes

- Replace the fan-out joins with correlated team lookups that return at most one team for the current user and phase.
- Preserve the recorded `differential_chat.tmid` when it is already available.
- Extract report query builders into a pure module and add regression coverage for both CSV queries.

## Impact

Each response and chat message is now returned once with the applicable `team_id`, rather than once per team in the phase. The separate CSV encoding observation in #610 is intentionally out of scope.

## Verification

- `node --test controllers/activities/__tests__/reports.node-test.mjs` (from `ethicapp/backend`)
- `npm run lint-js`

## Limitations

The focused tests validate the generated SQL structure without PostgreSQL. A host-side `npm test` run also encounters existing `redis-cache` DNS failures outside Docker after the affected tests pass; full integration verification should be performed through Docker Compose.