### PR TITLE
Include external agent messages in chat transcript exports

### DIFF
--- a/ethicapp/backend/controllers/activities/__tests__/reports.node-test.mjs
+++ b/ethicapp/backend/controllers/activities/__tests__/reports.node-test.mjs
@@ -19,7 +19,14 @@ test("chat transcript preserves its recorded team and avoids phase-wide team joi
     const sql = buildSemanticDifferentialChatTranscriptSql();
 
     assert.doesNotMatch(sql, /LEFT JOIN teams AS t/);
+    assert.doesNotMatch(sql, /INNER JOIN users AS u/);
     assert.match(sql, /COALESCE\(dc\.tmid, \([\s\S]*tu\.uid = dc\.uid/);
     assert.match(sql, /t\.sesid = st\.sesid[\s\S]*t\.stageid = st\.id/);
     assert.match(sql, /ORDER BY tu\.tmid[\s\S]*LIMIT 1[\s\S]*\)\) AS team_id/);
+    assert.match(sql, /LEFT JOIN users AS u[\s\S]*ON dc\.uid = u\.id/);
+    assert.match(sql, /LEFT JOIN external_service_agents AS esa[\s\S]*ON dc\.external_agent_id = esa\.id/);
+    assert.match(sql, /dc\.external_agent_id/);
+    assert.match(sql, /WHEN esa\.id IS NOT NULL THEN 'external_service'/);
+    assert.match(sql, /COALESCE\(esa\.display_name, u\.name\) AS name/);
+    assert.match(sql, /esa\.service_id AS external_service_id/);
 });

--- a/ethicapp/backend/controllers/activities/report-query-builders.js
+++ b/ethicapp/backend/controllers/activities/report-query-builders.js
@@ -43,6 +43,7 @@ export function buildSemanticDifferentialChatTranscriptSql() {
         SELECT
             dc.id,
             dc.uid AS user_id,
+            dc.external_agent_id,
             COALESCE(dc.tmid, (
                 SELECT tu.tmid
                 FROM teamusers AS tu
@@ -54,9 +55,14 @@ export function buildSemanticDifferentialChatTranscriptSql() {
                 ORDER BY tu.tmid
                 LIMIT 1
             )) AS team_id,
-            u.name,
+            CASE
+                WHEN esa.id IS NOT NULL THEN 'external_service'
+                ELSE u.role
+            END AS author_role,
+            COALESCE(esa.display_name, u.name) AS name,
             u.rut,
             u.sex AS gender,
+            esa.service_id AS external_service_id,
             d.orden AS question_number,
             d.title AS question_text,
             d.tleft AS left_pole,
@@ -70,8 +76,10 @@ export function buildSemanticDifferentialChatTranscriptSql() {
             ON dc.did = d.id
         INNER JOIN stages AS st
             ON d.stageid = st.id
-        INNER JOIN users AS u
+        LEFT JOIN users AS u
             ON dc.uid = u.id
+        LEFT JOIN external_service_agents AS esa
+            ON dc.external_agent_id = esa.id
         WHERE st.sesid = $1
         ORDER BY st.number, d.orden, team_id, dc.stime, dc.id
     `;

--- a/ethicapp/backend/controllers/activities/reports.js
+++ b/ethicapp/backend/controllers/activities/reports.js
@@ -39,10 +39,13 @@ const SEMANTIC_DIFFERENTIAL_RESPONSE_COLUMNS = [
 const SEMANTIC_DIFFERENTIAL_CHAT_COLUMNS = [
     "id",
     "user_id",
+    "external_agent_id",
     "team_id",
+    "author_role",
     "name",
     "rut",
     "gender",
+    "external_service_id",
     "question_number",
     "question_text",
     "left_pole",


### PR DESCRIPTION
## Summary

Implements the **Approach A** near-term fix defined in #620: include persisted external-service agent messages directly in semantic-differential chat transcript CSV exports.

## Why this approach

#620 distinguishes two paths:

- **Approach A (this PR):** adapt the report read query to represent human and external authors from the existing chat rows.
- **Approach B (out of scope):** introduce a report-generation hook/strategy contract so adapters can contribute arbitrary chat- and response-processing data.

Approach A is the smallest safe correction for the immediate defect: agent messages are already first-class rows in `differential_chat`; the report was dropping them through an inner join to `users`. It preserves chronological ordering and the conversation source of truth without introducing a new reporting architecture.

Approach B remains the planned strategic follow-up in #620 for non-chat external-service outputs and generalized report contributions.

## Root cause

External agent messages are stored with `uid = NULL` and `external_agent_id` set. The report query used an inner join to `users`, which silently removed those rows.

## Changes

- Uses optional joins for human users and external service agents.
- Resolves the exported author name and role for both human and external authors.
- Adds `external_agent_id` and `external_service_id` to the transcript CSV.
- Extends the SQL contract test to protect the external-agent path.

## Verification

- `node --test controllers/activities/__tests__/reports.node-test.mjs`

Implements the Approach A checklist item in #620.