### PR TITLE
Add UTF-8 BOM to CSV report exports

### DIFF
--- a/ethicapp/backend/controllers/activities/__tests__/csv-builder.node-test.mjs
+++ b/ethicapp/backend/controllers/activities/__tests__/csv-builder.node-test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildCsv } from "../csv-builder.js";
+
+test("buildCsv prefixes UTF-8 output with a BOM for spreadsheet compatibility", () => {
+    const csv = buildCsv(
+        ["name", "comment"],
+        [{ name: "Joaquín", comment: "A decision by \"peers\"" }]
+    );
+
+    assert.equal(csv.codePointAt(0), 0xFEFF);
+    assert.equal(
+        csv.slice(1),
+        "\"name\",\"comment\"\n\"Joaquín\",\"A decision by \"\"peers\"\"\"\n"
+    );
+});

--- a/ethicapp/backend/controllers/activities/csv-builder.js
+++ b/ethicapp/backend/controllers/activities/csv-builder.js
@@ -1,0 +1,21 @@
+const UTF8_BOM = "\uFEFF";
+
+function csvEscape(value) {
+    if (value === undefined || value === null) {
+        return "\"\"";
+    }
+
+    const serializedValue = value instanceof Date
+        ? value.toISOString()
+        : String(value);
+    return `"${serializedValue.replaceAll("\"", "\"\"")}"`;
+}
+
+export function buildCsv(columns, rows) {
+    const lines = [
+        columns.map(csvEscape).join(","),
+        ...rows.map(row => columns.map(column => csvEscape(row[column])).join(",")),
+    ];
+
+    return `${UTF8_BOM}${lines.join("\n")}\n`;
+}

--- a/ethicapp/backend/controllers/activities/reports.js
+++ b/ethicapp/backend/controllers/activities/reports.js
@@ -15,6 +15,7 @@ import {
     buildSemanticDifferentialChatTranscriptSql,
     buildSemanticDifferentialResponsesReportSql,
 } from "./report-query-builders.js";
+import { buildCsv } from "./csv-builder.js";
 
 const router = express.Router();
 const REPORT_NOT_IMPLEMENTED = "REPORT_NOT_IMPLEMENTED";
@@ -138,26 +139,6 @@ function buildTimestampForFilename(date = new Date()) {
         padDatePart(date.getMinutes()),
         padDatePart(date.getSeconds()),
     ].join("");
-}
-
-function csvEscape(value) {
-    if (value === undefined || value === null) {
-        return "\"\"";
-    }
-
-    const serializedValue = value instanceof Date
-        ? value.toISOString()
-        : String(value);
-    return `"${serializedValue.replaceAll("\"", "\"\"")}"`;
-}
-
-function buildCsv(columns, rows) {
-    const lines = [
-        columns.map(csvEscape).join(","),
-        ...rows.map(row => columns.map(column => csvEscape(row[column])).join(",")),
-    ];
-
-    return `${lines.join("\n")}\n`;
 }
 
 function hashContent(content) {


### PR DESCRIPTION
## Context

Fixes #611. CSV reports containing accented characters were displayed as mojibake when opened directly in Excel because the downloaded file had no UTF-8 byte order mark (BOM).

## Changes

- Prefix every generated activity-report CSV with a UTF-8 BOM.
- Extract CSV serialization into a small pure module.
- Add regression coverage for the BOM, accented text, and existing quote escaping.

## Impact

Excel and similar spreadsheet tools can now detect UTF-8 when users open exported files locally. The existing `text/csv; charset=utf-8` response header remains unchanged. Line endings remain LF to keep this fix scoped to encoding detection.

## Verification

- `node --test controllers/activities/__tests__/csv-builder.node-test.mjs controllers/activities/__tests__/reports.node-test.mjs` (from `ethicapp/backend`)
- `npm run lint-js`

## Limitations

The focused tests verify the generated CSV content without opening a spreadsheet application. Manual verification in Excel should confirm correct display of accented characters.